### PR TITLE
fix(firefox): remove redundant host_permissions to dedupe AMO listing

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
         "webNavigation",
         ...(isFirefox ? [] : ["sidePanel"]),
       ],
-      host_permissions: ["<all_urls>"],
+      ...(isFirefox ? {} : { host_permissions: ["<all_urls>"] }),
       ...(isFirefox ? {} : { minimum_chrome_version: "118" }),
       icons: {
         16: 'icon16.png',


### PR DESCRIPTION
## Summary

The Firefox AMO listing page (and `about:addons` → Permissions and data) was showing **"Access your data for all websites" twice** — once under **Required** (from `host_permissions: ["<all_urls>"]`) and once under **Optional** (from `content_scripts.matches: ["<all_urls>"]`). Same access, two rows.

In Firefox MV3 (>=127), `content_scripts.matches` grants host access for the entire extension at install time — including `chrome.scripting` calls from the background. So `host_permissions` is redundant in our Firefox build. This PR drops it for Firefox only and keeps it for Chrome (Chrome MV3 still requires `host_permissions` for `chrome.scripting.executeScript()`).

## Why this is safe

Verified against Firefox source / MDN / Bugzilla:

| Feature | Still works without `host_permissions`? | Reason |
|---|---|---|
| Auto-injected content scripts | ✅ | `content_scripts.matches` granted at install (FF 127+) |
| `tabs.captureVisibleTab` | ✅ | `activeTab` alone is sufficient (FF 126+) |
| `webNavigation` listeners | ✅ | Only requires the `webNavigation` permission |
| `runtime.sendMessage` / ports | ✅ | Intra-extension messaging, no host gating |
| `scripting.executeScript()` from background | ✅ | `content_scripts.matches` patterns land in the same granted-origins set checked by `executeScript` ([Bugzilla 1778461](https://bugzilla.mozilla.org/show_bug.cgi?id=1778461)) |

## Verified

- ✅ Install prompt unchanged (always rendered one row regardless)
- ✅ `about:addons` Permissions tab now lists `<all_urls>` once instead of twice (image proof in conversation)
- ✅ Chrome build untouched — `host_permissions` still present
- ✅ All 184 tests pass

## References

- [MDN: host_permissions](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions)
- [Bugzilla 1745818 — Treat host permissions as optional in MV3](https://bugzilla.mozilla.org/show_bug.cgi?id=1745818)
- [Bugzilla 1745819 — Require granted host permission for content scripts in MV3](https://bugzilla.mozilla.org/show_bug.cgi?id=1745819)

## Test plan

- [x] Firefox build manifest no longer contains `host_permissions`
- [x] Chrome build manifest still contains `host_permissions: ["<all_urls>"]`
- [x] Install prompt verified in Firefox Developer Edition
- [ ] AMO listing page deduplicates after publishing 1.0.x