### PR TITLE
fix: restore Firefox host_permissions + v1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimik",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "index.js",
   "packageManager": "pnpm@10.32.1",

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
   webExt: {
     chromiumArgs: ['--user-data-dir=/tmp/mimik-dev-profile', '--window-size=1280,800', '--window-position=0,0', '--force-device-scale-factor=1.25'],
   },
+  zip: {
+    excludeSources: ["docs/**", "mockups/**"],
+  },
   alias: {
     '@': 'src',
   },
@@ -37,7 +40,7 @@ export default defineConfig({
         "webNavigation",
         ...(isFirefox ? [] : ["sidePanel"]),
       ],
-      ...(isFirefox ? {} : { host_permissions: ["<all_urls>"] }),
+      host_permissions: ["<all_urls>"],
       ...(isFirefox ? {} : { minimum_chrome_version: "118" }),
       icons: {
         16: 'icon16.png',


### PR DESCRIPTION
## Summary

PR #2 removed \`host_permissions: ["<all_urls>"]\` from the Firefox build on the theory that \`content_scripts.matches\` + \`activeTab\` would cover the same access. **They don't.**

\`tabs.captureVisibleTab\` (used to grab a screenshot per step) loses access after **any page navigation** when only \`activeTab\` is granted — \`activeTab\` lasts until the user navigates to a new URL. Recording across navigations therefore captures a screenshot for the first step and **silently fails** for every subsequent step.

This was caught in manual testing on a recording that crosses pages (GitHub repo browse → folder navigation). Reproducible in any flow that involves navigation, which is most flows worth recording.

## Fix

- Revert PR #2: \`host_permissions: ["<all_urls>"]\` declared for both Chrome and Firefox.
- Trade-off accepted: the AMO listing will again show "Access your data for all websites" twice (once Required, once Optional). Cosmetic. Broken capture is not.
- Bump to \`1.0.2\` so the AMO update mechanism ships the fix to users on the broken \`1.0.1\`.

## Bonus: cleaner AMO sources zip

Add \`zip.excludeSources: ["docs/**", "mockups/**"]\` to keep internal scratch out of the source zip submitted to AMO reviewers. Sources zip drops from 13.9 MB → 6.4 MB.

## Test plan

- [x] Firefox manifest has \`host_permissions: ["<all_urls>"]\`
- [x] Chrome manifest has \`host_permissions: ["<all_urls>"]\`
- [x] Sources zip excludes \`docs/\` and \`mockups/\` (\`unzip -l\` confirms)
- [ ] Manual: install \`mimik-1.0.2-firefox.zip\` in Firefox, record a flow that crosses navigations, confirm every step captures a screenshot