### PR TITLE
fix(pdf-export): re-encode screenshots as JPEG to shrink output

### DIFF
--- a/src/core/export/pdf-export.ts
+++ b/src/core/export/pdf-export.ts
@@ -1,8 +1,22 @@
 import { jsPDF } from 'jspdf';
 import { i18n } from '#imports';
-import { blobToDataUrl, extractDomain, fetchFaviconBase64, formatDate } from '@/core/export/utils';
+import { extractDomain, fetchFaviconBase64, formatDate } from '@/core/export/utils';
 import type { Guide, Screenshot, Step } from '@/core/guides/types';
 import { logger } from '@/lib/logger';
+
+const JPEG_QUALITY = 0.85;
+
+async function reencodeScreenshotAsJpeg(blob: Blob): Promise<string> {
+  const bitmap = await createImageBitmap(blob);
+  const canvas = document.createElement('canvas');
+  canvas.width = bitmap.width;
+  canvas.height = bitmap.height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('no 2d context');
+  ctx.drawImage(bitmap, 0, 0);
+  bitmap.close?.();
+  return canvas.toDataURL('image/jpeg', JPEG_QUALITY);
+}
 
 export async function exportGuideAsPDF(
   guide: Guide,
@@ -129,7 +143,7 @@ export async function exportGuideAsPDF(
 
     if (screenshot) {
       try {
-        imgDataUrl = await blobToDataUrl(screenshot.blob);
+        imgDataUrl = await reencodeScreenshotAsJpeg(screenshot.blob);
         imgHeight = Math.min((screenshot.height / screenshot.width) * imgWidth, maxImgHeight);
       } catch (err) {
         logger.warn('PDF: failed to load screenshot for step', step.index, err);


### PR DESCRIPTION
jsPDF was embedding screenshots as raw uncompressed RGB pixels (no `/Filter` in the PDF image dictionaries), so every 1920×1080 screenshot cost ~6.2 MB regardless of the original PNG size. A 30-step guide produced a ~187 MB PDF, which many viewers reject and which times out or gets truncated when downloaded under Playwright automation.

The fix re-encodes each screenshot as JPEG at quality 0.85 via a canvas before handing it to `doc.addImage`. jsPDF then embeds the compressed JPEG bytes directly with `/Filter /DCTDecode`. Same 30-step / 1920×1080 fixture PDF drops from 187 MB → 1.8 MB (~105×).

Closes #14.

Verified locally with a Playwright script that loads the extension via `launchPersistentContext`, seeds a 30-step guide with 1920×1080 PNG screenshots in IndexedDB, opens the fullview, clicks Export → PDF, and asserts the download is a valid PDF (`%PDF-…EOF`). Pre-fix: 187 MB, post-fix: 1.8 MB, both open cleanly in `pdfinfo` and a viewer.