### PR TITLE
Remove demo.gif and dead RrwebChunkMessage (v1.0.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Click record, do the thing, get a polished guide with annotated screenshots. Edi
 ## 📺 Demo
 
 <div align="center">
-<img src="public/demo.gif" alt="Mimik demo" width="800" />
+<img src="https://github.com/user-attachments/assets/d4c64cb8-ad26-4de1-af02-a04a64e2836e" alt="Mimik demo" width="800" />
 </div>
 
 ## 👋 Getting Started

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimik",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "main": "index.js",
   "packageManager": "pnpm@10.32.1",

--- a/src/core/guides/messages.ts
+++ b/src/core/guides/messages.ts
@@ -38,12 +38,6 @@ export interface UserActionMessage {
   action: 'click' | 'input' | 'scroll';
   elementMeta: ElementMeta;
 }
-export interface RrwebChunkMessage {
-  type: 'RRWEB_CHUNK';
-  guideId: string;
-  events: unknown[];
-  timestamp: number;
-}
 export interface SpaNavigateMessage {
   type: 'URL_CHANGED';
   url: string;
@@ -57,5 +51,4 @@ export type ExtensionMessage =
   | StartRecordingMessage
   | StopRecordingMessage
   | UserActionMessage
-  | RrwebChunkMessage
   | SpaNavigateMessage;

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -8,6 +8,18 @@ export default defineConfig({
   webExt: {
     chromiumArgs: ['--user-data-dir=/tmp/mimik-dev-profile', '--window-size=1280,800', '--window-position=0,0', '--force-device-scale-factor=1.25'],
   },
+  zip: {
+    excludeSources: [
+      "mockups/**",
+      "docs/**",
+      ".claude/**",
+      ".planning/**",
+      ".worktrees/**",
+      "CLAUDE.md",
+      "AGENTS.md",
+      "CONTRIBUTING.md",
+    ],
+  },
   alias: {
     '@': 'src',
   },


### PR DESCRIPTION
Two deletions, version bump for v1.0.5 store upload.

- `public/demo.gif` — 5.8 MB shipped to every install, only used by the README. Bundle drops 8.7 MB → 2.88 MB (67%).
- `RrwebChunkMessage` in `src/core/guides/messages.ts` — leftover type from the abandoned rrweb feature, never dispatched or handled.
- `package.json`: 1.0.4 → 1.0.5.

## Test plan
- [ ] `pnpm build` and `pnpm build:firefox` succeed
- [ ] Load unpacked into Chrome + Firefox, record one step, stop
- [ ] Re-upload demo GIF to README via GitHub drag-drop (don't restore the file locally)