### PR TITLE
fix(firefox): permissions UX + capture reliability + UI truncation (v1.0.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimik",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "",
   "main": "index.js",
   "packageManager": "pnpm@10.32.1",

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -54,10 +54,25 @@ async function generateTitleInBackground(guideId: string) {
 export default defineBackground(() => {
   logger.info('Background service worker started');
 
-  browser.runtime.onInstalled.addListener((details) => {
-    if (details.reason === 'install') {
-      browser.tabs.create({ url: browser.runtime.getURL('/onboarding.html') });
+  browser.runtime.onInstalled.addListener(async (details) => {
+    if (details.reason !== 'install') return;
+    if (import.meta.env.BROWSER === 'firefox') {
+      // Firefox MV3 bug 1758306: the <all_urls> grant lands in the origin
+      // store but is missed by _setupStartupPermissions when populating the
+      // API-permission resolution table that captureVisibleTab consults.
+      // Result: permissions.contains() returns true but captureVisibleTab
+      // silently rejects. Removing the permission here forces a clean state
+      // so the user-gesture permissions.request() in onboarding's "Get
+      // Started" / sidepanel's "Start Recording" goes through the working
+      // re-grant code path. Remove this when Mozilla ships:
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1758306
+      try {
+        await browser.permissions.remove({ origins: ['<all_urls>'] });
+      } catch (err) {
+        logger.warn('Failed to clear stale host permission on install', err);
+      }
     }
+    browser.tabs.create({ url: browser.runtime.getURL('/onboarding.html') });
   });
 
   setSidePanelBehavior(true);

--- a/src/ui/sidepanel/LibraryView.tsx
+++ b/src/ui/sidepanel/LibraryView.tsx
@@ -157,16 +157,17 @@ export default function LibraryView({ onOpen, searchQuery = '' }: LibraryViewPro
               <p className={`text-[13px] font-medium truncate ${isEmpty ? 'text-[#8B92A8]' : 'text-foreground'}`}>
                 {guide.title}
               </p>
-              <p className="text-[10px] mt-0.5 text-[#8B92A8]">{formatRelativeTime(guide.updatedAt)}</p>
+              <div className="flex items-center gap-2 mt-0.5">
+                <span className="text-[10px] text-[#8B92A8]">{formatRelativeTime(guide.updatedAt)}</span>
+                {guide.stepIds.length > 0 && (
+                  <span className="text-[9px] font-semibold text-muted-foreground bg-secondary px-2 py-0.5 rounded-full leading-none">
+                    {guide.stepIds.length !== 1
+                      ? i18n.t('fullview.stepCountPlural', [String(guide.stepIds.length)])
+                      : i18n.t('fullview.stepCount', [String(guide.stepIds.length)])}
+                  </span>
+                )}
+              </div>
             </div>
-
-            {guide.stepIds.length > 0 && (
-              <span className="text-[9px] font-semibold text-muted-foreground bg-secondary px-2 py-1 rounded-full shrink-0 leading-none mt-0.5">
-                {guide.stepIds.length !== 1
-                  ? i18n.t('fullview.stepCountPlural', [String(guide.stepIds.length)])
-                  : i18n.t('fullview.stepCount', [String(guide.stepIds.length)])}
-              </span>
-            )}
 
             <div className="flex items-center gap-0.5 shrink-0">
               <button

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -37,8 +37,9 @@ export default defineConfig({
         "webNavigation",
         ...(isFirefox ? [] : ["sidePanel"]),
       ],
-      ...(isFirefox ? {} : { host_permissions: ["<all_urls>"] }),
-      ...(isFirefox ? {} : { minimum_chrome_version: "118" }),
+      ...(isFirefox
+        ? { optional_host_permissions: ["<all_urls>"] }
+        : { host_permissions: ["<all_urls>"], minimum_chrome_version: "118" }),
       icons: {
         16: 'icon16.png',
         32: 'icon32.png',
@@ -57,7 +58,7 @@ export default defineConfig({
             browser_specific_settings: {
               gecko: {
                 id: "mimik@westpoint.io",
-                strict_min_version: "112.0",
+                strict_min_version: "128.0",
                 data_collection_permissions: {
                   required: ["none"],
                 },


### PR DESCRIPTION
## Summary

Three bundled fixes for Firefox + one minor UI fix. Tested in fresh Firefox profiles (Stable + Developer Edition).

### 1. Single permission row on AMO listing

Replace `host_permissions: ["<all_urls>"]` with `optional_host_permissions: ["<all_urls>"]` for the Firefox build. With the previous setup, the AMO listing showed "Access your data for all websites" twice — once Required (from `host_permissions`), once Optional (from `content_scripts.matches`). With `optional_host_permissions`, Firefox/AMO de-duplicates the two manifest fields into a single row.

Bumps `strict_min_version` from `112.0` → `128.0` (required for `optional_host_permissions`). Chrome build is unchanged — `host_permissions: ["<all_urls>"]` stays for Chrome MV3.

### 2. Workaround Firefox Bug 1758306 (capture silently fails on fresh install)

Mozilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1758306 — open, patch in flight but not landed.

The `<all_urls>` grant lands in Firefox's origin-permission store but is missed by `_setupStartupPermissions` when populating the API-permission resolution table that `tabs.captureVisibleTab` consults. Result: `permissions.contains({origins: ["<all_urls>"]})` returns `true`, the `about:addons` toggle shows ON, but `captureVisibleTab` silently rejects on every step. Manually toggling the permission OFF/ON in `about:addons` clears the broken state.

We replicate that toggle programmatically: in `onInstalled`, call `permissions.remove({origins: ["<all_urls>"]})` so the existing `permissions.request()` in onboarding's "Get Started" / sidepanel's "Start Recording" fires a real prompt and goes through Firefox's working re-grant code path.

Verified: in a fresh Firefox profile, install → onboarding "Get Started" prompts for permission → accept → captures work for every step across navigations, and survive a full browser restart.

### 3. Sidepanel library card layout

Title was being truncated to one character (`G…`) at narrow sidebar widths because the trailing step-count badge and action buttons were eating the top-row space. Move the timestamp + step badge into a stacked row below the title; only the star/trash buttons compete with the title for top-row width.

## Test plan

- [x] Fresh Firefox stable profile, sideload zip → install → "Get Started" fires permission prompt → accept → record across navigations → every step has a screenshot
- [x] Browser restart preserves working capture
- [x] `about:addons` Permissions and data tab shows single `<all_urls>` row
- [x] Sidepanel library card title is no longer truncated to one char at narrow widths
- [x] Chrome build still has `host_permissions` (manifest verified)
- [ ] Submit 1.0.3 to AMO → confirm public listing shows single row (will verify after merge)

## References

- [Bugzilla 1758306 — `<all_urls>` API permissions setup at startup](https://bugzilla.mozilla.org/show_bug.cgi?id=1758306) (still open)
- [Bugzilla 2014047 — captureVisibleTab fails until reload](https://bugzilla.mozilla.org/show_bug.cgi?id=2014047) (DUP of 1758306)
- [MDN: optional_host_permissions](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_host_permissions)