### PR TITLE
Add toggle recording keyboard shortcut

### DIFF
--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -51,6 +51,44 @@ async function generateTitleInBackground(guideId: string) {
   }
 }
 
+async function startRecordingFromActiveTab() {
+  await waitUntilReady();
+  const actor = getActor();
+  const activeTab = await getActiveTab();
+  actor.send({ type: 'START_RECORDING', url: activeTab?.url });
+  const guideId = actor.getSnapshot().context.currentGuideId!;
+
+  await createGuide(guideId);
+
+  if (activeTab?.id) await showNotificationOnTab(activeTab.id);
+
+  await broadcastStartCapture(guideId);
+  return guideId;
+}
+
+async function stopRecordingInBackground() {
+  await waitUntilReady();
+  const actor = getActor();
+  const guideId = actor.getSnapshot().context.currentGuideId;
+  await broadcastStopCapture();
+  actor.send({ type: 'STOP_RECORDING' });
+
+  if (guideId) generateTitleInBackground(guideId);
+
+  return guideId ?? undefined;
+}
+
+async function toggleRecordingFromCommand(command: string) {
+  if (command !== 'toggle-recording') return;
+  await waitUntilReady();
+  const actor = getActor();
+  if (actor.getSnapshot().value === 'recording') {
+    await stopRecordingInBackground();
+  } else {
+    await startRecordingFromActiveTab();
+  }
+}
+
 export default defineBackground(() => {
   logger.info('Background service worker started');
 
@@ -81,6 +119,11 @@ export default defineBackground(() => {
       browser.sidebarAction.toggle();
     });
   }
+  browser.commands.onCommand.addListener((command) => {
+    toggleRecordingFromCommand(command).catch((err) => {
+      logger.error('Toggle recording shortcut failed', err);
+    });
+  });
   initActor().catch(initActorFallback);
   cancelSession();
   registerNavigationListeners();
@@ -128,15 +171,8 @@ export default defineBackground(() => {
   });
 
   onMessage('stopRecording', async () => {
-    await waitUntilReady();
-    const actor = getActor();
-    const guideId = actor.getSnapshot().context.currentGuideId;
-    await broadcastStopCapture();
-    actor.send({ type: 'STOP_RECORDING' });
-
-    if (guideId) generateTitleInBackground(guideId);
-
-    return { success: true, guideId: guideId ?? undefined };
+    const guideId = await stopRecordingInBackground();
+    return { success: true, guideId };
   });
 
   onMessage('enterBlurMode', async () => {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -59,6 +59,15 @@ export default defineConfig({
         128: 'icon128.png',
       },
       action: {},
+      commands: {
+        'toggle-recording': {
+          suggested_key: {
+            default: 'Ctrl+Shift+R',
+            mac: 'Command+Shift+R',
+          },
+          description: 'Start or stop a Mimik recording',
+        },
+      },
       ...(isFirefox
         ? {
             sidebar_action: {


### PR DESCRIPTION
## Summary
- add a `toggle-recording` extension command with Ctrl+Shift+R / Cmd+Shift+R defaults
- wire the command in the background service worker to start recording when idle and stop when already recording
- reuse the active tab URL when starting from the shortcut so it works from any page

Closes #7.

## Verification
- `corepack pnpm test -- --runInBand` (184 tests passed)
- `corepack pnpm build`
- `corepack pnpm build:firefox`
- `corepack pnpm lint` (passes; existing optional-chain warnings only)
- inspected generated Chrome and Firefox manifests to confirm `commands.toggle-recording` is present
