### PR TITLE
feat: Support DOCX export

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "css-selector-generator": "^3.8.1",
     "dayjs": "^1.11.20",
     "dexie": "^4.3.0",
+    "docx": "^9.6.1",
+    "fflate": "^0.8.2",
     "jspdf": "^4.2.1",
     "lucide-react": "^0.577.0",
     "p-queue": "^9.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,12 @@ importers:
       dexie:
         specifier: ^4.3.0
         version: 4.4.1
+      docx:
+        specifier: ^9.6.1
+        version: 9.6.1
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.2
       jspdf:
         specifier: ^4.2.1
         version: 4.2.1(patch_hash=e301aed06890ed05f438774320bce683b16494cc9344453aa36d1d07f2b83e97)
@@ -2035,6 +2041,10 @@ packages:
   dexie@4.4.1:
     resolution: {integrity: sha512-4Xec5+yrS+TgyFAnMrneFOt/QG8sD3FxlkUVpfypui3SriRN80UN0SZBWmkNAY7ulfKgk0ilvv7M6pBURprdgA==}
 
+  docx@9.6.1:
+    resolution: {integrity: sha512-ZJja9/KBUuFC109sCMzovoq2GR2wCG/AuxivjA+OHj/q0TEgJIm3S7yrlUxIy3B+bV8YDj/BiHfWyrRFmyWpDQ==}
+    engines: {node: '>=10'}
+
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
@@ -2278,6 +2288,9 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
 
   hookable@6.1.0:
     resolution: {integrity: sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw==}
@@ -2696,6 +2709,9 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
@@ -2723,6 +2739,11 @@ packages:
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.1.11:
+    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   nanospinner@1.2.2:
@@ -3564,6 +3585,10 @@ packages:
     resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
     engines: {node: '>=12'}
 
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -3571,6 +3596,9 @@ packages:
   xml2js@0.6.2:
     resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
     engines: {node: '>=4.0.0'}
+
+  xml@1.0.1:
+    resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
 
   xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
@@ -5433,6 +5461,15 @@ snapshots:
 
   dexie@4.4.1: {}
 
+  docx@9.6.1:
+    dependencies:
+      '@types/node': 25.5.0
+      hash.js: 1.1.7
+      jszip: 3.10.1
+      nanoid: 5.1.11
+      xml: 1.0.1
+      xml-js: 1.6.11
+
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
@@ -5671,6 +5708,11 @@ snapshots:
       - utf-8-validate
 
   has-flag@4.0.0: {}
+
+  hash.js@1.1.7:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
 
   hookable@6.1.0: {}
 
@@ -6048,6 +6090,8 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  minimalistic-assert@1.0.1: {}
+
   minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.5
@@ -6077,6 +6121,8 @@ snapshots:
   nano-spawn@2.0.0: {}
 
   nanoid@3.3.11: {}
+
+  nanoid@5.1.11: {}
 
   nanospinner@1.2.2:
     dependencies:
@@ -7009,12 +7055,18 @@ snapshots:
 
   xdg-basedir@5.1.0: {}
 
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.6.0
+
   xml-name-validator@5.0.0: {}
 
   xml2js@0.6.2:
     dependencies:
       sax: 1.6.0
       xmlbuilder: 11.0.1
+
+  xml@1.0.1: {}
 
   xmlbuilder@11.0.1: {}
 

--- a/src/core/export/__tests__/docx-export.test.ts
+++ b/src/core/export/__tests__/docx-export.test.ts
@@ -63,9 +63,10 @@ describe('exportGuideAsDOCX', () => {
     const xml = await readDocumentXml(blob);
     expect(xml).toContain('My Guide');
     expect(xml).toContain('export.stepsCount[1]');
-    expect(xml).toContain('export.createdLabel[');
-    expect(xml).toContain('export.sourceLabel[example.com]');
-    expect(xml).toContain('export.stepLabel[01]');
+    expect(xml).toContain('EXPORT.CREATED');
+    expect(xml).toContain('EXPORT.SOURCE');
+    expect(xml).toContain('example.com');
+    expect(xml).toContain('<w:pageBreakBefore/>');
     expect(xml).toContain('Click the button');
   });
 
@@ -75,7 +76,7 @@ describe('exportGuideAsDOCX', () => {
 
     expect(xml).toContain('Test Guide');
     expect(xml).toContain('export.stepsCount[0]');
-    expect(xml).not.toContain('export.stepLabel[');
+    expect(xml).not.toContain('Click the button');
   });
 
   it('embeds screenshot media when steps have screenshots', async () => {

--- a/src/core/export/__tests__/docx-export.test.ts
+++ b/src/core/export/__tests__/docx-export.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { strFromU8, unzipSync } from 'fflate';
 import { describe, expect, it } from 'vitest';
-import { exportGuideAsDOCX } from '@/core/export/docx-export';
+import { exportGuideAsDOCX, fitDocxImageSize } from '@/core/export/docx-export';
 import type { Guide, Screenshot, Step } from '@/core/guides/types';
 
 function makeGuide(overrides: Partial<Guide> = {}): Guide {
@@ -94,5 +94,29 @@ describe('exportGuideAsDOCX', () => {
     const files = await unzipDocx(blob);
 
     expect(Object.keys(files).some((name) => name.startsWith('word/media/'))).toBe(false);
+  });
+});
+
+describe('fitDocxImageSize', () => {
+  it('preserves aspect ratio and never upscales', () => {
+    expect(fitDocxImageSize(400, 300)).toEqual({ width: 400, height: 300 });
+  });
+
+  it('clamps wide screenshots to max width', () => {
+    const { width, height } = fitDocxImageSize(1040, 600);
+    expect(width).toBe(520);
+    expect(height).toBe(300);
+  });
+
+  it('clamps tall screenshots so they fit one page', () => {
+    const { width, height } = fitDocxImageSize(400, 2000);
+    expect(height).toBe(640);
+    expect(width).toBe(128);
+  });
+
+  it('accounts for left indent when clamping width', () => {
+    const { width, height } = fitDocxImageSize(800, 600, 900);
+    expect(width).toBe(475);
+    expect(height).toBe(356);
   });
 });

--- a/src/core/export/__tests__/docx-export.test.ts
+++ b/src/core/export/__tests__/docx-export.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { strFromU8, unzipSync } from 'fflate';
+import { describe, expect, it } from 'vitest';
+import { exportGuideAsDOCX } from '@/core/export/docx-export';
+import type { Guide, Screenshot, Step } from '@/core/guides/types';
+
+function makeGuide(overrides: Partial<Guide> = {}): Guide {
+  return {
+    id: 'guide-1',
+    title: 'Test Guide',
+    createdAt: new Date('2025-06-01T00:00:00Z').getTime(),
+    updatedAt: new Date('2025-06-01T00:00:00Z').getTime(),
+    stepIds: [],
+    starred: false,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+function makeStep(overrides: Partial<Step> = {}): Step {
+  return {
+    id: 'step-1',
+    guideId: 'guide-1',
+    index: 0,
+    description: 'Click the button',
+    action: 'click',
+    url: 'https://example.com',
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeScreenshot(stepId: string, content = 'image-data'): Screenshot {
+  return {
+    id: `ss-${stepId}`,
+    stepId,
+    blob: new Blob([content], { type: 'image/png' }),
+    mimeType: 'image/png',
+    width: 800,
+    height: 600,
+  };
+}
+
+async function unzipDocx(blob: Blob) {
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  return unzipSync(bytes);
+}
+
+async function readDocumentXml(blob: Blob): Promise<string> {
+  const files = await unzipDocx(blob);
+  return strFromU8(files['word/document.xml']);
+}
+
+describe('exportGuideAsDOCX', () => {
+  it('creates a non-empty docx blob with guide metadata and step content', async () => {
+    const guide = makeGuide({ title: 'My Guide' });
+    const steps = [makeStep()];
+    const blob = await exportGuideAsDOCX(guide, steps, new Map());
+
+    expect(blob.size).toBeGreaterThan(0);
+    expect(blob.type).toBe('application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+
+    const xml = await readDocumentXml(blob);
+    expect(xml).toContain('My Guide');
+    expect(xml).toContain('export.stepsCount[1]');
+    expect(xml).toContain('export.createdLabel[');
+    expect(xml).toContain('export.sourceLabel[example.com]');
+    expect(xml).toContain('export.stepLabel[01]');
+    expect(xml).toContain('Click the button');
+  });
+
+  it('handles guides with no steps', async () => {
+    const blob = await exportGuideAsDOCX(makeGuide(), [], new Map());
+    const xml = await readDocumentXml(blob);
+
+    expect(xml).toContain('Test Guide');
+    expect(xml).toContain('export.stepsCount[0]');
+    expect(xml).not.toContain('export.stepLabel[');
+  });
+
+  it('embeds screenshot media when steps have screenshots', async () => {
+    const step = makeStep();
+    const screenshots = new Map<string, Screenshot>([[step.id, makeScreenshot(step.id)]]);
+
+    const blob = await exportGuideAsDOCX(makeGuide(), [step], screenshots);
+    const files = await unzipDocx(blob);
+
+    expect(Object.keys(files).some((name) => name.startsWith('word/media/'))).toBe(true);
+  });
+
+  it('does not add media files when screenshots are missing', async () => {
+    const blob = await exportGuideAsDOCX(makeGuide(), [makeStep()], new Map());
+    const files = await unzipDocx(blob);
+
+    expect(Object.keys(files).some((name) => name.startsWith('word/media/'))).toBe(false);
+  });
+});

--- a/src/core/export/docx-export.ts
+++ b/src/core/export/docx-export.ts
@@ -19,8 +19,23 @@ import { logger } from '@/lib/logger';
 type SupportedDocxImageType = 'bmp' | 'gif' | 'jpg' | 'png';
 
 const DOCX_MAX_IMAGE_WIDTH = 520;
+const DOCX_MAX_IMAGE_HEIGHT = 640; // px @ 96dpi, fits one page after margins
 const DOCX_STEP_INDENT = 900;
 const DOCX_FONT_FAMILY = 'Helvetica';
+
+/** Scale screenshot to fit page bounds without upscaling or distorting. */
+export function fitDocxImageSize(
+  screenshotWidth: number,
+  screenshotHeight: number,
+  leftIndent = 0,
+): { width: number; height: number } {
+  const maxWidth = DOCX_MAX_IMAGE_WIDTH - Math.round(leftIndent / 20);
+  const scale = Math.min(maxWidth / screenshotWidth, DOCX_MAX_IMAGE_HEIGHT / screenshotHeight, 1);
+  return {
+    width: Math.max(1, Math.round(screenshotWidth * scale)),
+    height: Math.max(1, Math.round(screenshotHeight * scale)),
+  };
+}
 
 function buildGradientDividerParagraph(): Paragraph {
   const gradientSegments = ['4F46E5', '635BED', '8178F4', 'A4A1F9', 'C7D2FE', '9BD2FE', '60C8FB', '38BDF8'];
@@ -145,8 +160,7 @@ async function buildImageParagraph(
 
   try {
     const arrayBuffer = await blobToArrayBuffer(screenshot.blob);
-    const width = Math.min(screenshot.width, DOCX_MAX_IMAGE_WIDTH - Math.round(leftIndent / 20));
-    const height = Math.max(1, Math.round((screenshot.height / screenshot.width) * width));
+    const { width, height } = fitDocxImageSize(screenshot.width, screenshot.height, leftIndent);
 
     return new Paragraph({
       alignment: AlignmentType.LEFT,

--- a/src/core/export/docx-export.ts
+++ b/src/core/export/docx-export.ts
@@ -1,4 +1,16 @@
-import { AlignmentType, BorderStyle, Document, ImageRun, Packer, Paragraph, TextRun } from 'docx';
+import {
+  AlignmentType,
+  BorderStyle,
+  Document,
+  ImageRun,
+  Packer,
+  Paragraph,
+  Table,
+  TableCell,
+  TableRow,
+  TextRun,
+  WidthType,
+} from 'docx';
 import { i18n } from '#imports';
 import { blobToArrayBuffer, extractDomain, formatDate } from '@/core/export/utils';
 import type { Guide, Screenshot, Step } from '@/core/guides/types';
@@ -7,6 +19,102 @@ import { logger } from '@/lib/logger';
 type SupportedDocxImageType = 'bmp' | 'gif' | 'jpg' | 'png';
 
 const DOCX_MAX_IMAGE_WIDTH = 520;
+const DOCX_STEP_INDENT = 900;
+const DOCX_FONT_FAMILY = 'Helvetica';
+
+function buildGradientDividerParagraph(): Paragraph {
+  const gradientSegments = ['4F46E5', '635BED', '8178F4', 'A4A1F9', 'C7D2FE', '9BD2FE', '60C8FB', '38BDF8'];
+
+  return new Paragraph({
+    alignment: AlignmentType.CENTER,
+    spacing: { after: 260 },
+    children: gradientSegments.map(
+      (color) =>
+        new TextRun({
+          text: '--------',
+          font: DOCX_FONT_FAMILY,
+          color,
+          bold: true,
+          size: 16,
+        }),
+    ),
+  });
+}
+
+function buildMetaTable(guide: Guide, domain: string | null): Table {
+  const baseCell = {
+    borders: {
+      top: { style: BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+      right: { style: BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+      bottom: { style: BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+      left: { style: BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+    },
+    margins: { top: 0, bottom: 0, left: 80, right: 80 },
+  };
+
+  return new Table({
+    width: { size: 70, type: WidthType.PERCENTAGE },
+    alignment: AlignmentType.CENTER,
+    rows: [
+      new TableRow({
+        children: [
+          new TableCell({
+            ...baseCell,
+            width: { size: domain ? 50 : 100, type: WidthType.PERCENTAGE },
+            children: [
+              new Paragraph({
+                alignment: AlignmentType.LEFT,
+                spacing: { after: 40 },
+                children: [
+                  new TextRun({
+                    text: i18n.t('export.created').toUpperCase(),
+                    font: DOCX_FONT_FAMILY,
+                    bold: true,
+                    color: '6B7280',
+                    size: 14,
+                  }),
+                ],
+              }),
+              new Paragraph({
+                alignment: AlignmentType.LEFT,
+                children: [
+                  new TextRun({ text: formatDate(guide.createdAt), font: DOCX_FONT_FAMILY, color: '1E1B4B', size: 24 }),
+                ],
+              }),
+            ],
+          }),
+          ...(domain
+            ? [
+                new TableCell({
+                  ...baseCell,
+                  width: { size: 50, type: WidthType.PERCENTAGE },
+                  children: [
+                    new Paragraph({
+                      alignment: AlignmentType.LEFT,
+                      spacing: { after: 40 },
+                      children: [
+                        new TextRun({
+                          text: i18n.t('export.source').toUpperCase(),
+                          font: DOCX_FONT_FAMILY,
+                          bold: true,
+                          color: '6B7280',
+                          size: 14,
+                        }),
+                      ],
+                    }),
+                    new Paragraph({
+                      alignment: AlignmentType.LEFT,
+                      children: [new TextRun({ text: domain, font: DOCX_FONT_FAMILY, color: '4F46E5', size: 24 })],
+                    }),
+                  ],
+                }),
+              ]
+            : []),
+        ],
+      }),
+    ],
+  });
+}
 
 function getDocxImageType(mimeType: string): SupportedDocxImageType | null {
   switch (mimeType) {
@@ -24,7 +132,11 @@ function getDocxImageType(mimeType: string): SupportedDocxImageType | null {
   }
 }
 
-async function buildImageParagraph(screenshot: Screenshot, stepIndex: number): Promise<Paragraph | null> {
+async function buildImageParagraph(
+  screenshot: Screenshot,
+  stepIndex: number,
+  leftIndent = 0,
+): Promise<Paragraph | null> {
   const imageType = getDocxImageType(screenshot.mimeType);
   if (!imageType) {
     logger.warn('DOCX: unsupported screenshot mime type', screenshot.mimeType, 'for step', stepIndex);
@@ -33,11 +145,12 @@ async function buildImageParagraph(screenshot: Screenshot, stepIndex: number): P
 
   try {
     const arrayBuffer = await blobToArrayBuffer(screenshot.blob);
-    const width = Math.min(screenshot.width, DOCX_MAX_IMAGE_WIDTH);
+    const width = Math.min(screenshot.width, DOCX_MAX_IMAGE_WIDTH - Math.round(leftIndent / 20));
     const height = Math.max(1, Math.round((screenshot.height / screenshot.width) * width));
 
     return new Paragraph({
-      alignment: AlignmentType.CENTER,
+      alignment: AlignmentType.LEFT,
+      indent: { left: leftIndent },
       spacing: { after: 280 },
       children: [
         new ImageRun({
@@ -59,31 +172,39 @@ export async function exportGuideAsDOCX(
   screenshots: Map<string, Screenshot>,
 ): Promise<Blob> {
   const domain = extractDomain(steps);
-  const meta = [
-    i18n.t('export.stepsCount', [String(steps.length)]),
-    i18n.t('export.createdLabel', [formatDate(guide.createdAt)]),
-    ...(domain ? [i18n.t('export.sourceLabel', [domain])] : []),
-  ].join(' · ');
-
-  const children: Paragraph[] = [
+  const coverChildren: Array<Paragraph | Table> = [
     new Paragraph({
       alignment: AlignmentType.CENTER,
-      spacing: { after: 140 },
+      spacing: { before: 3300, after: 200 },
       children: [
-        new TextRun({ text: i18n.t('export.stepsCount', [String(steps.length)]), bold: true, color: '4F46E5' }),
+        new TextRun({
+          text: i18n.t('export.stepsCount', [String(steps.length)]),
+          font: DOCX_FONT_FAMILY,
+          bold: true,
+          color: '4F46E5',
+          size: 20,
+        }),
       ],
     }),
+    buildGradientDividerParagraph(),
     new Paragraph({
       alignment: AlignmentType.CENTER,
-      spacing: { after: 220 },
-      children: [new TextRun({ text: guide.title, bold: true, size: 36, color: '1E1B4B' })],
+      spacing: { after: 280 },
+      children: [new TextRun({ text: guide.title, font: DOCX_FONT_FAMILY, bold: true, size: 44, color: '1E1B4B' })],
     }),
-    new Paragraph({
-      alignment: AlignmentType.CENTER,
-      spacing: { after: steps.length > 0 ? 360 : 0 },
-      children: [new TextRun({ text: meta, italics: true, color: '6B7280' })],
-    }),
+    buildMetaTable(guide, domain),
+    new Paragraph({ spacing: { after: 420 } }),
   ];
+
+  const children: Array<Paragraph | Table> = [...coverChildren];
+
+  if (steps.length > 0) {
+    children.push(
+      new Paragraph({
+        pageBreakBefore: true,
+      }),
+    );
+  }
 
   for (const step of steps) {
     const stepNumber = String(step.index + 1).padStart(2, '0');
@@ -98,25 +219,23 @@ export async function exportGuideAsDOCX(
             style: BorderStyle.SINGLE,
           },
         },
-        spacing: { before: 240, after: 100 },
-        children: [
-          new TextRun({
-            text: i18n.t('export.stepLabel', [stepNumber]),
-            bold: true,
-            color: '818CF8',
-            size: 24,
-          }),
-        ],
+        spacing: { before: 240, after: 120 },
+        children: [new TextRun({ text: '', font: DOCX_FONT_FAMILY })],
       }),
       new Paragraph({
-        spacing: { after: 160 },
-        children: [new TextRun({ text: step.description, color: '1E1B4B', size: 24 })],
+        indent: { left: DOCX_STEP_INDENT / 2 },
+        spacing: { after: 180 },
+        children: [
+          new TextRun({ text: stepNumber, font: DOCX_FONT_FAMILY, bold: true, color: '818CF8', size: 32 }),
+          new TextRun({ text: '   ', font: DOCX_FONT_FAMILY }),
+          new TextRun({ text: step.description, font: DOCX_FONT_FAMILY, color: '1E1B4B', size: 24 }),
+        ],
       }),
     );
 
     const screenshot = screenshots.get(step.id);
     if (screenshot) {
-      const imageParagraph = await buildImageParagraph(screenshot, step.index);
+      const imageParagraph = await buildImageParagraph(screenshot, step.index, DOCX_STEP_INDENT / 2);
       if (imageParagraph) {
         children.push(imageParagraph);
       }
@@ -124,6 +243,15 @@ export async function exportGuideAsDOCX(
   }
 
   const doc = new Document({
+    styles: {
+      default: {
+        document: {
+          run: {
+            font: DOCX_FONT_FAMILY,
+          },
+        },
+      },
+    },
     sections: [
       {
         properties: {},

--- a/src/core/export/docx-export.ts
+++ b/src/core/export/docx-export.ts
@@ -1,0 +1,136 @@
+import { AlignmentType, BorderStyle, Document, ImageRun, Packer, Paragraph, TextRun } from 'docx';
+import { i18n } from '#imports';
+import { blobToArrayBuffer, extractDomain, formatDate } from '@/core/export/utils';
+import type { Guide, Screenshot, Step } from '@/core/guides/types';
+import { logger } from '@/lib/logger';
+
+type SupportedDocxImageType = 'bmp' | 'gif' | 'jpg' | 'png';
+
+const DOCX_MAX_IMAGE_WIDTH = 520;
+
+function getDocxImageType(mimeType: string): SupportedDocxImageType | null {
+  switch (mimeType) {
+    case 'image/png':
+      return 'png';
+    case 'image/jpeg':
+    case 'image/jpg':
+      return 'jpg';
+    case 'image/gif':
+      return 'gif';
+    case 'image/bmp':
+      return 'bmp';
+    default:
+      return null;
+  }
+}
+
+async function buildImageParagraph(screenshot: Screenshot, stepIndex: number): Promise<Paragraph | null> {
+  const imageType = getDocxImageType(screenshot.mimeType);
+  if (!imageType) {
+    logger.warn('DOCX: unsupported screenshot mime type', screenshot.mimeType, 'for step', stepIndex);
+    return null;
+  }
+
+  try {
+    const arrayBuffer = await blobToArrayBuffer(screenshot.blob);
+    const width = Math.min(screenshot.width, DOCX_MAX_IMAGE_WIDTH);
+    const height = Math.max(1, Math.round((screenshot.height / screenshot.width) * width));
+
+    return new Paragraph({
+      alignment: AlignmentType.CENTER,
+      spacing: { after: 280 },
+      children: [
+        new ImageRun({
+          type: imageType,
+          data: new Uint8Array(arrayBuffer),
+          transformation: { width, height },
+        }),
+      ],
+    });
+  } catch (err) {
+    logger.warn('DOCX: failed to load screenshot for step', stepIndex, err);
+    return null;
+  }
+}
+
+export async function exportGuideAsDOCX(
+  guide: Guide,
+  steps: Step[],
+  screenshots: Map<string, Screenshot>,
+): Promise<Blob> {
+  const domain = extractDomain(steps);
+  const meta = [
+    i18n.t('export.stepsCount', [String(steps.length)]),
+    i18n.t('export.createdLabel', [formatDate(guide.createdAt)]),
+    ...(domain ? [i18n.t('export.sourceLabel', [domain])] : []),
+  ].join(' · ');
+
+  const children: Paragraph[] = [
+    new Paragraph({
+      alignment: AlignmentType.CENTER,
+      spacing: { after: 140 },
+      children: [
+        new TextRun({ text: i18n.t('export.stepsCount', [String(steps.length)]), bold: true, color: '4F46E5' }),
+      ],
+    }),
+    new Paragraph({
+      alignment: AlignmentType.CENTER,
+      spacing: { after: 220 },
+      children: [new TextRun({ text: guide.title, bold: true, size: 36, color: '1E1B4B' })],
+    }),
+    new Paragraph({
+      alignment: AlignmentType.CENTER,
+      spacing: { after: steps.length > 0 ? 360 : 0 },
+      children: [new TextRun({ text: meta, italics: true, color: '6B7280' })],
+    }),
+  ];
+
+  for (const step of steps) {
+    const stepNumber = String(step.index + 1).padStart(2, '0');
+
+    children.push(
+      new Paragraph({
+        border: {
+          top: {
+            color: 'C7D2FE',
+            size: 6,
+            space: 1,
+            style: BorderStyle.SINGLE,
+          },
+        },
+        spacing: { before: 240, after: 100 },
+        children: [
+          new TextRun({
+            text: i18n.t('export.stepLabel', [stepNumber]),
+            bold: true,
+            color: '818CF8',
+            size: 24,
+          }),
+        ],
+      }),
+      new Paragraph({
+        spacing: { after: 160 },
+        children: [new TextRun({ text: step.description, color: '1E1B4B', size: 24 })],
+      }),
+    );
+
+    const screenshot = screenshots.get(step.id);
+    if (screenshot) {
+      const imageParagraph = await buildImageParagraph(screenshot, step.index);
+      if (imageParagraph) {
+        children.push(imageParagraph);
+      }
+    }
+  }
+
+  const doc = new Document({
+    sections: [
+      {
+        properties: {},
+        children,
+      },
+    ],
+  });
+
+  return await Packer.toBlob(doc);
+}

--- a/src/core/export/utils.ts
+++ b/src/core/export/utils.ts
@@ -22,6 +22,10 @@ export function blobToDataUrl(blob: Blob): Promise<string> {
   });
 }
 
+export async function blobToArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
+  return await blob.arrayBuffer();
+}
+
 export function extractDomain(steps: Step[]): string | null {
   const stepWithUrl = steps.find((s) => s.url);
   if (!stepWithUrl) return null;

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -162,6 +162,7 @@ blurPanel:
   resetAll: Reset All
 
 exportMenu:
+  docx: DOCX
   html: HTML
   markdown: Markdown
   pdf: PDF

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -162,6 +162,7 @@ blurPanel:
   resetAll: Restablecer todo
 
 exportMenu:
+  docx: DOCX
   html: HTML
   markdown: Markdown
   pdf: PDF

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -162,6 +162,7 @@ blurPanel:
   resetAll: Tout réinitialiser
 
 exportMenu:
+  docx: DOCX
   html: HTML
   markdown: Markdown
   pdf: PDF

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -162,6 +162,7 @@ blurPanel:
   resetAll: Limpar tudo
 
 exportMenu:
+  docx: DOCX
   html: HTML
   markdown: Markdown
   pdf: PDF

--- a/src/ui/sidepanel/ExportMenu.tsx
+++ b/src/ui/sidepanel/ExportMenu.tsx
@@ -16,6 +16,10 @@ interface ExportMenuProps {
 
 function downloadFile(content: string, filename: string, mimeType: string) {
   const blob = new Blob([content], { type: mimeType });
+  downloadBlob(blob, filename);
+}
+
+function downloadBlob(blob: Blob, filename: string) {
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
@@ -23,6 +27,8 @@ function downloadFile(content: string, filename: string, mimeType: string) {
   a.click();
   URL.revokeObjectURL(url);
 }
+
+type ExportType = 'docx' | 'html' | 'markdown' | 'pdf';
 
 export default function ExportMenu({ guide, steps, screenshots }: ExportMenuProps) {
   const [open, setOpen] = useState(false);
@@ -37,24 +43,23 @@ export default function ExportMenu({ guide, steps, screenshots }: ExportMenuProp
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [open]);
 
-  async function handleExport(type: 'html' | 'markdown' | 'pdf') {
+  async function handleExport(type: ExportType) {
     setOpen(false);
     setExporting(true);
     try {
       if (type === 'html') {
         const html = await exportGuideAsHTML(guide, steps, screenshots);
         downloadFile(html, `${guide.title}.html`, 'text/html');
+      } else if (type === 'docx') {
+        const { exportGuideAsDOCX } = await import('@/core/export/docx-export');
+        const blob = await exportGuideAsDOCX(guide, steps, screenshots);
+        downloadBlob(blob, `${guide.title}.docx`);
       } else if (type === 'markdown') {
         const md = await exportGuideAsMarkdown(guide, steps, screenshots);
         downloadFile(md, `${guide.title}.md`, 'text/markdown');
       } else {
         const blob = await exportGuideAsPDF(guide, steps, screenshots);
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `${guide.title}.pdf`;
-        a.click();
-        URL.revokeObjectURL(url);
+        downloadBlob(blob, `${guide.title}.pdf`);
       }
     } finally {
       setExporting(false);
@@ -62,6 +67,7 @@ export default function ExportMenu({ guide, steps, screenshots }: ExportMenuProp
   }
 
   const items = [
+    { type: 'docx' as const, icon: FileText, label: i18n.t('exportMenu.docx') },
     { type: 'html' as const, icon: FileCode, label: i18n.t('exportMenu.html') },
     { type: 'markdown' as const, icon: FileText, label: i18n.t('exportMenu.markdown') },
     { type: 'pdf' as const, icon: FileDown, label: i18n.t('exportMenu.pdf') },


### PR DESCRIPTION
## Summary
- Add client-side DOCX export support for guides, including title, metadata, step content, and screenshots.
- Wire DOCX into the shared export menu and locale labels so it is available anywhere exports are shown.
- Add focused DOCX export tests and lazy-load the DOCX exporter to keep the main export bundle smaller.


<img width="514" height="359" alt="image" src="https://github.com/user-attachments/assets/114e7f8b-b81e-417c-8d6e-6ef3dd9f12e4" />

<img width="601" height="411" alt="image" src="https://github.com/user-attachments/assets/57b3ca13-40d7-4517-a346-640f7cd56213" />


## Verification
- `pnpm test -- src/core/export/__tests__/docx-export.test.ts`
- `pnpm lint`
- `pnpm build`
- Generated a sample `.docx` and confirmed it could be parsed successfully