### PR TITLE
feat: add edit mode and local version history for guides

### DIFF
--- a/src/core/export/__tests__/utils.test.ts
+++ b/src/core/export/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
-import { blobToBase64, blobToDataUrl, escapeHtml, extractDomain, formatDate } from '@/core/export/utils';
+import { blobToBase64, blobToDataUrl, escapeHtml, extractDomain, fitImage, formatDate } from '@/core/export/utils';
 import type { Step } from '@/core/guides/types';
 
 function makeStep(overrides: Partial<Step> = {}): Step {
@@ -116,5 +116,36 @@ describe('blobToDataUrl', () => {
     expect(result).toMatch(/^data:text\/plain;base64,/);
     const b64Part = result.split(',')[1];
     expect(atob(b64Part)).toBe('hello');
+  });
+});
+
+describe('fitImage', () => {
+  it('leaves an image that already fits untouched', () => {
+    expect(fitImage(103, 58, 211.5)).toEqual({ width: 103, height: 58 });
+  });
+
+  it('scales width down proportionally when the height exceeds the cap', () => {
+    const fitted = fitImage(143, 300, 211.5);
+    expect(fitted.height).toBe(211.5);
+    expect(fitted.width).toBeCloseTo(143 * (211.5 / 300), 5);
+    expect(fitted.width / fitted.height).toBeCloseTo(143 / 300, 5);
+  });
+
+  it('keeps a portrait phone screenshot inside the page at medium scale', () => {
+    const width = 103;
+    const height = (2436 / 1125) * width;
+    const fitted = fitImage(width, height, 211.5);
+    expect(height).toBeGreaterThan(211.5);
+    expect(fitted.height).toBe(211.5);
+    expect(fitted.width).toBeLessThan(width);
+  });
+
+  it('returns the input for a zero or non-finite height', () => {
+    expect(fitImage(100, 0, 200)).toEqual({ width: 100, height: 0 });
+    expect(fitImage(100, Number.NaN, 200)).toEqual({ width: 100, height: Number.NaN });
+  });
+
+  it('leaves an image exactly at the cap untouched', () => {
+    expect(fitImage(143, 211.5, 211.5)).toEqual({ width: 143, height: 211.5 });
   });
 });

--- a/src/core/export/pdf-export.ts
+++ b/src/core/export/pdf-export.ts
@@ -2,7 +2,7 @@ import { jsPDF } from 'jspdf';
 import { i18n } from '#imports';
 import { fitLogo, loadBranding } from '@/core/export/branding';
 import { type ExportOptions, IMAGE_SCALE_FACTORS, loadExportOptions } from '@/core/export/options';
-import { blobToDataUrl, extractDomain, formatDate } from '@/core/export/utils';
+import { blobToDataUrl, extractDomain, fitImage, formatDate } from '@/core/export/utils';
 import type { Guide, Screenshot, Step } from '@/core/guides/types';
 import { hexToRgb } from '@/core/screenshot/color';
 import { resolveViewport } from '@/core/screenshot/geometry';
@@ -146,18 +146,26 @@ export async function exportGuideAsPDF(
     const screenshot = opts.screenshots ? screenshots.get(step.id) : undefined;
     let imgDataUrl: string | null = null;
     let imgHeight = 0;
+    let stepImgWidth = imgWidth;
+    const textOverhead = 6 + descLines.length * 5 + 4;
     if (screenshot) {
       try {
         const rendered = await renderScreenshot(screenshot, { format: 'image/jpeg', quality: JPEG_QUALITY });
         imgDataUrl = await blobToDataUrl(rendered);
         const viewport = resolveViewport(screenshot);
-        imgHeight = (viewport.height / viewport.width) * imgWidth;
+        const fitted = fitImage(
+          imgWidth,
+          (viewport.height / viewport.width) * imgWidth,
+          FOOTER_Y - 8 - STEP_TOP - textOverhead,
+        );
+        stepImgWidth = fitted.width;
+        imgHeight = fitted.height;
       } catch (err) {
         logger.warn('PDF: failed to load screenshot for step', step.index, err);
       }
     }
 
-    const blockH = 6 + descLines.length * 5 + 4 + imgHeight;
+    const blockH = textOverhead + imgHeight;
     if (sy + blockH > FOOTER_Y - 8 && sy > STEP_TOP) {
       sy = startStepPage();
     }
@@ -204,9 +212,9 @@ export async function exportGuideAsPDF(
 
     let iy = uy + 4;
     if (imgDataUrl) {
-      doc.addImage(imgDataUrl, 'JPEG', TEXT_X, iy, imgWidth, imgHeight);
+      doc.addImage(imgDataUrl, 'JPEG', TEXT_X, iy, stepImgWidth, imgHeight);
       const altText = screenshot?.edits?.alt || i18n.t('export.stepLabel', [stepNum]);
-      doc.text(doc.splitTextToSize(altText, imgWidth), TEXT_X, iy + 4, { renderingMode: 'invisible' });
+      doc.text(doc.splitTextToSize(altText, stepImgWidth), TEXT_X, iy + 4, { renderingMode: 'invisible' });
       iy += imgHeight;
     }
     sy = iy + STEP_GAP;

--- a/src/core/export/utils.ts
+++ b/src/core/export/utils.ts
@@ -66,3 +66,8 @@ export async function fetchFaviconBase64(domain: string): Promise<string | null>
     return null;
   }
 }
+
+export function fitImage(width: number, height: number, maxHeight: number): { width: number; height: number } {
+  if (!Number.isFinite(height) || height <= 0 || height <= maxHeight) return { width, height };
+  return { width: width * (maxHeight / height), height: maxHeight };
+}

--- a/src/core/guides/__tests__/service.test.ts
+++ b/src/core/guides/__tests__/service.test.ts
@@ -85,6 +85,7 @@ afterEach(async () => {
   await db.guides.clear();
   await db.steps.clear();
   await db.screenshots.clear();
+  await db.snapshots.clear();
 });
 
 describe('createGuide', () => {
@@ -150,7 +151,7 @@ describe('addStepToGuide', () => {
 });
 
 describe('deleteStep', () => {
-  it('removes step, re-indexes remaining, cleans up screenshot', async () => {
+  it('removes step, re-indexes remaining, drops the screenshot row when there is no history', async () => {
     await seedGuide('g1', { stepIds: ['s1', 's2', 's3'] });
     await db.steps.bulkAdd([
       makeStep({ id: 's1', guideId: 'g1', index: 0, screenshotId: 'sc1' }),

--- a/src/core/guides/__tests__/snapshot-diff.test.ts
+++ b/src/core/guides/__tests__/snapshot-diff.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest';
+import type { ScreenshotEdits } from '@/core/screenshot/types';
+import { diffSnapshots, type SnapshotLike } from '../snapshot-diff';
+import type { Snapshot } from '../types';
+
+type StepInput = SnapshotLike['steps'][number];
+type ShotInput = SnapshotLike['screenshots'][number];
+
+function step(id: string, description = `${id} description`, screenshotId?: string): StepInput {
+  return screenshotId ? { id, description, screenshotId } : { id, description };
+}
+
+function shot(id: string, stepId: string, edits?: ScreenshotEdits): ShotInput & { stepId: string } {
+  return edits ? { id, stepId, edits } : { id, stepId };
+}
+
+function like(steps: StepInput[], overrides: Partial<SnapshotLike> = {}): SnapshotLike {
+  return { title: 'Guide', stepIds: steps.map((s) => s.id), steps, screenshots: [], ...overrides };
+}
+
+const empty = { titleChanged: false, added: 0, removed: 0, reordered: false, edited: 0, images: 0 };
+
+describe('diffSnapshots', () => {
+  it('reports nothing for identical content', () => {
+    const a = like([step('s1'), step('s2', 'second', 'sc1')], { screenshots: [shot('sc1', 's2')] });
+    const b = like([step('s1'), step('s2', 'second', 'sc1')], { screenshots: [shot('sc1', 's2')] });
+
+    expect(diffSnapshots(a, b)).toEqual(empty);
+  });
+
+  it('reports a title change', () => {
+    const a = like([step('s1')], { title: 'Before' });
+    const b = like([step('s1')], { title: 'After' });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, titleChanged: true });
+  });
+
+  it('counts step ids present only in the newer side as added', () => {
+    const a = like([step('s1')]);
+    const b = like([step('s1'), step('s2'), step('s3')]);
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, added: 2 });
+  });
+
+  it('counts step ids present only in the older side as removed', () => {
+    const a = like([step('s1'), step('s2'), step('s3')]);
+    const b = like([step('s2')]);
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, removed: 2 });
+  });
+
+  it('compares step ids as sets, so a pure reorder adds and removes nothing', () => {
+    const a = like([step('s1'), step('s2'), step('s3')]);
+    const b = like([step('s3'), step('s2'), step('s1')]);
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, reordered: true });
+  });
+
+  it('does not report a reorder for a pure append', () => {
+    const a = like([step('s1'), step('s2')]);
+    const b = like([step('s1'), step('s2'), step('s3')]);
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, added: 1 });
+  });
+
+  it('does not report a reorder for an insert at the front', () => {
+    const a = like([step('s1'), step('s2')]);
+    const b = like([step('s3'), step('s1'), step('s2')]);
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, added: 1 });
+  });
+
+  it('does not report a reorder for a pure delete', () => {
+    const a = like([step('s1'), step('s2'), step('s3')]);
+    const b = like([step('s1'), step('s3')]);
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, removed: 1 });
+  });
+
+  it('does not report a reorder when a delete plus an add leaves survivors in order', () => {
+    const a = like([step('s1'), step('s2'), step('s3')]);
+    const b = like([step('s1'), step('s4'), step('s3'), step('s5')]);
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, added: 2, removed: 1 });
+  });
+
+  it('reports a reorder when survivors of a delete change relative order', () => {
+    const a = like([step('s1'), step('s2'), step('s3')]);
+    const b = like([step('s3'), step('s1')]);
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, removed: 1, reordered: true });
+  });
+
+  it('counts steps whose description changed as edited', () => {
+    const a = like([step('s1', 'Old one'), step('s2', 'Old two'), step('s3', 'Same')]);
+    const b = like([step('s1', 'New one'), step('s2', 'New two'), step('s3', 'Same')]);
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, edited: 2 });
+  });
+
+  it('does not count a removed step as edited', () => {
+    const a = like([step('s1', 'Kept'), step('s2', 'Gone')]);
+    const b = like([step('s1', 'Kept')]);
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, removed: 1 });
+  });
+
+  it('does not count an added step as edited', () => {
+    const a = like([step('s1', 'Kept')]);
+    const b = like([step('s1', 'Kept'), step('s2', 'Brand new')]);
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, added: 1 });
+  });
+
+  it('counts a repointed screenshot as an image change', () => {
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1')] });
+    const b = like([step('s1', 'Same', 'sc2')], { screenshots: [shot('sc1', 's1'), shot('sc2', 's1')] });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, images: 1 });
+  });
+
+  it('counts a deleted screenshot as an image change', () => {
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1')] });
+    const b = like([step('s1', 'Same')], { screenshots: [shot('sc1', 's1')] });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, images: 1 });
+  });
+
+  it('counts a newly attached screenshot as an image change', () => {
+    const a = like([step('s1', 'Same')], { screenshots: [] });
+    const b = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1')] });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, images: 1 });
+  });
+
+  it('counts changed edits on the same screenshot row as an image change', () => {
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { alt: 'before' })] });
+    const b = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { alt: 'after' })] });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, images: 1 });
+  });
+
+  it('counts changed annotations as an image change', () => {
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { annotations: [] })] });
+    const b = like([step('s1', 'Same', 'sc1')], {
+      screenshots: [
+        shot('sc1', 's1', { annotations: [{ id: 'a1', type: 'redact', x: 0, y: 0, w: 2, h: 2, style: 'blur' }] }),
+      ],
+    });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, images: 1 });
+  });
+
+  it('treats absent edits and empty edits as the same', () => {
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1')] });
+    const b = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', {})] });
+
+    expect(diffSnapshots(a, b)).toEqual(empty);
+  });
+
+  it('resolves the screenshot through the step pointer, not by stepId', () => {
+    const a = like([step('s1', 'Same', 'sc2')], {
+      screenshots: [shot('sc1', 's1', { alt: 'stale row' }), shot('sc2', 's1', { alt: 'live row' })],
+    });
+    const b = like([step('s1', 'Same', 'sc2')], {
+      screenshots: [shot('sc1', 's1', { alt: 'stale row changed' }), shot('sc2', 's1', { alt: 'live row' })],
+    });
+
+    expect(diffSnapshots(a, b)).toEqual(empty);
+  });
+
+  it('counts a step once when both its pointer and its edits changed', () => {
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { alt: 'one' })] });
+    const b = like([step('s1', 'Same', 'sc2')], {
+      screenshots: [shot('sc1', 's1', { alt: 'one' }), shot('sc2', 's1', { alt: 'two' })],
+    });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, images: 1 });
+  });
+
+  it('ignores screenshots belonging to steps present on only one side', () => {
+    const a = like([step('s1', 'Same'), step('s2', 'Gone', 'sc1')], { screenshots: [shot('sc1', 's2')] });
+    const b = like([step('s1', 'Same'), step('s3', 'New', 'sc2')], { screenshots: [shot('sc2', 's3')] });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, added: 1, removed: 1 });
+  });
+
+  it('reports every dimension at once', () => {
+    const a = like([step('s1', 'One', 'sc1'), step('s2', 'Two'), step('s3', 'Three')], {
+      title: 'Before',
+      screenshots: [shot('sc1', 's1', { alt: 'a' })],
+    });
+    const b = like([step('s3', 'Three'), step('s1', 'One edited', 'sc1'), step('s4', 'Four')], {
+      title: 'After',
+      screenshots: [shot('sc1', 's1', { alt: 'b' })],
+    });
+
+    expect(diffSnapshots(a, b)).toEqual({
+      titleChanged: true,
+      added: 1,
+      removed: 1,
+      reordered: true,
+      edited: 1,
+      images: 1,
+    });
+  });
+
+  it('accepts full Snapshot records on both sides', () => {
+    const base: Snapshot = {
+      id: 'n1',
+      guideId: 'g1',
+      createdAt: 1,
+      contentHash: 'h1',
+      title: 'Guide',
+      stepIds: ['s1'],
+      steps: [
+        {
+          id: 's1',
+          guideId: 'g1',
+          index: 0,
+          description: 'Click it',
+          action: 'click',
+          url: 'https://example.com',
+          timestamp: 1,
+          screenshotId: 'sc1',
+        },
+      ],
+      screenshots: [{ id: 'sc1', stepId: 's1', mimeType: 'image/png', width: 10, height: 10 }],
+    };
+    const next: Snapshot = { ...base, id: 'n2', title: 'Guide renamed' };
+
+    expect(diffSnapshots(base, next)).toEqual({ ...empty, titleChanged: true });
+  });
+});

--- a/src/core/guides/__tests__/snapshot-diff.test.ts
+++ b/src/core/guides/__tests__/snapshot-diff.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { Annotation, ScreenshotEdits } from '@/core/screenshot/types';
 import { diffSnapshots, type SnapshotLike } from '../snapshot-diff';
-import type { Snapshot } from '../types';
+import type { ScreenshotBounds, Snapshot } from '../types';
 
 type StepInput = SnapshotLike['steps'][number];
 type ShotInput = SnapshotLike['screenshots'][number];
@@ -10,8 +10,13 @@ function step(id: string, description = `${id} description`, screenshotId?: stri
   return { id, description, ...(screenshotId ? { screenshotId } : {}), ...(url ? { url } : {}) };
 }
 
-function shot(id: string, stepId: string, edits?: ScreenshotEdits): ShotInput & { stepId: string } {
-  return edits ? { id, stepId, edits } : { id, stepId };
+function shot(
+  id: string,
+  stepId: string,
+  edits?: ScreenshotEdits,
+  captured?: { bounds?: ScreenshotBounds; pixelRatio?: number },
+): ShotInput & { stepId: string } {
+  return { id, stepId, ...(edits ? { edits } : {}), ...captured };
 }
 
 function like(steps: StepInput[], overrides: Partial<SnapshotLike> = {}): SnapshotLike {
@@ -370,13 +375,140 @@ describe('diffSnapshots', () => {
     expect(diffSnapshots(a, b)).toEqual(empty);
   });
 
-  it('reports a replacement that also clears the edits on the new row', () => {
+  it('does not report the edits left behind on the row a replacement replaced', () => {
     const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { alt: 'one' })] });
     const b = like([step('s1', 'Same', 'sc2')], {
       screenshots: [shot('sc1', 's1', { alt: 'one' }), shot('sc2', 's1', { alt: 'two' })],
     });
 
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, replaced: 1 });
+  });
+
+  it('reports only the replacement when a pristine screenshot is replaced', () => {
+    const a = like([step('s1', 'Same', 'old')], {
+      screenshots: [shot('old', 's1', undefined, { bounds: { x: 2, y: 3, width: 4, height: 5 }, pixelRatio: 2 })],
+    });
+    const b = like([step('s1', 'Same', 'new')], {
+      screenshots: [
+        shot('old', 's1', undefined, { bounds: { x: 2, y: 3, width: 4, height: 5 }, pixelRatio: 2 }),
+        shot('new', 's1', { target: null }),
+      ],
+    });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, replaced: 1 });
+  });
+
+  it('reports only the replacement when a fully edited screenshot is replaced', () => {
+    const edited: ScreenshotEdits = {
+      viewport: { x: 1, y: 2, width: 30, height: 40 },
+      target: { x: 0, y: 0, width: 5, height: 5, border: 'dashed', color: '#4F46E5' },
+      annotations: [box, redact],
+      alt: 'hello',
+    };
+    const carried: ScreenshotEdits = { ...edited, target: null };
+    delete carried.viewport;
+    delete carried.alt;
+
+    const a = like([step('s1', 'Same', 'old')], { screenshots: [shot('old', 's1', edited)] });
+    const b = like([step('s1', 'Same', 'new')], {
+      screenshots: [shot('old', 's1', edited), shot('new', 's1', carried)],
+    });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, replaced: 1 });
+  });
+
+  it('suppresses the derived causes per step, not per diff', () => {
+    const a = like([step('r1', 'Same', 'old'), step('c1', 'Same', 'kept')], {
+      screenshots: [
+        shot('old', 'r1', { alt: 'gone' }),
+        shot('kept', 'c1', { viewport: { x: 0, y: 0, width: 9, height: 9 } }),
+      ],
+    });
+    const b = like([step('r1', 'Same', 'new'), step('c1', 'Same', 'kept')], {
+      screenshots: [
+        shot('new', 'r1', { target: null }),
+        shot('kept', 'c1', { viewport: { x: 3, y: 0, width: 6, height: 9 } }),
+      ],
+    });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, replaced: 1, cropped: 1 });
+  });
+
+  it('lets a step other than the replaced one set the alt flag', () => {
+    const a = like([step('r1', 'Same', 'old'), step('t1', 'Same', 'text')], {
+      screenshots: [shot('old', 'r1', { alt: 'gone' }), shot('text', 't1', { alt: 'before' })],
+    });
+    const b = like([step('r1', 'Same', 'new'), step('t1', 'Same', 'text')], {
+      screenshots: [shot('new', 'r1', { target: null }), shot('text', 't1', { alt: 'after' })],
+    });
+
     expect(diffSnapshots(a, b)).toEqual({ ...empty, replaced: 1, altEdited: true });
+  });
+
+  it('reports nothing for an annotation editor visit that materialised the derived target', () => {
+    const captured = { bounds: { x: 2, y: 3, width: 4, height: 5 }, pixelRatio: 2 };
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', undefined, captured)] });
+    const b = like([step('s1', 'Same', 'sc1')], {
+      screenshots: [
+        shot(
+          'sc1',
+          's1',
+          {
+            annotations: [],
+            target: { x: 4, y: 6, width: 8, height: 10, border: 'dashed', color: '#4F46E5' },
+          },
+          captured,
+        ),
+      ],
+    });
+
+    expect(diffSnapshots(a, b)).toEqual(empty);
+  });
+
+  it('reports nothing when an absent target and an explicit null both resolve to no target', () => {
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1')] });
+    const b = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { target: null })] });
+
+    expect(diffSnapshots(a, b)).toEqual(empty);
+  });
+
+  it('still reports a target the user actually moved away from the derived box', () => {
+    const captured = { bounds: { x: 2, y: 3, width: 4, height: 5 }, pixelRatio: 2 };
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', undefined, captured)] });
+    const b = like([step('s1', 'Same', 'sc1')], {
+      screenshots: [
+        shot(
+          'sc1',
+          's1',
+          { target: { x: 40, y: 6, width: 8, height: 10, border: 'dashed', color: '#4F46E5' } },
+          captured,
+        ),
+      ],
+    });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, annotated: 1 });
+  });
+
+  it('still reports a target the user switched off', () => {
+    const captured = { bounds: { x: 2, y: 3, width: 4, height: 5 }, pixelRatio: 2 };
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', undefined, captured)] });
+    const b = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { target: null }, captured)] });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, annotated: 1 });
+  });
+
+  it('treats an empty alt string as no alt text', () => {
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1')] });
+    const b = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { alt: '' })] });
+
+    expect(diffSnapshots(a, b)).toEqual(empty);
+  });
+
+  it('reports clearing an alt text that was really there', () => {
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { alt: 'described' })] });
+    const b = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { alt: '' })] });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, altEdited: true });
   });
 
   it('ignores screenshots belonging to steps present on only one side', () => {

--- a/src/core/guides/__tests__/snapshot-diff.test.ts
+++ b/src/core/guides/__tests__/snapshot-diff.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import type { ScreenshotEdits } from '@/core/screenshot/types';
+import type { Annotation, ScreenshotEdits } from '@/core/screenshot/types';
 import { diffSnapshots, type SnapshotLike } from '../snapshot-diff';
 import type { Snapshot } from '../types';
 
 type StepInput = SnapshotLike['steps'][number];
 type ShotInput = SnapshotLike['screenshots'][number];
 
-function step(id: string, description = `${id} description`, screenshotId?: string): StepInput {
-  return screenshotId ? { id, description, screenshotId } : { id, description };
+function step(id: string, description = `${id} description`, screenshotId?: string, url?: string): StepInput {
+  return { id, description, ...(screenshotId ? { screenshotId } : {}), ...(url ? { url } : {}) };
 }
 
 function shot(id: string, stepId: string, edits?: ScreenshotEdits): ShotInput & { stepId: string } {
@@ -18,7 +18,25 @@ function like(steps: StepInput[], overrides: Partial<SnapshotLike> = {}): Snapsh
   return { title: 'Guide', stepIds: steps.map((s) => s.id), steps, screenshots: [], ...overrides };
 }
 
-const empty = { titleChanged: false, added: 0, removed: 0, reordered: false, edited: 0, images: 0 };
+const box: Annotation = { id: 'a1', type: 'box', x: 0, y: 0, w: 10, h: 10, color: '#000000' };
+const otherBox: Annotation = { id: 'a1', type: 'box', x: 4, y: 4, w: 10, h: 10, color: '#000000' };
+const arrow: Annotation = { id: 'a2', type: 'arrow', x1: 0, y1: 0, x2: 5, y2: 5, color: '#000000' };
+const redact: Annotation = { id: 'r1', type: 'redact', x: 0, y: 0, w: 5, h: 5, style: 'blur' };
+const otherRedact: Annotation = { id: 'r1', type: 'redact', x: 0, y: 0, w: 5, h: 5, style: 'solid' };
+
+const empty = {
+  titleChanged: false,
+  added: 0,
+  removed: 0,
+  reordered: false,
+  edited: 0,
+  urls: 0,
+  replaced: 0,
+  cropped: 0,
+  annotated: 0,
+  blurred: 0,
+  altEdited: false,
+};
 
 describe('diffSnapshots', () => {
   it('reports nothing for identical content', () => {
@@ -112,48 +130,220 @@ describe('diffSnapshots', () => {
     expect(diffSnapshots(a, b)).toEqual({ ...empty, added: 1 });
   });
 
-  it('counts a repointed screenshot as an image change', () => {
+  it('resolves surviving steps by id even when the steps array order differs', () => {
+    const a = like([step('s1', 'One'), step('s2', 'Two')]);
+    const b = { ...like([step('s1', 'One'), step('s2', 'Two')]), steps: [step('s2', 'Two'), step('s1', 'One')] };
+
+    expect(diffSnapshots(a, b)).toEqual(empty);
+  });
+
+  it('counts steps whose url changed as link changes', () => {
+    const a = like([
+      step('s1', 'Same', undefined, 'https://a.test/one'),
+      step('s2', 'Same', undefined, 'https://a.test/two'),
+    ]);
+    const b = like([
+      step('s1', 'Same', undefined, 'https://b.test/one'),
+      step('s2', 'Same', undefined, 'https://a.test/two'),
+    ]);
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, urls: 1 });
+  });
+
+  it('does not count a description change as a link change', () => {
+    const a = like([step('s1', 'Old', undefined, 'https://a.test')]);
+    const b = like([step('s1', 'New', undefined, 'https://a.test')]);
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, edited: 1 });
+  });
+
+  it('does not count a link change as a description change', () => {
+    const a = like([step('s1', 'Same', undefined, 'https://a.test')]);
+    const b = like([step('s1', 'Same', undefined, 'https://b.test')]);
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, urls: 1 });
+  });
+
+  it('counts a repointed screenshot as replaced', () => {
     const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1')] });
     const b = like([step('s1', 'Same', 'sc2')], { screenshots: [shot('sc1', 's1'), shot('sc2', 's1')] });
 
-    expect(diffSnapshots(a, b)).toEqual({ ...empty, images: 1 });
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, replaced: 1 });
   });
 
-  it('counts a deleted screenshot as an image change', () => {
+  it('counts a deleted screenshot as replaced', () => {
     const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1')] });
     const b = like([step('s1', 'Same')], { screenshots: [shot('sc1', 's1')] });
 
-    expect(diffSnapshots(a, b)).toEqual({ ...empty, images: 1 });
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, replaced: 1 });
   });
 
-  it('counts a newly attached screenshot as an image change', () => {
+  it('counts a newly attached screenshot as replaced', () => {
     const a = like([step('s1', 'Same')], { screenshots: [] });
     const b = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1')] });
 
-    expect(diffSnapshots(a, b)).toEqual({ ...empty, images: 1 });
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, replaced: 1 });
   });
 
-  it('counts changed edits on the same screenshot row as an image change', () => {
-    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { alt: 'before' })] });
-    const b = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { alt: 'after' })] });
+  it('does not count an edits-only change as replaced', () => {
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { annotations: [box] })] });
+    const b = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { annotations: [otherBox] })] });
 
-    expect(diffSnapshots(a, b)).toEqual({ ...empty, images: 1 });
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, annotated: 1 });
   });
 
-  it('counts changed annotations as an image change', () => {
-    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { annotations: [] })] });
+  it('counts a changed viewport as cropped', () => {
+    const a = like([step('s1', 'Same', 'sc1')], {
+      screenshots: [shot('sc1', 's1', { viewport: { x: 0, y: 0, width: 100, height: 50 } })],
+    });
+    const b = like([step('s1', 'Same', 'sc1')], {
+      screenshots: [shot('sc1', 's1', { viewport: { x: 10, y: 0, width: 80, height: 50 } })],
+    });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, cropped: 1 });
+  });
+
+  it('does not count an annotation change as cropped', () => {
+    const a = like([step('s1', 'Same', 'sc1')], {
+      screenshots: [shot('sc1', 's1', { viewport: { x: 0, y: 0, width: 100, height: 50 }, annotations: [box] })],
+    });
+    const b = like([step('s1', 'Same', 'sc1')], {
+      screenshots: [shot('sc1', 's1', { viewport: { x: 0, y: 0, width: 100, height: 50 }, annotations: [otherBox] })],
+    });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, annotated: 1 });
+  });
+
+  it('counts changed non-redact annotations as annotated', () => {
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { annotations: [box] })] });
+    const b = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { annotations: [box, arrow] })] });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, annotated: 1 });
+  });
+
+  it('counts reordered annotations as annotated', () => {
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { annotations: [box, arrow] })] });
+    const b = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { annotations: [arrow, box] })] });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, annotated: 1 });
+  });
+
+  it('counts a changed click target as annotated', () => {
+    const a = like([step('s1', 'Same', 'sc1')], {
+      screenshots: [
+        shot('sc1', 's1', { target: { x: 1, y: 2, width: 3, height: 4, border: 'dashed', color: '#4F46E5' } }),
+      ],
+    });
     const b = like([step('s1', 'Same', 'sc1')], {
       screenshots: [
-        shot('sc1', 's1', { annotations: [{ id: 'a1', type: 'redact', x: 0, y: 0, w: 2, h: 2, style: 'blur' }] }),
+        shot('sc1', 's1', { target: { x: 1, y: 2, width: 3, height: 4, border: 'solid', color: '#4F46E5' } }),
       ],
     });
 
-    expect(diffSnapshots(a, b)).toEqual({ ...empty, images: 1 });
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, annotated: 1 });
+  });
+
+  it('does not count a redact change as annotated', () => {
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { annotations: [box, redact] })] });
+    const b = like([step('s1', 'Same', 'sc1')], {
+      screenshots: [shot('sc1', 's1', { annotations: [box, otherRedact] })],
+    });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, blurred: 1 });
+  });
+
+  it('counts changed redact annotations as blurred', () => {
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { annotations: [] })] });
+    const b = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { annotations: [redact] })] });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, blurred: 1 });
+  });
+
+  it('does not count a non-redact change as blurred', () => {
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { annotations: [redact, box] })] });
+    const b = like([step('s1', 'Same', 'sc1')], {
+      screenshots: [shot('sc1', 's1', { annotations: [redact, otherBox] })],
+    });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, annotated: 1 });
+  });
+
+  it('reports annotated and blurred separately when both partitions changed', () => {
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { annotations: [box, redact] })] });
+    const b = like([step('s1', 'Same', 'sc1')], {
+      screenshots: [shot('sc1', 's1', { annotations: [otherBox, otherRedact] })],
+    });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, annotated: 1, blurred: 1 });
+  });
+
+  it('ignores where a redact sits in the annotations array relative to other annotations', () => {
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { annotations: [redact, box] })] });
+    const b = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { annotations: [box, redact] })] });
+
+    expect(diffSnapshots(a, b)).toEqual(empty);
+  });
+
+  it('reports a changed alt text as a single boolean, not a count', () => {
+    const a = like([step('s1', 'Same', 'sc1'), step('s2', 'Same', 'sc2')], {
+      screenshots: [shot('sc1', 's1', { alt: 'one' }), shot('sc2', 's2', { alt: 'two' })],
+    });
+    const b = like([step('s1', 'Same', 'sc1'), step('s2', 'Same', 'sc2')], {
+      screenshots: [shot('sc1', 's1', { alt: 'ONE' }), shot('sc2', 's2', { alt: 'TWO' })],
+    });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, altEdited: true });
+  });
+
+  it('does not report an alt change when only the annotations moved', () => {
+    const a = like([step('s1', 'Same', 'sc1')], {
+      screenshots: [shot('sc1', 's1', { alt: 'same', annotations: [box] })],
+    });
+    const b = like([step('s1', 'Same', 'sc1')], {
+      screenshots: [shot('sc1', 's1', { alt: 'same', annotations: [otherBox] })],
+    });
+
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, annotated: 1 });
   });
 
   it('treats absent edits and empty edits as the same', () => {
     const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1')] });
     const b = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', {})] });
+
+    expect(diffSnapshots(a, b)).toEqual(empty);
+  });
+
+  it('ignores the key order of the edits object', () => {
+    const before: ScreenshotEdits = {
+      viewport: { x: 0, y: 0, width: 10, height: 10 },
+      alt: 'a',
+      annotations: [box],
+      target: null,
+    };
+    const after: ScreenshotEdits = { ...before, target: null };
+    delete after.viewport;
+    delete after.alt;
+    const rebuilt: ScreenshotEdits = { target: null, annotations: [box] };
+
+    expect(JSON.stringify(after)).not.toBe(JSON.stringify(rebuilt));
+
+    const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', after)] });
+    const b = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', rebuilt)] });
+
+    expect(diffSnapshots(a, b)).toEqual(empty);
+  });
+
+  it('ignores the key order of nested annotation objects', () => {
+    const a = like([step('s1', 'Same', 'sc1')], {
+      screenshots: [
+        shot('sc1', 's1', { annotations: [{ id: 'a1', type: 'box', x: 0, y: 0, w: 1, h: 1, color: '#000' }] }),
+      ],
+    });
+    const b = like([step('s1', 'Same', 'sc1')], {
+      screenshots: [
+        shot('sc1', 's1', { annotations: [{ color: '#000', h: 1, w: 1, y: 0, x: 0, type: 'box', id: 'a1' }] }),
+      ],
+    });
 
     expect(diffSnapshots(a, b)).toEqual(empty);
   });
@@ -169,13 +359,24 @@ describe('diffSnapshots', () => {
     expect(diffSnapshots(a, b)).toEqual(empty);
   });
 
-  it('counts a step once when both its pointer and its edits changed', () => {
+  it('resolves screenshot rows by id even when the screenshots array order differs', () => {
+    const a = like([step('s1', 'Same', 'sc1'), step('s2', 'Same', 'sc2')], {
+      screenshots: [shot('sc1', 's1', { alt: 'one' }), shot('sc2', 's2', { alt: 'two' })],
+    });
+    const b = like([step('s1', 'Same', 'sc1'), step('s2', 'Same', 'sc2')], {
+      screenshots: [shot('sc2', 's2', { alt: 'two' }), shot('sc1', 's1', { alt: 'one' })],
+    });
+
+    expect(diffSnapshots(a, b)).toEqual(empty);
+  });
+
+  it('reports a replacement that also clears the edits on the new row', () => {
     const a = like([step('s1', 'Same', 'sc1')], { screenshots: [shot('sc1', 's1', { alt: 'one' })] });
     const b = like([step('s1', 'Same', 'sc2')], {
       screenshots: [shot('sc1', 's1', { alt: 'one' }), shot('sc2', 's1', { alt: 'two' })],
     });
 
-    expect(diffSnapshots(a, b)).toEqual({ ...empty, images: 1 });
+    expect(diffSnapshots(a, b)).toEqual({ ...empty, replaced: 1, altEdited: true });
   });
 
   it('ignores screenshots belonging to steps present on only one side', () => {
@@ -186,14 +387,50 @@ describe('diffSnapshots', () => {
   });
 
   it('reports every dimension at once', () => {
-    const a = like([step('s1', 'One', 'sc1'), step('s2', 'Two'), step('s3', 'Three')], {
-      title: 'Before',
-      screenshots: [shot('sc1', 's1', { alt: 'a' })],
-    });
-    const b = like([step('s3', 'Three'), step('s1', 'One edited', 'sc1'), step('s4', 'Four')], {
-      title: 'After',
-      screenshots: [shot('sc1', 's1', { alt: 'b' })],
-    });
+    const a = like(
+      [
+        step('s1', 'Gone'),
+        step('s3', 'Old three'),
+        step('s4', 'Same', undefined, 'https://a.test'),
+        step('s5', 'Same', 'sc5a'),
+        step('s6', 'Same', 'sc6'),
+        step('s7', 'Same', 'sc7'),
+        step('s8', 'Same', 'sc8'),
+        step('s9', 'Same', 'sc9'),
+      ],
+      {
+        title: 'Before',
+        screenshots: [
+          shot('sc5a', 's5'),
+          shot('sc6', 's6', { viewport: { x: 0, y: 0, width: 100, height: 50 } }),
+          shot('sc7', 's7', { annotations: [box] }),
+          shot('sc8', 's8', { annotations: [redact] }),
+          shot('sc9', 's9', { alt: 'before' }),
+        ],
+      },
+    );
+    const b = like(
+      [
+        step('s2', 'New'),
+        step('s4', 'Same', undefined, 'https://b.test'),
+        step('s3', 'New three'),
+        step('s5', 'Same', 'sc5b'),
+        step('s6', 'Same', 'sc6'),
+        step('s7', 'Same', 'sc7'),
+        step('s8', 'Same', 'sc8'),
+        step('s9', 'Same', 'sc9'),
+      ],
+      {
+        title: 'After',
+        screenshots: [
+          shot('sc5b', 's5'),
+          shot('sc6', 's6', { viewport: { x: 5, y: 0, width: 90, height: 50 } }),
+          shot('sc7', 's7', { annotations: [otherBox] }),
+          shot('sc8', 's8', { annotations: [otherRedact] }),
+          shot('sc9', 's9', { alt: 'after' }),
+        ],
+      },
+    );
 
     expect(diffSnapshots(a, b)).toEqual({
       titleChanged: true,
@@ -201,7 +438,12 @@ describe('diffSnapshots', () => {
       removed: 1,
       reordered: true,
       edited: 1,
-      images: 1,
+      urls: 1,
+      replaced: 1,
+      cropped: 1,
+      annotated: 1,
+      blurred: 1,
+      altEdited: true,
     });
   });
 

--- a/src/core/guides/__tests__/snapshot-groups.test.ts
+++ b/src/core/guides/__tests__/snapshot-groups.test.ts
@@ -2,8 +2,18 @@ import { describe, expect, it } from 'vitest';
 import { groupSnapshots } from '../snapshot-groups';
 import type { Snapshot } from '../types';
 
-function snap(id: string, contentHash: string): Snapshot {
-  return { id, guideId: 'g1', createdAt: 0, contentHash, title: '', stepIds: [], steps: [], screenshots: [] };
+function snap(id: string, contentHash: string, name?: string): Snapshot {
+  return {
+    id,
+    guideId: 'g1',
+    createdAt: 0,
+    contentHash,
+    title: '',
+    stepIds: [],
+    steps: [],
+    screenshots: [],
+    ...(name === undefined ? {} : { name }),
+  };
 }
 
 describe('groupSnapshots', () => {
@@ -41,5 +51,63 @@ describe('groupSnapshots', () => {
 
   it('returns nothing for an empty list', () => {
     expect(groupSnapshots([])).toEqual([]);
+  });
+
+  it('keeps a named snapshot out of a run of three, splitting it into three entries', () => {
+    const rows = groupSnapshots([snap('a', 'h1'), snap('b', 'h1', 'before rewrite'), snap('c', 'h1')]);
+
+    expect(rows.map((r) => r.kind)).toEqual(['entry', 'entry', 'entry']);
+    expect(rows.map((r) => r.kind === 'entry' && r.snapshot.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('splits a longer run around a named snapshot', () => {
+    const rows = groupSnapshots([
+      snap('a', 'h1'),
+      snap('b', 'h1'),
+      snap('c', 'h1', 'checkpoint'),
+      snap('d', 'h1'),
+      snap('e', 'h1'),
+    ]);
+
+    expect(rows.map((r) => r.kind)).toEqual(['group', 'entry', 'group']);
+    expect(rows[0].kind === 'group' && rows[0].snapshots.map((s) => s.id)).toEqual(['a', 'b']);
+    expect(rows[1].kind === 'entry' && rows[1].snapshot.id).toBe('c');
+    expect(rows[2].kind === 'group' && rows[2].snapshots.map((s) => s.id)).toEqual(['d', 'e']);
+  });
+
+  it('never hides a named snapshot inside a group', () => {
+    const rows = groupSnapshots([
+      snap('a', 'h1'),
+      snap('b', 'h1', 'first name'),
+      snap('c', 'h1'),
+      snap('d', 'h1'),
+      snap('e', 'h2'),
+      snap('f', 'h2', 'second name'),
+    ]);
+
+    const grouped = rows.flatMap((r) => (r.kind === 'group' ? r.snapshots : []));
+    expect(grouped.some((s) => s.name)).toBe(false);
+    expect(rows.filter((r) => r.kind === 'entry' && r.snapshot.name).length).toBe(2);
+  });
+
+  it('keeps a named snapshot at the head of the list as an entry', () => {
+    const rows = groupSnapshots([snap('a', 'h1', 'named head'), snap('b', 'h1'), snap('c', 'h1')]);
+
+    expect(rows.map((r) => r.kind)).toEqual(['entry', 'group']);
+    expect(rows[0].kind === 'entry' && rows[0].snapshot.id).toBe('a');
+  });
+
+  it('keeps a named snapshot at the tail of the list as an entry', () => {
+    const rows = groupSnapshots([snap('a', 'h1'), snap('b', 'h1'), snap('c', 'h1', 'named tail')]);
+
+    expect(rows.map((r) => r.kind)).toEqual(['group', 'entry']);
+    expect(rows[1].kind === 'entry' && rows[1].snapshot.id).toBe('c');
+  });
+
+  it('treats an empty name as unnamed', () => {
+    const rows = groupSnapshots([snap('a', 'h1'), snap('b', 'h1', ''), snap('c', 'h1')]);
+
+    expect(rows.map((r) => r.kind)).toEqual(['group']);
+    expect(rows[0].kind === 'group' && rows[0].snapshots).toHaveLength(3);
   });
 });

--- a/src/core/guides/__tests__/snapshot-groups.test.ts
+++ b/src/core/guides/__tests__/snapshot-groups.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { groupSnapshots } from '../snapshot-groups';
+import type { Snapshot } from '../types';
+
+function snap(id: string, contentHash: string): Snapshot {
+  return { id, guideId: 'g1', createdAt: 0, contentHash, title: '', stepIds: [], steps: [], screenshots: [] };
+}
+
+describe('groupSnapshots', () => {
+  it('returns a plain entry for a lone hash', () => {
+    expect(groupSnapshots([snap('a', 'h1')])).toEqual([{ kind: 'entry', snapshot: snap('a', 'h1') }]);
+  });
+
+  it('collapses a run of matching hashes into one group', () => {
+    const rows = groupSnapshots([snap('a', 'h1'), snap('b', 'h1'), snap('c', 'h1')]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('group');
+    expect(rows[0].kind === 'group' && rows[0].snapshots).toHaveLength(3);
+  });
+
+  it('keeps runs separate and preserves order', () => {
+    const rows = groupSnapshots([snap('a', 'h1'), snap('b', 'h2'), snap('c', 'h2'), snap('d', 'h3')]);
+
+    expect(rows.map((r) => r.kind)).toEqual(['entry', 'group', 'entry']);
+  });
+
+  it('preserves snapshot identity and order across rows', () => {
+    const rows = groupSnapshots([snap('a', 'h1'), snap('b', 'h2'), snap('c', 'h2'), snap('d', 'h3')]);
+
+    expect(rows[0].kind === 'entry' && rows[0].snapshot.id).toBe('a');
+    expect(rows[1].kind === 'group' && rows[1].snapshots.map((s) => s.id)).toEqual(['b', 'c']);
+    expect(rows[2].kind === 'entry' && rows[2].snapshot.id).toBe('d');
+  });
+
+  it('does not merge non-adjacent matching hashes', () => {
+    const rows = groupSnapshots([snap('a', 'h1'), snap('b', 'h2'), snap('c', 'h1')]);
+
+    expect(rows.map((r) => r.kind)).toEqual(['entry', 'entry', 'entry']);
+  });
+
+  it('returns nothing for an empty list', () => {
+    expect(groupSnapshots([])).toEqual([]);
+  });
+});

--- a/src/core/guides/__tests__/snapshots.test.ts
+++ b/src/core/guides/__tests__/snapshots.test.ts
@@ -1,13 +1,16 @@
 import 'fake-indexeddb/auto';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-vi.hoisted(() => {
+const { broadcasts } = vi.hoisted(() => {
+  const broadcasts: unknown[] = [];
   globalThis.BroadcastChannel = class BroadcastChannel {
     name: string;
     constructor(name: string) {
       this.name = name;
     }
-    postMessage() {}
+    postMessage(message: unknown) {
+      broadcasts.push(message);
+    }
     addEventListener() {}
     removeEventListener() {}
     close() {}
@@ -17,10 +20,23 @@ vi.hoisted(() => {
       return true;
     }
   } as unknown as typeof BroadcastChannel;
+  return { broadcasts };
 });
 
 import { db } from '../db';
-import { createSnapshot, getSnapshots, updateStepDescription } from '../service';
+import {
+  createSnapshot,
+  deleteStep,
+  getGuide,
+  getSnapshots,
+  permanentlyDeleteGuide,
+  reorderSteps,
+  revertToSnapshot,
+  softDeleteGuide,
+  toggleStar,
+  updateGuideTitle,
+  updateStepDescription,
+} from '../service';
 import type { Guide, Screenshot, Step } from '../types';
 
 function makeStep(overrides: Partial<Step> & { id: string; guideId: string }): Step {
@@ -163,5 +179,151 @@ describe('getSnapshots', () => {
     const list = await getSnapshots('g1');
 
     expect(list.map((s) => s.id)).toEqual(['n2', 'n1']);
+  });
+});
+
+describe('revertToSnapshot', () => {
+  it('restores title, step order and step content', async () => {
+    await seedGuide('g1', { stepIds: ['s1', 's2'], title: 'Original' });
+    await db.steps.bulkAdd([
+      makeStep({ id: 's1', guideId: 'g1', index: 0, description: 'First' }),
+      makeStep({ id: 's2', guideId: 'g1', index: 1, description: 'Second' }),
+    ]);
+    const snapshot = await createSnapshot('g1');
+
+    await updateGuideTitle('g1', 'Changed');
+    await updateStepDescription('s1', 'Edited');
+    await deleteStep('g1', 's2');
+
+    await revertToSnapshot(snapshot!.id);
+
+    const restored = await getGuide('g1');
+    expect(restored?.guide.title).toBe('Original');
+    expect(restored?.guide.stepIds).toEqual(['s1', 's2']);
+    expect(restored?.steps.map((s) => s.description)).toEqual(['First', 'Second']);
+  });
+
+  it('restores step order after a reorder', async () => {
+    await seedGuide('g1', { stepIds: ['s3', 's1', 's2'] });
+    await db.steps.bulkAdd([
+      makeStep({ id: 's1', guideId: 'g1', index: 1, description: 'Middle' }),
+      makeStep({ id: 's2', guideId: 'g1', index: 2, description: 'Last' }),
+      makeStep({ id: 's3', guideId: 'g1', index: 0, description: 'First' }),
+    ]);
+    const snapshot = await createSnapshot('g1');
+
+    await reorderSteps('g1', ['s1', 's2', 's3']);
+
+    await revertToSnapshot(snapshot!.id);
+
+    const restored = await getGuide('g1');
+    expect(restored?.steps.map((s) => s.description)).toEqual(['First', 'Middle', 'Last']);
+    expect(restored?.guide.stepIds).toEqual(['s3', 's1', 's2']);
+  });
+
+  it('removes steps added after the snapshot was taken', async () => {
+    await seedGuide('g1', { stepIds: ['s1'], title: 'Original' });
+    await db.steps.add(makeStep({ id: 's1', guideId: 'g1', index: 0, description: 'First' }));
+    const snapshot = await createSnapshot('g1');
+
+    await db.steps.add(makeStep({ id: 's2', guideId: 'g1', index: 1, description: 'Added later' }));
+    await db.guides.update('g1', { stepIds: ['s1', 's2'] });
+
+    await revertToSnapshot(snapshot!.id);
+
+    const restored = await getGuide('g1');
+    expect(restored?.guide.stepIds).toEqual(['s1']);
+    expect(restored?.steps.map((s) => s.description)).toEqual(['First']);
+    expect(await db.steps.get('s2')).toBeUndefined();
+  });
+
+  it('snapshots the current state before restoring, so restore is undoable', async () => {
+    await seedGuide('g1', { stepIds: [], title: 'Original' });
+    const first = await createSnapshot('g1');
+    await updateGuideTitle('g1', 'Changed');
+
+    const undo = await revertToSnapshot(first!.id);
+
+    const list = await getSnapshots('g1');
+    expect(list).toHaveLength(2);
+    expect(list[0].title).toBe('Changed');
+    expect(undo?.id).toBe(list[0].id);
+    expect(undo?.title).toBe('Changed');
+
+    await revertToSnapshot(undo!.id);
+    expect((await db.guides.get('g1'))?.title).toBe('Changed');
+  });
+
+  it('does not un-star or un-trash the guide', async () => {
+    await seedGuide('g1', { stepIds: [], starred: false, deletedAt: null });
+    const snapshot = await createSnapshot('g1');
+    await toggleStar('g1');
+    await softDeleteGuide('g1');
+
+    await revertToSnapshot(snapshot!.id);
+
+    const guide = await db.guides.get('g1');
+    expect(guide?.starred).toBe(true);
+    expect(guide?.deletedAt).not.toBeNull();
+  });
+
+  it('restores screenshot metadata onto the live blob and bumps updatedAt', async () => {
+    await seedGuide('g1', { stepIds: ['s1'], updatedAt: 1000 });
+    await db.steps.add(makeStep({ id: 's1', guideId: 'g1', screenshotId: 'sc1' }));
+    await db.screenshots.add(
+      makeScreenshot({
+        id: 'sc1',
+        stepId: 's1',
+        width: 800,
+        edits: {
+          alt: 'original caption',
+          annotations: [{ id: 'a1', type: 'redact', x: 1, y: 2, w: 3, h: 4, style: 'blur' }],
+        },
+      }),
+    );
+    const snapshot = await createSnapshot('g1');
+
+    await db.screenshots.update('sc1', {
+      width: 1234,
+      edits: { alt: 'edited caption', annotations: [] },
+      blob: new Blob(['edited'], { type: 'image/png' }),
+    });
+
+    const undo = await revertToSnapshot(snapshot!.id);
+
+    expect(undo).not.toBeNull();
+    const restored = await db.screenshots.get('sc1');
+    expect(restored?.width).toBe(800);
+    expect(restored?.edits).toEqual({
+      alt: 'original caption',
+      annotations: [{ id: 'a1', type: 'redact', x: 1, y: 2, w: 3, h: 4, style: 'blur' }],
+    });
+    expect(await restored?.blob.text()).toBe('edited');
+    expect((await db.guides.get('g1'))?.updatedAt).toBeGreaterThan(1000);
+  });
+
+  it('is a no-op for an unknown snapshot id', async () => {
+    await seedGuide('g1', { stepIds: [], title: 'Original' });
+    broadcasts.length = 0;
+    expect(await revertToSnapshot('missing')).toBeNull();
+    expect((await db.guides.get('g1'))?.title).toBe('Original');
+    expect(broadcasts).toEqual([]);
+  });
+
+  it('writes nothing and returns null when the guide no longer exists', async () => {
+    await seedGuide('g1', { stepIds: ['s1'], title: 'Original' });
+    await db.steps.add(makeStep({ id: 's1', guideId: 'g1', screenshotId: 'sc1' }));
+    await db.screenshots.add(makeScreenshot({ id: 'sc1', stepId: 's1' }));
+    const snapshot = await createSnapshot('g1');
+
+    await permanentlyDeleteGuide('g1');
+    broadcasts.length = 0;
+
+    expect(await revertToSnapshot(snapshot!.id)).toBeNull();
+    expect(broadcasts).toEqual([]);
+    expect(await db.steps.count()).toBe(0);
+    expect(await db.screenshots.count()).toBe(0);
+    expect(await db.guides.count()).toBe(0);
+    expect(await getSnapshots('g1')).toHaveLength(1);
   });
 });

--- a/src/core/guides/__tests__/snapshots.test.ts
+++ b/src/core/guides/__tests__/snapshots.test.ts
@@ -1,0 +1,167 @@
+import 'fake-indexeddb/auto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.hoisted(() => {
+  globalThis.BroadcastChannel = class BroadcastChannel {
+    name: string;
+    constructor(name: string) {
+      this.name = name;
+    }
+    postMessage() {}
+    addEventListener() {}
+    removeEventListener() {}
+    close() {}
+    onmessage = null;
+    onmessageerror = null;
+    dispatchEvent() {
+      return true;
+    }
+  } as unknown as typeof BroadcastChannel;
+});
+
+import { db } from '../db';
+import { createSnapshot, getSnapshots, updateStepDescription } from '../service';
+import type { Guide, Screenshot, Step } from '../types';
+
+function makeStep(overrides: Partial<Step> & { id: string; guideId: string }): Step {
+  return {
+    index: 0,
+    description: 'Test step',
+    action: 'click',
+    url: 'https://example.com',
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeScreenshot(overrides: Partial<Screenshot> & { id: string; stepId: string }): Screenshot {
+  return {
+    blob: new Blob(['img'], { type: 'image/png' }),
+    mimeType: 'image/png',
+    width: 800,
+    height: 600,
+    ...overrides,
+  };
+}
+
+async function seedGuide(id: string, extras?: Partial<Guide>): Promise<Guide> {
+  const guide: Guide = {
+    id,
+    title: 'Test Guide',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    stepIds: [],
+    starred: false,
+    deletedAt: null,
+    ...extras,
+  };
+  await db.guides.add(guide);
+  return guide;
+}
+
+afterEach(async () => {
+  await db.guides.clear();
+  await db.steps.clear();
+  await db.screenshots.clear();
+  await db.snapshots.clear();
+});
+
+describe('createSnapshot', () => {
+  it('stores the guide, steps and screenshot rows without blobs', async () => {
+    await seedGuide('g1', { stepIds: ['s1'], title: 'Original' });
+    await db.steps.add(makeStep({ id: 's1', guideId: 'g1', screenshotId: 'sc1' }));
+    await db.screenshots.add(makeScreenshot({ id: 'sc1', stepId: 's1' }));
+
+    const snapshot = await createSnapshot('g1');
+
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.title).toBe('Original');
+    expect(snapshot?.stepIds).toEqual(['s1']);
+    expect(snapshot?.steps).toHaveLength(1);
+    expect(snapshot?.screenshots).toHaveLength(1);
+    expect(snapshot?.screenshots[0]).not.toHaveProperty('blob');
+    expect(snapshot?.contentHash).toBeTypeOf('string');
+  });
+
+  it('returns null for a guide that does not exist', async () => {
+    expect(await createSnapshot('missing')).toBeNull();
+  });
+
+  it('orders steps by index, not insertion order', async () => {
+    await seedGuide('g1', { stepIds: ['s2', 's1'] });
+    await db.steps.add(makeStep({ id: 's2', guideId: 'g1', index: 1, description: 'Second' }));
+    await db.steps.add(makeStep({ id: 's1', guideId: 'g1', index: 0, description: 'First' }));
+
+    const snapshot = await createSnapshot('g1');
+
+    expect(snapshot?.steps.map((s) => s.description)).toEqual(['First', 'Second']);
+    expect(snapshot?.stepIds).toEqual(['s1', 's2']);
+  });
+
+  it('gives unchanged content the same hash and changed content a different one', async () => {
+    await seedGuide('g1', { stepIds: ['s1'] });
+    await db.steps.add(makeStep({ id: 's1', guideId: 'g1', description: 'Before' }));
+
+    const first = await createSnapshot('g1');
+    const unchanged = await createSnapshot('g1');
+    expect(unchanged?.contentHash).toBe(first?.contentHash);
+
+    await updateStepDescription('s1', 'After');
+    const changed = await createSnapshot('g1');
+    expect(changed?.contentHash).not.toBe(first?.contentHash);
+  });
+
+  it('keeps createdAt strictly increasing within a guide', async () => {
+    await seedGuide('g1', { stepIds: [] });
+
+    const a = await createSnapshot('g1');
+    const b = await createSnapshot('g1');
+    const c = await createSnapshot('g1');
+
+    expect(b!.createdAt).toBeGreaterThan(a!.createdAt);
+    expect(c!.createdAt).toBeGreaterThan(b!.createdAt);
+    expect((await getSnapshots('g1')).map((s) => s.id)).toEqual([c!.id, b!.id, a!.id]);
+  });
+});
+
+describe('getSnapshots', () => {
+  it('returns snapshots for the guide, newest first', async () => {
+    await seedGuide('g1', { stepIds: [] });
+    await db.snapshots.bulkAdd([
+      {
+        id: 'n1',
+        guideId: 'g1',
+        createdAt: 100,
+        contentHash: 'a',
+        title: 'A',
+        stepIds: [],
+        steps: [],
+        screenshots: [],
+      },
+      {
+        id: 'n2',
+        guideId: 'g1',
+        createdAt: 300,
+        contentHash: 'b',
+        title: 'B',
+        stepIds: [],
+        steps: [],
+        screenshots: [],
+      },
+      {
+        id: 'n3',
+        guideId: 'g2',
+        createdAt: 200,
+        contentHash: 'c',
+        title: 'C',
+        stepIds: [],
+        steps: [],
+        screenshots: [],
+      },
+    ]);
+
+    const list = await getSnapshots('g1');
+
+    expect(list.map((s) => s.id)).toEqual(['n2', 'n1']);
+  });
+});

--- a/src/core/guides/__tests__/snapshots.test.ts
+++ b/src/core/guides/__tests__/snapshots.test.ts
@@ -26,11 +26,13 @@ const { broadcasts } = vi.hoisted(() => {
 import { db } from '../db';
 import {
   createSnapshot,
+  deleteScreenshot,
   deleteStep,
   getGuide,
   getSnapshots,
   permanentlyDeleteGuide,
   reorderSteps,
+  replaceScreenshot,
   revertToSnapshot,
   softDeleteGuide,
   toggleStar,
@@ -316,7 +318,9 @@ describe('revertToSnapshot', () => {
     await db.screenshots.add(makeScreenshot({ id: 'sc1', stepId: 's1' }));
     const snapshot = await createSnapshot('g1');
 
-    await permanentlyDeleteGuide('g1');
+    await db.guides.delete('g1');
+    await db.steps.clear();
+    await db.screenshots.clear();
     broadcasts.length = 0;
 
     expect(await revertToSnapshot(snapshot!.id)).toBeNull();
@@ -325,5 +329,123 @@ describe('revertToSnapshot', () => {
     expect(await db.screenshots.count()).toBe(0);
     expect(await db.guides.count()).toBe(0);
     expect(await getSnapshots('g1')).toHaveLength(1);
+  });
+});
+
+describe('append-only screenshots', () => {
+  it('replaceScreenshot keeps the old row and repoints the step', async () => {
+    await seedGuide('g1', { stepIds: ['s1'] });
+    await db.steps.add(makeStep({ id: 's1', guideId: 'g1', screenshotId: 'sc1' }));
+    await db.screenshots.add(makeScreenshot({ id: 'sc1', stepId: 's1' }));
+
+    const newId = await replaceScreenshot('s1', new Blob(['new'], { type: 'image/webp' }), {
+      width: 100,
+      height: 50,
+    });
+
+    expect(newId).not.toBe('sc1');
+    expect(await db.screenshots.get('sc1')).toBeDefined();
+    expect((await db.steps.get('s1'))?.screenshotId).toBe(newId);
+  });
+
+  it('deleteScreenshot clears the pointer but keeps the row', async () => {
+    await seedGuide('g1', { stepIds: ['s1'] });
+    await db.steps.add(makeStep({ id: 's1', guideId: 'g1', screenshotId: 'sc1' }));
+    await db.screenshots.add(makeScreenshot({ id: 'sc1', stepId: 's1' }));
+
+    await deleteScreenshot('s1');
+
+    expect((await db.steps.get('s1'))?.screenshotId).toBeUndefined();
+    expect(await db.screenshots.get('sc1')).toBeDefined();
+  });
+
+  it('deleteStep keeps the screenshot row', async () => {
+    await seedGuide('g1', { stepIds: ['s1'] });
+    await db.steps.add(makeStep({ id: 's1', guideId: 'g1', screenshotId: 'sc1' }));
+    await db.screenshots.add(makeScreenshot({ id: 'sc1', stepId: 's1' }));
+    await createSnapshot('g1');
+
+    await deleteStep('g1', 's1');
+
+    expect(await db.screenshots.get('sc1')).toBeDefined();
+  });
+
+  it('permanentlyDeleteGuide sweeps unreferenced rows and snapshots', async () => {
+    await seedGuide('g1', { stepIds: ['s1'] });
+    await db.steps.add(makeStep({ id: 's1', guideId: 'g1', screenshotId: 'sc2' }));
+    await db.screenshots.bulkAdd([
+      makeScreenshot({ id: 'sc1', stepId: 's1' }),
+      makeScreenshot({ id: 'sc2', stepId: 's1' }),
+    ]);
+    await createSnapshot('g1');
+
+    await permanentlyDeleteGuide('g1');
+
+    expect(await db.screenshots.count()).toBe(0);
+    expect(await db.snapshots.count()).toBe(0);
+    expect(await db.steps.count()).toBe(0);
+  });
+
+  it('restores the previous image after a replace', async () => {
+    await seedGuide('g1', { stepIds: ['s1'] });
+    await db.steps.add(makeStep({ id: 's1', guideId: 'g1', screenshotId: 'sc1' }));
+    await db.screenshots.add(makeScreenshot({ id: 'sc1', stepId: 's1' }));
+    const snapshot = await createSnapshot('g1');
+
+    await replaceScreenshot('s1', new Blob(['new'], { type: 'image/webp' }), { width: 100, height: 50 });
+    await revertToSnapshot(snapshot!.id);
+
+    expect((await db.steps.get('s1'))?.screenshotId).toBe('sc1');
+    expect(await (await db.screenshots.get('sc1'))?.blob.text()).toBe('img');
+  });
+
+  it('restores a deleted image', async () => {
+    await seedGuide('g1', { stepIds: ['s1'] });
+    await db.steps.add(makeStep({ id: 's1', guideId: 'g1', screenshotId: 'sc1' }));
+    await db.screenshots.add(makeScreenshot({ id: 'sc1', stepId: 's1' }));
+    const snapshot = await createSnapshot('g1');
+
+    await deleteScreenshot('s1');
+    await revertToSnapshot(snapshot!.id);
+
+    expect((await db.steps.get('s1'))?.screenshotId).toBe('sc1');
+    const restored = await getGuide('g1');
+    expect(restored?.screenshots.get('s1')?.id).toBe('sc1');
+    expect(await restored?.screenshots.get('s1')?.blob.text()).toBe('img');
+  });
+
+  it('sweeps screenshot rows orphaned by a step deletion', async () => {
+    await seedGuide('g1', { stepIds: ['s1'] });
+    await db.steps.add(makeStep({ id: 's1', guideId: 'g1', screenshotId: 'sc1' }));
+    await db.screenshots.add(makeScreenshot({ id: 'sc1', stepId: 's1' }));
+    await createSnapshot('g1');
+
+    await deleteStep('g1', 's1');
+    await permanentlyDeleteGuide('g1');
+
+    expect(await db.screenshots.count()).toBe(0);
+  });
+
+  it('sweeps rows added after the snapshot once their step is deleted', async () => {
+    await seedGuide('g1', { stepIds: ['s1'] });
+    await db.steps.add(makeStep({ id: 's1', guideId: 'g1', screenshotId: 'sc1' }));
+    await db.screenshots.add(makeScreenshot({ id: 'sc1', stepId: 's1' }));
+    await createSnapshot('g1');
+
+    await replaceScreenshot('s1', new Blob(['new'], { type: 'image/webp' }), { width: 10, height: 10 });
+    await deleteStep('g1', 's1');
+    await permanentlyDeleteGuide('g1');
+
+    expect(await db.screenshots.count()).toBe(0);
+  });
+
+  it('drops the screenshot row when a step is deleted before any snapshot exists', async () => {
+    await seedGuide('g1', { stepIds: ['s1'] });
+    await db.steps.add(makeStep({ id: 's1', guideId: 'g1', screenshotId: 'sc1' }));
+    await db.screenshots.add(makeScreenshot({ id: 'sc1', stepId: 's1' }));
+
+    await deleteStep('g1', 's1');
+
+    expect(await db.screenshots.count()).toBe(0);
   });
 });

--- a/src/core/guides/__tests__/snapshots.test.ts
+++ b/src/core/guides/__tests__/snapshots.test.ts
@@ -31,6 +31,7 @@ import {
   getGuide,
   getSnapshots,
   permanentlyDeleteGuide,
+  renameSnapshot,
   reorderSteps,
   replaceScreenshot,
   revertToSnapshot,
@@ -181,6 +182,79 @@ describe('getSnapshots', () => {
     const list = await getSnapshots('g1');
 
     expect(list.map((s) => s.id)).toEqual(['n2', 'n1']);
+  });
+});
+
+describe('renameSnapshot', () => {
+  it('stores a name on the snapshot without a schema migration', async () => {
+    await seedGuide('g1', { stepIds: [] });
+    const snapshot = await createSnapshot('g1');
+
+    await renameSnapshot(snapshot!.id, 'before rewrite');
+
+    expect((await db.snapshots.get(snapshot!.id))?.name).toBe('before rewrite');
+    expect((await getSnapshots('g1'))[0].name).toBe('before rewrite');
+  });
+
+  it('trims surrounding whitespace', async () => {
+    await seedGuide('g1', { stepIds: [] });
+    const snapshot = await createSnapshot('g1');
+
+    await renameSnapshot(snapshot!.id, '   spaced out  ');
+
+    expect((await db.snapshots.get(snapshot!.id))?.name).toBe('spaced out');
+  });
+
+  it('clears the name when given an empty or whitespace-only value', async () => {
+    await seedGuide('g1', { stepIds: [] });
+    const snapshot = await createSnapshot('g1');
+    await renameSnapshot(snapshot!.id, 'named');
+
+    await renameSnapshot(snapshot!.id, '   ');
+
+    expect((await db.snapshots.get(snapshot!.id))?.name).toBeUndefined();
+  });
+
+  it('leaves createdAt and contentHash untouched', async () => {
+    await seedGuide('g1', { stepIds: ['s1'] });
+    await db.steps.add(makeStep({ id: 's1', guideId: 'g1' }));
+    const snapshot = await createSnapshot('g1');
+
+    await renameSnapshot(snapshot!.id, 'milestone');
+
+    const stored = await db.snapshots.get(snapshot!.id);
+    expect(stored?.createdAt).toBe(snapshot!.createdAt);
+    expect(stored?.contentHash).toBe(snapshot!.contentHash);
+  });
+
+  it('keeps the content hash out of naming, so a named version still groups with unchanged siblings', async () => {
+    await seedGuide('g1', { stepIds: ['s1'] });
+    await db.steps.add(makeStep({ id: 's1', guideId: 'g1' }));
+    const first = await createSnapshot('g1');
+
+    await renameSnapshot(first!.id, 'checkpoint');
+    const second = await createSnapshot('g1');
+
+    expect(second?.contentHash).toBe(first?.contentHash);
+    expect(second?.name).toBeUndefined();
+  });
+
+  it('does not rename other snapshots or touch the guide', async () => {
+    await seedGuide('g1', { stepIds: [], updatedAt: 5000 });
+    const first = await createSnapshot('g1');
+    const second = await createSnapshot('g1');
+    await db.guides.update('g1', { updatedAt: 5000 });
+    broadcasts.length = 0;
+
+    await renameSnapshot(second!.id, 'only this one');
+
+    expect((await db.snapshots.get(first!.id))?.name).toBeUndefined();
+    expect((await db.guides.get('g1'))?.updatedAt).toBe(5000);
+    expect(broadcasts.filter((m) => !!m && typeof m === 'object' && 'type' in m)).toEqual([]);
+  });
+
+  it('is a no-op for an unknown snapshot id', async () => {
+    await expect(renameSnapshot('missing', 'ghost')).resolves.toBeUndefined();
   });
 });
 

--- a/src/core/guides/db.ts
+++ b/src/core/guides/db.ts
@@ -1,10 +1,11 @@
 import Dexie, { type EntityTable } from 'dexie';
-import type { Guide, Screenshot, Step } from './types';
+import type { Guide, Screenshot, Snapshot, Step } from './types';
 
 export class MimikDB extends Dexie {
   guides!: EntityTable<Guide, 'id'>;
   steps!: EntityTable<Step, 'id'>;
   screenshots!: EntityTable<Screenshot, 'id'>;
+  snapshots!: EntityTable<Snapshot, 'id'>;
 
   constructor() {
     super('mimik');
@@ -12,6 +13,9 @@ export class MimikDB extends Dexie {
       guides: 'id, createdAt, updatedAt, starred, deletedAt',
       steps: 'id, guideId, index',
       screenshots: 'id, stepId',
+    });
+    this.version(2).stores({
+      snapshots: 'id, guideId, createdAt',
     });
   }
 }

--- a/src/core/guides/db.ts
+++ b/src/core/guides/db.ts
@@ -15,7 +15,7 @@ export class MimikDB extends Dexie {
       screenshots: 'id, stepId',
     });
     this.version(2).stores({
-      snapshots: 'id, guideId, createdAt',
+      snapshots: 'id, guideId, createdAt, [guideId+createdAt]',
     });
   }
 }

--- a/src/core/guides/service.ts
+++ b/src/core/guides/service.ts
@@ -252,6 +252,11 @@ export async function getSnapshots(guideId: string): Promise<Snapshot[]> {
     .toArray();
 }
 
+export async function renameSnapshot(snapshotId: string, name: string): Promise<void> {
+  const trimmed = name.trim();
+  await db.snapshots.update(snapshotId, { name: trimmed === '' ? undefined : trimmed });
+}
+
 export async function revertToSnapshot(snapshotId: string): Promise<Snapshot | null> {
   const undo = await db.transaction('rw', db.guides, db.steps, db.screenshots, db.snapshots, async () => {
     const snapshot = await db.snapshots.get(snapshotId);

--- a/src/core/guides/service.ts
+++ b/src/core/guides/service.ts
@@ -1,7 +1,8 @@
 import { i18n } from '#imports';
 import type { ScreenshotEdits } from '@/core/screenshot/types';
 import { db } from './db';
-import type { Guide, Screenshot, Step } from './types';
+import { hashPayload } from './snapshot-hash';
+import type { Guide, Screenshot, Snapshot, Step } from './types';
 
 export type GuideChangeEvent = { type: 'starred'; id: string; starred: boolean } | { type: 'mutated' };
 
@@ -193,4 +194,38 @@ export async function getFirstScreenshot(guideId: string): Promise<Screenshot | 
     }
   }
   return null;
+}
+
+export async function createSnapshot(guideId: string): Promise<Snapshot | null> {
+  return db.transaction('rw', db.guides, db.steps, db.screenshots, db.snapshots, async () => {
+    const guide = await db.guides.get(guideId);
+    if (!guide) return null;
+    const steps = await db.steps.where('guideId').equals(guideId).sortBy('index');
+    const stepIds = steps.map((s) => s.id);
+    const rows = await db.screenshots.where('stepId').anyOf(stepIds).toArray();
+    const screenshots = rows.map(({ blob, ...rest }) => rest);
+    const payload = { title: guide.title, stepIds, steps, screenshots };
+    const latest = await db.snapshots
+      .where('[guideId+createdAt]')
+      .between([guideId, -Infinity], [guideId, Infinity])
+      .last();
+    const now = Date.now();
+    const snapshot: Snapshot = {
+      id: crypto.randomUUID(),
+      guideId,
+      createdAt: latest && latest.createdAt >= now ? latest.createdAt + 1 : now,
+      contentHash: hashPayload(payload),
+      ...payload,
+    };
+    await db.snapshots.add(snapshot);
+    return snapshot;
+  });
+}
+
+export async function getSnapshots(guideId: string): Promise<Snapshot[]> {
+  return db.snapshots
+    .where('[guideId+createdAt]')
+    .between([guideId, -Infinity], [guideId, Infinity])
+    .reverse()
+    .toArray();
 }

--- a/src/core/guides/service.ts
+++ b/src/core/guides/service.ts
@@ -106,8 +106,16 @@ export async function restoreGuide(id: string): Promise<void> {
 
 export async function permanentlyDeleteGuide(id: string): Promise<void> {
   const steps = await db.steps.where('guideId').equals(id).toArray();
-  const screenshotIds = steps.map((s) => s.screenshotId).filter(Boolean) as string[];
-  await db.screenshots.where('id').anyOf(screenshotIds).delete();
+  const snapshots = await db.snapshots.where('guideId').equals(id).toArray();
+  const stepIds = new Set(steps.map((s) => s.id));
+  for (const snapshot of snapshots) {
+    for (const step of snapshot.steps) stepIds.add(step.id);
+  }
+  await db.screenshots
+    .where('stepId')
+    .anyOf([...stepIds])
+    .delete();
+  await db.snapshots.where('guideId').equals(id).delete();
   await db.steps.where('guideId').equals(id).delete();
   await db.guides.delete(id);
   notifyGuidesChanged({ type: 'mutated' });
@@ -135,9 +143,10 @@ export async function getStepsForGuide(guideId: string): Promise<Step[]> {
 }
 
 export async function deleteStep(guideId: string, stepId: string): Promise<void> {
-  const step = await db.steps.get(stepId);
-  if (step?.screenshotId) {
-    await db.screenshots.delete(step.screenshotId);
+  const snapshotCount = await db.snapshots.where('guideId').equals(guideId).count();
+  if (snapshotCount === 0) {
+    const step = await db.steps.get(stepId);
+    if (step?.screenshotId) await db.screenshots.delete(step.screenshotId);
   }
   await db.steps.delete(stepId);
   const guide = await db.guides.get(guideId);
@@ -163,23 +172,34 @@ export async function saveScreenshot(screenshot: Screenshot): Promise<void> {
   await db.screenshots.add(screenshot);
 }
 
-export async function updateScreenshotBlob(
-  screenshotId: string,
+export async function replaceScreenshot(
+  stepId: string,
   blob: Blob,
-  dimensions?: { width: number; height: number },
-): Promise<void> {
-  await db.screenshots.update(screenshotId, { blob, ...dimensions });
+  dimensions: { width: number; height: number },
+  edits?: ScreenshotEdits,
+): Promise<string> {
+  const id = crypto.randomUUID();
+  await db.transaction('rw', db.screenshots, db.steps, async () => {
+    await db.screenshots.add({
+      id,
+      stepId,
+      blob,
+      mimeType: blob.type,
+      width: dimensions.width,
+      height: dimensions.height,
+      ...(edits ? { edits } : {}),
+    });
+    await db.steps.update(stepId, { screenshotId: id });
+  });
+  return id;
 }
 
 export async function updateScreenshotEdits(screenshotId: string, edits: ScreenshotEdits): Promise<void> {
   await db.screenshots.update(screenshotId, { edits });
 }
 
-export async function deleteScreenshot(screenshotId: string, stepId: string): Promise<void> {
-  await db.transaction('rw', db.screenshots, db.steps, async () => {
-    await db.screenshots.delete(screenshotId);
-    await db.steps.update(stepId, { screenshotId: undefined });
-  });
+export async function deleteScreenshot(stepId: string): Promise<void> {
+  await db.steps.update(stepId, { screenshotId: undefined });
 }
 
 export async function getScreenshotsForSteps(stepIds: string[]): Promise<Map<string, Screenshot>> {

--- a/src/core/guides/service.ts
+++ b/src/core/guides/service.ts
@@ -74,13 +74,15 @@ export async function updateGuideTitle(id: string, title: string): Promise<void>
 }
 
 export async function addStepToGuide(guideId: string, stepId: string): Promise<void> {
-  const guide = await db.guides.get(guideId);
-  if (guide) {
-    await db.guides.update(guideId, {
-      stepIds: [...guide.stepIds, stepId],
-      updatedAt: Date.now(),
-    });
-  }
+  await db.transaction('rw', db.guides, async () => {
+    const guide = await db.guides.get(guideId);
+    if (guide) {
+      await db.guides.update(guideId, {
+        stepIds: [...guide.stepIds, stepId],
+        updatedAt: Date.now(),
+      });
+    }
+  });
 }
 
 export async function toggleStar(id: string): Promise<boolean> {
@@ -228,4 +230,30 @@ export async function getSnapshots(guideId: string): Promise<Snapshot[]> {
     .between([guideId, -Infinity], [guideId, Infinity])
     .reverse()
     .toArray();
+}
+
+export async function revertToSnapshot(snapshotId: string): Promise<Snapshot | null> {
+  const undo = await db.transaction('rw', db.guides, db.steps, db.screenshots, db.snapshots, async () => {
+    const snapshot = await db.snapshots.get(snapshotId);
+    if (!snapshot) return null;
+    const previous = await createSnapshot(snapshot.guideId);
+    if (!previous) return null;
+    const existing = await db.steps.where('guideId').equals(snapshot.guideId).toArray();
+    const keep = new Set(snapshot.steps.map((s) => s.id));
+    await db.steps.bulkDelete(existing.filter((s) => !keep.has(s.id)).map((s) => s.id));
+    await db.steps.bulkPut(snapshot.steps);
+    const live = await db.screenshots.bulkGet(snapshot.screenshots.map((r) => r.id));
+    const merged = snapshot.screenshots
+      .map((row, i) => (live[i] ? { ...row, blob: live[i]!.blob } : null))
+      .filter((r): r is Screenshot => r !== null);
+    if (merged.length > 0) await db.screenshots.bulkPut(merged);
+    await db.guides.update(snapshot.guideId, {
+      title: snapshot.title,
+      stepIds: snapshot.stepIds,
+      updatedAt: Date.now(),
+    });
+    return previous;
+  });
+  if (undo) notifyGuidesChanged({ type: 'mutated' });
+  return undo;
 }

--- a/src/core/guides/snapshot-diff.ts
+++ b/src/core/guides/snapshot-diff.ts
@@ -1,8 +1,9 @@
-import type { ScreenshotEdits } from '@/core/screenshot/types';
+import type { Annotation, ScreenshotEdits } from '@/core/screenshot/types';
 
 interface DiffStep {
   id: string;
   description: string;
+  url?: string;
   screenshotId?: string;
 }
 
@@ -24,13 +25,40 @@ export interface SnapshotDiff {
   removed: number;
   reordered: boolean;
   edited: number;
-  images: number;
+  urls: number;
+  replaced: number;
+  cropped: number;
+  annotated: number;
+  blurred: number;
+  altEdited: boolean;
 }
 
-function editsKey(snapshot: SnapshotLike, screenshotId: string | undefined): string {
-  if (!screenshotId) return '{}';
-  const row = snapshot.screenshots.find((r) => r.id === screenshotId);
-  return JSON.stringify(row?.edits ?? {});
+function stableStringify(value: unknown): string {
+  if (value === undefined) return 'undefined';
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record)
+    .filter((key) => record[key] !== undefined)
+    .sort();
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`).join(',')}}`;
+}
+
+function editsFor(snapshot: SnapshotLike, screenshotId: string | undefined): ScreenshotEdits {
+  if (!screenshotId) return {};
+  return snapshot.screenshots.find((row) => row.id === screenshotId)?.edits ?? {};
+}
+
+function redactions(edits: ScreenshotEdits): Annotation[] {
+  return (edits.annotations ?? []).filter((annotation) => annotation.type === 'redact');
+}
+
+function drawings(edits: ScreenshotEdits): Annotation[] {
+  return (edits.annotations ?? []).filter((annotation) => annotation.type !== 'redact');
+}
+
+function differs(before: unknown, after: unknown): boolean {
+  return stableStringify(before) !== stableStringify(after);
 }
 
 export function diffSnapshots(from: SnapshotLike, to: SnapshotLike): SnapshotDiff {
@@ -46,14 +74,42 @@ export function diffSnapshots(from: SnapshotLike, to: SnapshotLike): SnapshotDif
 
   const fromSteps = new Map(from.steps.map((s) => [s.id, s]));
   let edited = 0;
-  let images = 0;
+  let urls = 0;
+  let replaced = 0;
+  let cropped = 0;
+  let annotated = 0;
+  let blurred = 0;
+  let altEdited = false;
+
   for (const step of to.steps) {
     const before = fromSteps.get(step.id);
     if (!before) continue;
+
     if (before.description !== step.description) edited++;
-    if (before.screenshotId !== step.screenshotId) images++;
-    else if (editsKey(from, before.screenshotId) !== editsKey(to, step.screenshotId)) images++;
+    if (before.url !== step.url) urls++;
+    if (before.screenshotId !== step.screenshotId) replaced++;
+
+    const beforeEdits = editsFor(from, before.screenshotId);
+    const afterEdits = editsFor(to, step.screenshotId);
+
+    if (differs(beforeEdits.viewport, afterEdits.viewport)) cropped++;
+    if (differs(drawings(beforeEdits), drawings(afterEdits)) || differs(beforeEdits.target, afterEdits.target))
+      annotated++;
+    if (differs(redactions(beforeEdits), redactions(afterEdits))) blurred++;
+    if (differs(beforeEdits.alt, afterEdits.alt)) altEdited = true;
   }
 
-  return { titleChanged: from.title !== to.title, added, removed, reordered, edited, images };
+  return {
+    titleChanged: from.title !== to.title,
+    added,
+    removed,
+    reordered,
+    edited,
+    urls,
+    replaced,
+    cropped,
+    annotated,
+    blurred,
+    altEdited,
+  };
 }

--- a/src/core/guides/snapshot-diff.ts
+++ b/src/core/guides/snapshot-diff.ts
@@ -1,0 +1,59 @@
+import type { ScreenshotEdits } from '@/core/screenshot/types';
+
+interface DiffStep {
+  id: string;
+  description: string;
+  screenshotId?: string;
+}
+
+interface DiffScreenshot {
+  id: string;
+  edits?: ScreenshotEdits;
+}
+
+export interface SnapshotLike {
+  title: string;
+  stepIds: readonly string[];
+  steps: readonly DiffStep[];
+  screenshots: readonly DiffScreenshot[];
+}
+
+export interface SnapshotDiff {
+  titleChanged: boolean;
+  added: number;
+  removed: number;
+  reordered: boolean;
+  edited: number;
+  images: number;
+}
+
+function editsKey(snapshot: SnapshotLike, screenshotId: string | undefined): string {
+  if (!screenshotId) return '{}';
+  const row = snapshot.screenshots.find((r) => r.id === screenshotId);
+  return JSON.stringify(row?.edits ?? {});
+}
+
+export function diffSnapshots(from: SnapshotLike, to: SnapshotLike): SnapshotDiff {
+  const fromIds = new Set(from.stepIds);
+  const toIds = new Set(to.stepIds);
+
+  const added = to.stepIds.filter((id) => !fromIds.has(id)).length;
+  const removed = from.stepIds.filter((id) => !toIds.has(id)).length;
+
+  const survivorsBefore = from.stepIds.filter((id) => toIds.has(id));
+  const survivorsAfter = to.stepIds.filter((id) => fromIds.has(id));
+  const reordered = survivorsBefore.some((id, i) => survivorsAfter[i] !== id);
+
+  const fromSteps = new Map(from.steps.map((s) => [s.id, s]));
+  let edited = 0;
+  let images = 0;
+  for (const step of to.steps) {
+    const before = fromSteps.get(step.id);
+    if (!before) continue;
+    if (before.description !== step.description) edited++;
+    if (before.screenshotId !== step.screenshotId) images++;
+    else if (editsKey(from, before.screenshotId) !== editsKey(to, step.screenshotId)) images++;
+  }
+
+  return { titleChanged: from.title !== to.title, added, removed, reordered, edited, images };
+}

--- a/src/core/guides/snapshot-diff.ts
+++ b/src/core/guides/snapshot-diff.ts
@@ -1,4 +1,6 @@
+import { resolveTarget } from '@/core/screenshot/geometry';
 import type { Annotation, ScreenshotEdits } from '@/core/screenshot/types';
+import type { ScreenshotBounds } from './types';
 
 interface DiffStep {
   id: string;
@@ -10,6 +12,8 @@ interface DiffStep {
 interface DiffScreenshot {
   id: string;
   edits?: ScreenshotEdits;
+  bounds?: ScreenshotBounds;
+  pixelRatio?: number;
 }
 
 export interface SnapshotLike {
@@ -44,9 +48,13 @@ function stableStringify(value: unknown): string {
   return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`).join(',')}}`;
 }
 
-function editsFor(snapshot: SnapshotLike, screenshotId: string | undefined): ScreenshotEdits {
-  if (!screenshotId) return {};
-  return snapshot.screenshots.find((row) => row.id === screenshotId)?.edits ?? {};
+function rowFor(snapshot: SnapshotLike, screenshotId: string | undefined): DiffScreenshot {
+  if (!screenshotId) return { id: '' };
+  return snapshot.screenshots.find((row) => row.id === screenshotId) ?? { id: screenshotId };
+}
+
+function altOf(edits: ScreenshotEdits): string {
+  return edits.alt ?? '';
 }
 
 function redactions(edits: ScreenshotEdits): Annotation[] {
@@ -87,16 +95,24 @@ export function diffSnapshots(from: SnapshotLike, to: SnapshotLike): SnapshotDif
 
     if (before.description !== step.description) edited++;
     if (before.url !== step.url) urls++;
-    if (before.screenshotId !== step.screenshotId) replaced++;
+    if (before.screenshotId !== step.screenshotId) {
+      replaced++;
+      continue;
+    }
 
-    const beforeEdits = editsFor(from, before.screenshotId);
-    const afterEdits = editsFor(to, step.screenshotId);
+    const beforeRow = rowFor(from, before.screenshotId);
+    const afterRow = rowFor(to, step.screenshotId);
+    const beforeEdits = beforeRow.edits ?? {};
+    const afterEdits = afterRow.edits ?? {};
 
     if (differs(beforeEdits.viewport, afterEdits.viewport)) cropped++;
-    if (differs(drawings(beforeEdits), drawings(afterEdits)) || differs(beforeEdits.target, afterEdits.target))
+    if (
+      differs(drawings(beforeEdits), drawings(afterEdits)) ||
+      differs(resolveTarget(beforeRow), resolveTarget(afterRow))
+    )
       annotated++;
     if (differs(redactions(beforeEdits), redactions(afterEdits))) blurred++;
-    if (differs(beforeEdits.alt, afterEdits.alt)) altEdited = true;
+    if (altOf(beforeEdits) !== altOf(afterEdits)) altEdited = true;
   }
 
   return {

--- a/src/core/guides/snapshot-groups.ts
+++ b/src/core/guides/snapshot-groups.ts
@@ -13,6 +13,11 @@ export function groupSnapshots(snapshots: Snapshot[]): SnapshotRow[] {
   };
 
   for (const snapshot of snapshots) {
+    if (snapshot.name) {
+      flush();
+      rows.push({ kind: 'entry', snapshot });
+      continue;
+    }
     if (run.length > 0 && run[0].contentHash !== snapshot.contentHash) flush();
     run.push(snapshot);
   }

--- a/src/core/guides/snapshot-groups.ts
+++ b/src/core/guides/snapshot-groups.ts
@@ -1,0 +1,22 @@
+import type { Snapshot } from './types';
+
+export type SnapshotRow = { kind: 'entry'; snapshot: Snapshot } | { kind: 'group'; snapshots: Snapshot[] };
+
+export function groupSnapshots(snapshots: Snapshot[]): SnapshotRow[] {
+  const rows: SnapshotRow[] = [];
+  let run: Snapshot[] = [];
+
+  const flush = () => {
+    if (run.length === 0) return;
+    rows.push(run.length === 1 ? { kind: 'entry', snapshot: run[0] } : { kind: 'group', snapshots: run });
+    run = [];
+  };
+
+  for (const snapshot of snapshots) {
+    if (run.length > 0 && run[0].contentHash !== snapshot.contentHash) flush();
+    run.push(snapshot);
+  }
+  flush();
+
+  return rows;
+}

--- a/src/core/guides/snapshot-hash.ts
+++ b/src/core/guides/snapshot-hash.ts
@@ -1,0 +1,8 @@
+export function hashPayload(value: unknown): string {
+  const json = JSON.stringify(value) ?? '';
+  let hash = 5381;
+  for (let i = 0; i < json.length; i++) {
+    hash = ((hash << 5) + hash + json.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+}

--- a/src/core/guides/types.ts
+++ b/src/core/guides/types.ts
@@ -71,6 +71,7 @@ export interface Snapshot {
   guideId: string;
   createdAt: number;
   contentHash: string;
+  name?: string;
   title: string;
   stepIds: string[];
   steps: Step[];

--- a/src/core/guides/types.ts
+++ b/src/core/guides/types.ts
@@ -65,3 +65,14 @@ export interface ElementMeta {
   devicePixelRatio: number;
   clickPoint?: { x: number; y: number };
 }
+
+export interface Snapshot {
+  id: string;
+  guideId: string;
+  createdAt: number;
+  contentHash: string;
+  title: string;
+  stepIds: string[];
+  steps: Step[];
+  screenshots: Omit<Screenshot, 'blob'>[];
+}

--- a/src/core/screenshot/geometry.ts
+++ b/src/core/screenshot/geometry.ts
@@ -194,7 +194,9 @@ export function resizeAnnotation(a: Annotation, handle: Handle, dx: number, dy: 
   };
 }
 
-export function resolveTarget(screenshot: Screenshot): ClickTarget | null {
+export type TargetSource = Pick<Screenshot, 'edits' | 'bounds' | 'pixelRatio'>;
+
+export function resolveTarget(screenshot: TargetSource): ClickTarget | null {
   const explicit = screenshot.edits?.target;
   if (explicit !== undefined) return explicit;
 

--- a/src/core/screenshot/render.ts
+++ b/src/core/screenshot/render.ts
@@ -7,6 +7,13 @@ interface RenderOptions {
   quality?: number;
 }
 
+export async function imageDimensions(file: Blob): Promise<{ width: number; height: number }> {
+  const bitmap = await createImageBitmap(file);
+  const { width, height } = bitmap;
+  bitmap.close();
+  return { width, height };
+}
+
 export async function renderScreenshot(screenshot: Screenshot, opts: RenderOptions = {}): Promise<Blob> {
   const { format = 'image/webp', quality = 0.85 } = opts;
   const viewport = resolveViewport(screenshot);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -44,6 +44,12 @@ export function formatDateShort(ts: number): string {
   return d.format('MMM D');
 }
 
+export function formatDateTime(ts: number): string {
+  const locale = getDayjsLocale();
+  const d = locale ? dayjs(ts).locale(locale) : dayjs(ts);
+  return d.format('MMM D, YYYY — h:mm A');
+}
+
 export function formatRelativeTime(ts: number): string {
   const locale = getDayjsLocale();
   return locale ? dayjs(ts).locale(locale).fromNow() : dayjs(ts).fromNow();

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -357,6 +357,7 @@ screenshotView:
   downloadEdited: "Bearbeitetes Bild"
   downloadOriginal: "Originalbild"
   edit: "Bearbeiten"
+  addImage: "Bild hinzufügen"
   replaceImage: "Bild ersetzen"
   replaceHint: "Wähle ein neues Bild für diesen Schritt"
   replaceDrop: "Klicken zum Auswählen oder Bild hierher ziehen"

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -173,6 +173,22 @@ history:
   restoreError: Wiederherstellen hat nicht geklappt. Versuche es gleich noch einmal.
   storageFull: Zu wenig Speicher für einen Rückgängig-Punkt. Lösche eine Anleitung und versuche es erneut.
   empty: Noch keine früheren Versionen. Sie erscheinen hier, sobald du diese Anleitung bearbeitest.
+  nameVersion: Version benennen
+  namePlaceholder: Versionsname
+  allVersions: Alle Versionen
+  namedOnly: Nur benannte Versionen
+  emptyNamed: Noch keine benannten Versionen. Benenne eine, um sie später wiederzufinden.
+  renameError: Name konnte nicht gespeichert werden. Versuche es erneut.
+  changeTitle: Titel geändert
+  changeStepAdded: "$1 Schritt hinzugefügt"
+  changeStepsAdded: "$1 Schritte hinzugefügt"
+  changeStepRemoved: "$1 Schritt gelöscht"
+  changeStepsRemoved: "$1 Schritte gelöscht"
+  changeStepEdited: "$1 Schritt bearbeitet"
+  changeStepsEdited: "$1 Schritte bearbeitet"
+  changeStepReordered: Schritte neu sortiert
+  changeImage: "$1 Bild geändert"
+  changeImages: "$1 Bilder geändert"
 
 emptyGuide:
   title: Diese Anleitung ist leer

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -187,8 +187,17 @@ history:
   changeStepEdited: "$1 Schritt bearbeitet"
   changeStepsEdited: "$1 Schritte bearbeitet"
   changeStepReordered: Schritte neu sortiert
-  changeImage: "$1 Bild geändert"
-  changeImages: "$1 Bilder geändert"
+  changeLink: "$1 Link geändert"
+  changeLinks: "$1 Links geändert"
+  changeImageReplaced: "$1 Bild ersetzt"
+  changeImagesReplaced: "$1 Bilder ersetzt"
+  changeImageCropped: "$1 Bild zugeschnitten"
+  changeImagesCropped: "$1 Bilder zugeschnitten"
+  changeImageAnnotated: "$1 Bild kommentiert"
+  changeImagesAnnotated: "$1 Bilder kommentiert"
+  changeImageBlurred: "$1 Bild unkenntlich gemacht"
+  changeImagesBlurred: "$1 Bilder unkenntlich gemacht"
+  changeAltText: Alternativtext bearbeitet
 
 emptyGuide:
   title: Diese Anleitung ist leer

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -158,6 +158,21 @@ editor:
   deleteThisStep: "Diesen Schritt löschen?"
   copyScreenshot: Screenshot kopieren
   noScreenshot: Kein Screenshot
+  edit: Bearbeiten
+  done: Fertig
+  versionHistory: Versionsverlauf
+  moreActions: Weitere Aktionen
+
+history:
+  title: Versionsverlauf
+  current: Aktuell
+  restore: Wiederherstellen
+  unchangedVersions: "Unveränderte Versionen ($1)"
+  readOnlyBanner: "Du siehst eine frühere Version. Schließe den Versionsverlauf, um zur aktuellen Anleitung zurückzukehren."
+  loadError: Versionsverlauf konnte nicht geladen werden. Versuche es erneut.
+  restoreError: Wiederherstellen hat nicht geklappt. Versuche es gleich noch einmal.
+  storageFull: Zu wenig Speicher für einen Rückgängig-Punkt. Lösche eine Anleitung und versuche es erneut.
+  empty: Noch keine früheren Versionen. Sie erscheinen hier, sobald du diese Anleitung bearbeitest.
 
 emptyGuide:
   title: Diese Anleitung ist leer

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -173,6 +173,22 @@ history:
   restoreError: Unable to restore. Try again in a moment.
   storageFull: Not enough storage to save an undo point. Delete a guide and try again.
   empty: No earlier versions yet. They appear here once you edit this guide.
+  nameVersion: Name this version
+  namePlaceholder: Version name
+  allVersions: All versions
+  namedOnly: Named versions only
+  emptyNamed: No named versions yet. Name one to find it again later.
+  renameError: Unable to save that name. Try again.
+  changeTitle: Title changed
+  changeStepAdded: "$1 step added"
+  changeStepsAdded: "$1 steps added"
+  changeStepRemoved: "$1 step deleted"
+  changeStepsRemoved: "$1 steps deleted"
+  changeStepEdited: "$1 step edited"
+  changeStepsEdited: "$1 steps edited"
+  changeStepReordered: Steps reordered
+  changeImage: "$1 image changed"
+  changeImages: "$1 images changed"
 
 emptyGuide:
   title: This guide is empty

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -219,6 +219,7 @@ screenshotView:
   downloadEdited: "Edited image"
   downloadOriginal: "Original image"
   edit: "Edit"
+  addImage: Add image
   replaceImage: Replace image
   replaceHint: "Choose a new image for this step"
   replaceDrop: "Click to browse or drop an image here"

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -187,8 +187,17 @@ history:
   changeStepEdited: "$1 step edited"
   changeStepsEdited: "$1 steps edited"
   changeStepReordered: Steps reordered
-  changeImage: "$1 image changed"
-  changeImages: "$1 images changed"
+  changeLink: "$1 link changed"
+  changeLinks: "$1 links changed"
+  changeImageReplaced: "$1 image replaced"
+  changeImagesReplaced: "$1 images replaced"
+  changeImageCropped: "$1 image cropped"
+  changeImagesCropped: "$1 images cropped"
+  changeImageAnnotated: "$1 image annotated"
+  changeImagesAnnotated: "$1 images annotated"
+  changeImageBlurred: "$1 image blurred"
+  changeImagesBlurred: "$1 images blurred"
+  changeAltText: Alt text edited
 
 emptyGuide:
   title: This guide is empty

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -158,6 +158,21 @@ editor:
   deleteThisStep: "Delete this step?"
   copyScreenshot: Copy screenshot
   noScreenshot: No screenshot
+  edit: Edit
+  done: Done
+  versionHistory: Version history
+  moreActions: More actions
+
+history:
+  title: Version History
+  current: Current
+  restore: Restore
+  unchangedVersions: "Unchanged versions ($1)"
+  readOnlyBanner: "You're viewing an earlier version. Close Version History to return to the current guide."
+  loadError: Unable to load version history. Try again.
+  restoreError: Unable to restore. Try again in a moment.
+  storageFull: Not enough storage to save an undo point. Delete a guide and try again.
+  empty: No earlier versions yet. They appear here once you edit this guide.
 
 emptyGuide:
   title: This guide is empty

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -158,6 +158,21 @@ editor:
   deleteThisStep: "¿Eliminar este paso?"
   copyScreenshot: Copiar captura
   noScreenshot: Sin captura
+  edit: Editar
+  done: Listo
+  versionHistory: Historial de versiones
+  moreActions: Más acciones
+
+history:
+  title: Historial de versiones
+  current: Actual
+  restore: Restaurar
+  unchangedVersions: "Versiones sin cambios ($1)"
+  readOnlyBanner: "Estás viendo una versión anterior. Cierra el historial de versiones para volver a la guía actual."
+  loadError: No se pudo cargar el historial de versiones. Inténtalo de nuevo.
+  restoreError: No se pudo restaurar. Inténtalo de nuevo en un momento.
+  storageFull: No hay espacio para guardar un punto de deshacer. Elimina una guía e inténtalo de nuevo.
+  empty: Todavía no hay versiones anteriores. Aparecerán aquí cuando edites esta guía.
 
 emptyGuide:
   title: Esta guía está vacía

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -173,6 +173,22 @@ history:
   restoreError: No se pudo restaurar. Inténtalo de nuevo en un momento.
   storageFull: No hay espacio para guardar un punto de deshacer. Elimina una guía e inténtalo de nuevo.
   empty: Todavía no hay versiones anteriores. Aparecerán aquí cuando edites esta guía.
+  nameVersion: Ponle nombre a esta versión
+  namePlaceholder: Nombre de la versión
+  allVersions: Todas las versiones
+  namedOnly: Solo versiones con nombre
+  emptyNamed: Todavía no hay versiones con nombre. Ponle nombre a una para encontrarla después.
+  renameError: No se pudo guardar el nombre. Inténtalo de nuevo.
+  changeTitle: Título cambiado
+  changeStepAdded: "$1 paso añadido"
+  changeStepsAdded: "$1 pasos añadidos"
+  changeStepRemoved: "$1 paso eliminado"
+  changeStepsRemoved: "$1 pasos eliminados"
+  changeStepEdited: "$1 paso editado"
+  changeStepsEdited: "$1 pasos editados"
+  changeStepReordered: Pasos reordenados
+  changeImage: "$1 imagen cambiada"
+  changeImages: "$1 imágenes cambiadas"
 
 emptyGuide:
   title: Esta guía está vacía

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -219,6 +219,7 @@ screenshotView:
   downloadEdited: "Imagen editada"
   downloadOriginal: "Imagen original"
   edit: "Editar"
+  addImage: Añadir imagen
   replaceImage: Reemplazar imagen
   replaceHint: "Elige una nueva imagen para este paso"
   replaceDrop: "Haz clic para buscar o suelta una imagen aquí"

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -187,8 +187,17 @@ history:
   changeStepEdited: "$1 paso editado"
   changeStepsEdited: "$1 pasos editados"
   changeStepReordered: Pasos reordenados
-  changeImage: "$1 imagen cambiada"
-  changeImages: "$1 imágenes cambiadas"
+  changeLink: "$1 enlace cambiado"
+  changeLinks: "$1 enlaces cambiados"
+  changeImageReplaced: "$1 imagen reemplazada"
+  changeImagesReplaced: "$1 imágenes reemplazadas"
+  changeImageCropped: "$1 imagen recortada"
+  changeImagesCropped: "$1 imágenes recortadas"
+  changeImageAnnotated: "$1 imagen anotada"
+  changeImagesAnnotated: "$1 imágenes anotadas"
+  changeImageBlurred: "$1 imagen desenfocada"
+  changeImagesBlurred: "$1 imágenes desenfocadas"
+  changeAltText: Texto alternativo editado
 
 emptyGuide:
   title: Esta guía está vacía

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -173,6 +173,22 @@ history:
   restoreError: Impossible de restaurer. Réessayez dans un instant.
   storageFull: "Espace insuffisant pour enregistrer un point d'annulation. Supprimez un guide et réessayez."
   empty: Pas encore de version antérieure. Elles apparaîtront ici dès que vous modifierez ce guide.
+  nameVersion: Nommer cette version
+  namePlaceholder: Nom de la version
+  allVersions: Toutes les versions
+  namedOnly: Versions nommées uniquement
+  emptyNamed: "Aucune version nommée pour l'instant. Nommez-en une pour la retrouver plus tard."
+  renameError: "Impossible d'enregistrer ce nom. Réessayez."
+  changeTitle: Titre modifié
+  changeStepAdded: "$1 étape ajoutée"
+  changeStepsAdded: "$1 étapes ajoutées"
+  changeStepRemoved: "$1 étape supprimée"
+  changeStepsRemoved: "$1 étapes supprimées"
+  changeStepEdited: "$1 étape modifiée"
+  changeStepsEdited: "$1 étapes modifiées"
+  changeStepReordered: Étapes réordonnées
+  changeImage: "$1 image modifiée"
+  changeImages: "$1 images modifiées"
 
 emptyGuide:
   title: Ce guide est vide

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -219,6 +219,7 @@ screenshotView:
   downloadEdited: "Image modifiée"
   downloadOriginal: "Image originale"
   edit: "Modifier"
+  addImage: "Ajouter une image"
   replaceImage: "Remplacer l'image"
   replaceHint: "Choisissez une nouvelle image pour cette étape"
   replaceDrop: "Cliquez pour parcourir ou déposez une image ici"

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -187,8 +187,17 @@ history:
   changeStepEdited: "$1 étape modifiée"
   changeStepsEdited: "$1 étapes modifiées"
   changeStepReordered: Étapes réordonnées
-  changeImage: "$1 image modifiée"
-  changeImages: "$1 images modifiées"
+  changeLink: "$1 lien modifié"
+  changeLinks: "$1 liens modifiés"
+  changeImageReplaced: "$1 image remplacée"
+  changeImagesReplaced: "$1 images remplacées"
+  changeImageCropped: "$1 image recadrée"
+  changeImagesCropped: "$1 images recadrées"
+  changeImageAnnotated: "$1 image annotée"
+  changeImagesAnnotated: "$1 images annotées"
+  changeImageBlurred: "$1 image floutée"
+  changeImagesBlurred: "$1 images floutées"
+  changeAltText: Texte alternatif modifié
 
 emptyGuide:
   title: Ce guide est vide

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -158,6 +158,21 @@ editor:
   deleteThisStep: "Supprimer cette étape ?"
   copyScreenshot: "Copier la capture"
   noScreenshot: "Pas de capture"
+  edit: Modifier
+  done: Terminé
+  versionHistory: Historique des versions
+  moreActions: "Plus d'actions"
+
+history:
+  title: Historique des versions
+  current: Actuelle
+  restore: Restaurer
+  unchangedVersions: "Versions inchangées ($1)"
+  readOnlyBanner: "Vous consultez une version antérieure. Fermez l'historique des versions pour revenir au guide actuel."
+  loadError: "Impossible de charger l'historique des versions. Réessayez."
+  restoreError: Impossible de restaurer. Réessayez dans un instant.
+  storageFull: "Espace insuffisant pour enregistrer un point d'annulation. Supprimez un guide et réessayez."
+  empty: Pas encore de version antérieure. Elles apparaîtront ici dès que vous modifierez ce guide.
 
 emptyGuide:
   title: Ce guide est vide

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -187,8 +187,17 @@ history:
   changeStepEdited: "$1 passo editado"
   changeStepsEdited: "$1 passos editados"
   changeStepReordered: Passos reordenados
-  changeImage: "$1 imagem alterada"
-  changeImages: "$1 imagens alteradas"
+  changeLink: "$1 link alterado"
+  changeLinks: "$1 links alterados"
+  changeImageReplaced: "$1 imagem substituída"
+  changeImagesReplaced: "$1 imagens substituídas"
+  changeImageCropped: "$1 imagem recortada"
+  changeImagesCropped: "$1 imagens recortadas"
+  changeImageAnnotated: "$1 imagem anotada"
+  changeImagesAnnotated: "$1 imagens anotadas"
+  changeImageBlurred: "$1 imagem desfocada"
+  changeImagesBlurred: "$1 imagens desfocadas"
+  changeAltText: Texto alternativo editado
 
 emptyGuide:
   title: Esse guia tá vazio

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -158,6 +158,21 @@ editor:
   deleteThisStep: "Excluir esse passo?"
   copyScreenshot: Copiar captura
   noScreenshot: Sem captura
+  edit: Editar
+  done: Pronto
+  versionHistory: Histórico de versões
+  moreActions: Mais ações
+
+history:
+  title: Histórico de versões
+  current: Atual
+  restore: Restaurar
+  unchangedVersions: "Versões sem alterações ($1)"
+  readOnlyBanner: "Você tá vendo uma versão anterior. Fecha o histórico de versões pra voltar pro guia atual."
+  loadError: Não deu pra carregar o histórico de versões. Tenta de novo.
+  restoreError: Não deu pra restaurar. Tenta de novo num instante.
+  storageFull: Sem espaço pra salvar um ponto de desfazer. Exclui um guia e tenta de novo.
+  empty: Nenhuma versão anterior ainda. Elas aparecem aqui quando você editar esse guia.
 
 emptyGuide:
   title: Esse guia tá vazio

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -173,6 +173,22 @@ history:
   restoreError: Não deu pra restaurar. Tenta de novo num instante.
   storageFull: Sem espaço pra salvar um ponto de desfazer. Exclui um guia e tenta de novo.
   empty: Nenhuma versão anterior ainda. Elas aparecem aqui quando você editar esse guia.
+  nameVersion: Dar um nome pra essa versão
+  namePlaceholder: Nome da versão
+  allVersions: Todas as versões
+  namedOnly: Só versões com nome
+  emptyNamed: Nenhuma versão com nome ainda. Dá um nome pra uma e acha ela fácil depois.
+  renameError: Não deu pra salvar o nome. Tenta de novo.
+  changeTitle: Título alterado
+  changeStepAdded: "$1 passo adicionado"
+  changeStepsAdded: "$1 passos adicionados"
+  changeStepRemoved: "$1 passo excluído"
+  changeStepsRemoved: "$1 passos excluídos"
+  changeStepEdited: "$1 passo editado"
+  changeStepsEdited: "$1 passos editados"
+  changeStepReordered: Passos reordenados
+  changeImage: "$1 imagem alterada"
+  changeImages: "$1 imagens alteradas"
 
 emptyGuide:
   title: Esse guia tá vazio

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -219,6 +219,7 @@ screenshotView:
   downloadEdited: "Imagem editada"
   downloadOriginal: "Imagem original"
   edit: "Editar"
+  addImage: Adicionar imagem
   replaceImage: Substituir imagem
   replaceHint: "Escolha uma nova imagem para esta etapa"
   replaceDrop: "Clique para procurar ou solte uma imagem aqui"

--- a/src/stores/fullview.ts
+++ b/src/stores/fullview.ts
@@ -34,6 +34,18 @@ interface FullviewStore {
   scrollToStep: (stepId: string) => void;
   activeStepId: string | null;
   setActiveStepId: (id: string | null) => void;
+
+  editing: boolean;
+  setEditing: (editing: boolean) => void;
+  historyOpen: boolean;
+  setHistoryOpen: (open: boolean) => void;
+  historyRefreshKey: number;
+  bumpHistoryRefresh: () => void;
+}
+
+function flushFocusedField() {
+  const el = document.activeElement;
+  if (el instanceof HTMLTextAreaElement || el instanceof HTMLInputElement) el.blur();
 }
 
 export const useFullviewStore = create<FullviewStore>((set) => ({
@@ -56,7 +68,12 @@ export const useFullviewStore = create<FullviewStore>((set) => ({
   guideStepCount: 0,
   setGuideStepCount: (guideStepCount) => set({ guideStepCount }),
   guideExportData: null,
-  setGuideExportData: (guideExportData) => set({ guideExportData }),
+  setGuideExportData: (guideExportData) =>
+    set((s) =>
+      s.guideExportData?.guideId === guideExportData?.guideId
+        ? { guideExportData }
+        : { guideExportData, editing: false, historyOpen: false, historyRefreshKey: 0 },
+    ),
   scrollToStepId: null,
   scrollToStep: (stepId) => {
     set({ scrollToStepId: stepId });
@@ -64,6 +81,19 @@ export const useFullviewStore = create<FullviewStore>((set) => ({
   },
   activeStepId: null,
   setActiveStepId: (activeStepId) => set({ activeStepId }),
+
+  editing: false,
+  setEditing: (editing) => {
+    if (!editing) flushFocusedField();
+    set({ editing });
+  },
+  historyOpen: false,
+  setHistoryOpen: (historyOpen) => {
+    if (historyOpen) flushFocusedField();
+    set({ historyOpen });
+  },
+  historyRefreshKey: 0,
+  bumpHistoryRefresh: () => set((s) => ({ historyRefreshKey: s.historyRefreshKey + 1 })),
 }));
 
 export function useFullview<T>(selector: (s: FullviewStore) => T): T {

--- a/src/ui/fullview/App.tsx
+++ b/src/ui/fullview/App.tsx
@@ -38,12 +38,7 @@ export default function FullViewApp() {
       {route.page === 'guide' && (
         <main className="flex-1 py-10 px-6">
           <div className={`mx-auto ${historyOpen ? 'max-w-[1032px]' : 'max-w-[720px]'}`}>
-            <GuideContent
-              guideId={route.guideId}
-              initialStepId={route.stepId}
-              initialTool={route.tool}
-              initialHistory={route.history}
-            />
+            <GuideContent guideId={route.guideId} initialStepId={route.stepId} initialTool={route.tool} />
           </div>
         </main>
       )}

--- a/src/ui/fullview/App.tsx
+++ b/src/ui/fullview/App.tsx
@@ -8,7 +8,10 @@ import TopNav from './TopNav';
 
 export default function FullViewApp() {
   const route = useRoute();
-  const { toggleSearch } = useFullview((s) => ({ toggleSearch: s.toggleSearch }));
+  const { toggleSearch, historyOpen } = useFullview((s) => ({
+    toggleSearch: s.toggleSearch,
+    historyOpen: s.historyOpen,
+  }));
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -34,7 +37,7 @@ export default function FullViewApp() {
 
       {route.page === 'guide' && (
         <main className="flex-1 py-10 px-6">
-          <div className="max-w-[720px] mx-auto">
+          <div className={`mx-auto ${historyOpen ? 'max-w-[1032px]' : 'max-w-[720px]'}`}>
             <GuideContent guideId={route.guideId} initialStepId={route.stepId} initialTool={route.tool} />
           </div>
         </main>

--- a/src/ui/fullview/App.tsx
+++ b/src/ui/fullview/App.tsx
@@ -38,7 +38,12 @@ export default function FullViewApp() {
       {route.page === 'guide' && (
         <main className="flex-1 py-10 px-6">
           <div className={`mx-auto ${historyOpen ? 'max-w-[1032px]' : 'max-w-[720px]'}`}>
-            <GuideContent guideId={route.guideId} initialStepId={route.stepId} initialTool={route.tool} />
+            <GuideContent
+              guideId={route.guideId}
+              initialStepId={route.stepId}
+              initialTool={route.tool}
+              initialHistory={route.history}
+            />
           </div>
         </main>
       )}

--- a/src/ui/fullview/GuideContent.tsx
+++ b/src/ui/fullview/GuideContent.tsx
@@ -26,6 +26,7 @@ interface GuideContentProps {
   guideId: string;
   initialStepId?: string;
   initialTool?: 'annotate' | 'redact' | 'crop' | 'target';
+  initialHistory?: boolean;
 }
 
 interface GuideData {
@@ -55,7 +56,7 @@ async function buildPreview(snapshot: Snapshot): Promise<PreviewData> {
   return { snapshotId: snapshot.id, steps, screenshots };
 }
 
-export default function GuideContent({ guideId, initialStepId, initialTool }: GuideContentProps) {
+export default function GuideContent({ guideId, initialStepId, initialTool, initialHistory }: GuideContentProps) {
   const {
     setGuideTitle,
     setGuideStepCount,
@@ -86,6 +87,7 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
   const [previewData, setPreviewData] = useState<PreviewData | null>(null);
   const titleRef = useRef('');
   const appliedInitialRef = useRef(false);
+  const appliedHistoryRef = useRef(false);
 
   const loadGuide = useCallback(async () => {
     const result = await getGuide(guideId);
@@ -194,6 +196,12 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
       setEditingTool(initialTool);
     }
   }, [data, initialStepId, initialTool, scrollToStep]);
+
+  useEffect(() => {
+    if (appliedHistoryRef.current || !data || !initialHistory) return;
+    appliedHistoryRef.current = true;
+    setHistoryOpen(true);
+  }, [data, initialHistory, setHistoryOpen]);
 
   if (loading)
     return (

--- a/src/ui/fullview/GuideContent.tsx
+++ b/src/ui/fullview/GuideContent.tsx
@@ -1,5 +1,5 @@
 import { History, Play } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { TypeAnimation } from 'react-type-animation';
 import { i18n } from '#imports';
 import {
@@ -10,6 +10,7 @@ import {
   updateGuideTitle,
   updateStepDescription,
 } from '@/core/guides/service';
+import type { SnapshotLike } from '@/core/guides/snapshot-diff';
 import type { Guide, Screenshot, Snapshot, Step } from '@/core/guides/types';
 import type { ScreenshotEdits } from '@/core/screenshot/types';
 import { openSidebar } from '@/lib/browser-api';
@@ -203,6 +204,16 @@ export default function GuideContent({ guideId, initialStepId, initialTool, init
     setHistoryOpen(true);
   }, [data, initialHistory, setHistoryOpen]);
 
+  const live = useMemo<SnapshotLike>(
+    () => ({
+      title: data?.guide.title ?? '',
+      stepIds: data?.guide.stepIds ?? [],
+      steps: data?.steps ?? [],
+      screenshots: data ? [...data.screenshots.values()] : [],
+    }),
+    [data],
+  );
+
   if (loading)
     return (
       <div>
@@ -355,6 +366,7 @@ export default function GuideContent({ guideId, initialStepId, initialTool, init
             guideId={guideId}
             selectedId={preview?.id ?? null}
             refreshKey={historyRefreshKey}
+            live={live}
             onSelect={setPreview}
             onRestored={loadGuide}
             onClose={() => {

--- a/src/ui/fullview/GuideContent.tsx
+++ b/src/ui/fullview/GuideContent.tsx
@@ -27,7 +27,6 @@ interface GuideContentProps {
   guideId: string;
   initialStepId?: string;
   initialTool?: 'annotate' | 'redact' | 'crop' | 'target';
-  initialHistory?: boolean;
 }
 
 interface GuideData {
@@ -57,7 +56,7 @@ async function buildPreview(snapshot: Snapshot): Promise<PreviewData> {
   return { snapshotId: snapshot.id, steps, screenshots };
 }
 
-export default function GuideContent({ guideId, initialStepId, initialTool, initialHistory }: GuideContentProps) {
+export default function GuideContent({ guideId, initialStepId, initialTool }: GuideContentProps) {
   const {
     setGuideTitle,
     setGuideStepCount,
@@ -88,7 +87,6 @@ export default function GuideContent({ guideId, initialStepId, initialTool, init
   const [previewData, setPreviewData] = useState<PreviewData | null>(null);
   const titleRef = useRef('');
   const appliedInitialRef = useRef(false);
-  const appliedHistoryRef = useRef(false);
 
   const loadGuide = useCallback(async () => {
     const result = await getGuide(guideId);
@@ -197,12 +195,6 @@ export default function GuideContent({ guideId, initialStepId, initialTool, init
       setEditingTool(initialTool);
     }
   }, [data, initialStepId, initialTool, scrollToStep]);
-
-  useEffect(() => {
-    if (appliedHistoryRef.current || !data || !initialHistory) return;
-    appliedHistoryRef.current = true;
-    setHistoryOpen(true);
-  }, [data, initialHistory, setHistoryOpen]);
 
   const live = useMemo<SnapshotLike>(
     () => ({

--- a/src/ui/fullview/GuideContent.tsx
+++ b/src/ui/fullview/GuideContent.tsx
@@ -326,7 +326,7 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
                 {domain}
               </span>
             )}
-            {!preview && viewSteps.length > 0 && (
+            {!editing && !preview && viewSteps.length > 0 && (
               <button
                 onClick={() => {
                   openSidebar();

--- a/src/ui/fullview/GuideContent.tsx
+++ b/src/ui/fullview/GuideContent.tsx
@@ -350,6 +350,7 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
             onOpenEditor={handleOpenEditor}
             onReorder={(newSteps) => setData((prev) => (prev ? { ...prev, steps: newSteps } : prev))}
             readOnly={!editing || preview !== null}
+            onChanged={loadGuide}
           />
         </div>
 

--- a/src/ui/fullview/GuideContent.tsx
+++ b/src/ui/fullview/GuideContent.tsx
@@ -1,17 +1,26 @@
-import { Play } from 'lucide-react';
+import { History, Play } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { TypeAnimation } from 'react-type-animation';
 import { i18n } from '#imports';
-import { deleteStep, getGuide, onGuidesChanged, updateGuideTitle, updateStepDescription } from '@/core/guides/service';
-import type { Guide, Screenshot, Step } from '@/core/guides/types';
+import {
+  deleteStep,
+  getGuide,
+  getScreenshotsForSteps,
+  onGuidesChanged,
+  updateGuideTitle,
+  updateStepDescription,
+} from '@/core/guides/service';
+import type { Guide, Screenshot, Snapshot, Step } from '@/core/guides/types';
 import type { ScreenshotEdits } from '@/core/screenshot/types';
 import { openSidebar } from '@/lib/browser-api';
+import { logger } from '@/lib/logger';
 import { sendMessage } from '@/lib/messaging';
 import { formatDate, getMostCommonDomain } from '@/lib/utils';
 import { useFullview } from '@/stores/fullview';
 import AnnotationEditor from '@/ui/shared/AnnotationEditor';
 import FaviconImg from '@/ui/shared/FaviconImg';
 import GuideStepList from './components/GuideStepList';
+import VersionHistoryPanel from './components/VersionHistoryPanel';
 
 interface GuideContentProps {
   guideId: string;
@@ -25,12 +34,46 @@ interface GuideData {
   screenshots: Map<string, Screenshot>;
 }
 
+interface PreviewData {
+  snapshotId: string;
+  steps: Step[];
+  screenshots: Map<string, Screenshot>;
+}
+
+async function buildPreview(snapshot: Snapshot): Promise<PreviewData> {
+  const rows = new Map(snapshot.screenshots.map((row) => [row.id, row]));
+  const steps = [...snapshot.steps].sort((a, b) => a.index - b.index);
+  const wanted = steps.map((s) => s.screenshotId).filter((id): id is string => !!id && rows.has(id));
+  const live = await getScreenshotsForSteps(wanted);
+  const blobs = new Map([...live.values()].map((row) => [row.id, row.blob]));
+  const screenshots = new Map<string, Screenshot>();
+  for (const step of steps) {
+    const row = step.screenshotId ? rows.get(step.screenshotId) : undefined;
+    const blob = row ? blobs.get(row.id) : undefined;
+    if (row && blob) screenshots.set(step.id, { ...row, blob });
+  }
+  return { snapshotId: snapshot.id, steps, screenshots };
+}
+
 export default function GuideContent({ guideId, initialStepId, initialTool }: GuideContentProps) {
-  const { setGuideTitle, setGuideStepCount, setGuideExportData, scrollToStep } = useFullview((s) => ({
+  const {
+    setGuideTitle,
+    setGuideStepCount,
+    setGuideExportData,
+    scrollToStep,
+    editing,
+    historyOpen,
+    setHistoryOpen,
+    historyRefreshKey,
+  } = useFullview((s) => ({
     setGuideTitle: s.setGuideTitle,
     setGuideStepCount: s.setGuideStepCount,
     setGuideExportData: s.setGuideExportData,
     scrollToStep: s.scrollToStep,
+    editing: s.editing,
+    historyOpen: s.historyOpen,
+    setHistoryOpen: s.setHistoryOpen,
+    historyRefreshKey: s.historyRefreshKey,
   }));
 
   const [data, setData] = useState<GuideData | null>(null);
@@ -39,6 +82,8 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
   const [typingTitle, setTypingTitle] = useState<string | null>(null);
   const [editingStepId, setEditingStepId] = useState<string | null>(null);
   const [editingTool, setEditingTool] = useState<'annotate' | 'redact' | 'crop' | 'target'>('annotate');
+  const [preview, setPreview] = useState<Snapshot | null>(null);
+  const [previewData, setPreviewData] = useState<PreviewData | null>(null);
   const titleRef = useRef('');
   const appliedInitialRef = useRef(false);
 
@@ -120,6 +165,26 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
   );
 
   useEffect(() => {
+    if (!preview) {
+      setPreviewData(null);
+      return;
+    }
+    let cancelled = false;
+    buildPreview(preview)
+      .then((built) => {
+        if (!cancelled) setPreviewData(built);
+      })
+      .catch((err) => logger.error(' Version preview failed', err));
+    return () => {
+      cancelled = true;
+    };
+  }, [preview]);
+
+  useEffect(() => {
+    if (editing) setPreview(null);
+  }, [editing]);
+
+  useEffect(() => {
     if (appliedInitialRef.current || !data || !initialStepId) return;
     if (!data.screenshots.has(initialStepId)) return;
     appliedInitialRef.current = true;
@@ -153,8 +218,14 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
     );
   if (!data) return <p className="text-sm py-12 text-center text-purple">{i18n.t('fullview_guideNotFound')}</p>;
 
-  const domain = getMostCommonDomain(data.steps);
+  const previewView = preview && previewData?.snapshotId === preview.id ? previewData : null;
+  const viewSteps = previewView ? previewView.steps : data.steps;
+  const viewScreenshots = previewView ? previewView.screenshots : data.screenshots;
+  const domain = getMostCommonDomain(viewSteps);
   const editingScreenshot = editingStepId ? data.screenshots.get(editingStepId) : undefined;
+  const animatingTitle = preview ? null : typingTitle;
+  const untitledPending =
+    !preview && !typingTitle && title === i18n.t('fullview_untitledGuide') && viewSteps.length > 0;
 
   return (
     <div className="flex flex-col min-h-[calc(100vh-64px)]">
@@ -167,98 +238,124 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
         />
       )}
 
-      <div
-        className={
-          title === i18n.t('fullview_untitledGuide') && !typingTitle && data.steps.length > 0 ? 'min-h-[88px]' : ''
-        }
-      >
-        {title === i18n.t('fullview_untitledGuide') && !typingTitle && data.steps.length > 0 ? (
-          <div className="text-[32px] font-extrabold leading-tight animate-gradient-text bg-[length:300%_100%] bg-clip-text text-transparent bg-gradient-to-r from-muted-foreground via-violet to-muted-foreground max-w-[480px]">
-            {i18n.t('fullview_writingTitle')}
-          </div>
-        ) : typingTitle ? (
-          <div className="relative text-[32px] font-extrabold leading-tight">
-            <div className="invisible" aria-hidden="true">
-              {typingTitle}
+      <div className={historyOpen ? 'flex items-start gap-6' : ''}>
+        <div className={historyOpen ? 'flex-1 min-w-0' : ''}>
+          {preview && (
+            <div className="flex items-center gap-2 rounded-lg bg-secondary border border-border px-4 py-3 mb-4">
+              <History size={15} className="text-accent shrink-0" />
+              <span className="text-[12px] text-foreground">{i18n.t('history.readOnlyBanner')}</span>
             </div>
-            <div className="absolute inset-0 text-foreground">
-              <TypeAnimation
-                sequence={[
-                  typingTitle,
-                  () => {
-                    titleRef.current = typingTitle;
-                    setTitle(typingTitle);
-                    setTypingTitle(null);
-                  },
-                ]}
-                speed={70}
-                cursor={false}
+          )}
+
+          <div className={untitledPending ? 'min-h-[88px]' : ''}>
+            {untitledPending ? (
+              <div className="text-[32px] font-extrabold leading-tight animate-gradient-text bg-[length:300%_100%] bg-clip-text text-transparent bg-gradient-to-r from-muted-foreground via-violet to-muted-foreground max-w-[480px]">
+                {i18n.t('fullview_writingTitle')}
+              </div>
+            ) : animatingTitle ? (
+              <div className="relative text-[32px] font-extrabold leading-tight">
+                <div className="invisible" aria-hidden="true">
+                  {animatingTitle}
+                </div>
+                <div className="absolute inset-0 text-foreground">
+                  <TypeAnimation
+                    sequence={[
+                      animatingTitle,
+                      () => {
+                        titleRef.current = animatingTitle;
+                        setTitle(animatingTitle);
+                        setTypingTitle(null);
+                      },
+                    ]}
+                    speed={70}
+                    cursor={false}
+                  />
+                  <span className="inline-block w-[3px] h-[30px] bg-violet ml-0.5 align-text-bottom animate-blink" />
+                </div>
+              </div>
+            ) : editing && !preview ? (
+              <textarea
+                ref={(el) => {
+                  if (el) {
+                    el.style.height = '0';
+                    el.style.height = `${el.scrollHeight}px`;
+                  }
+                }}
+                value={title}
+                rows={1}
+                onChange={(e) => {
+                  setTitle(e.target.value);
+                  setGuideTitle(e.target.value);
+                  const el = e.target;
+                  el.style.height = '0';
+                  el.style.height = `${el.scrollHeight}px`;
+                }}
+                onBlur={handleTitleBlur}
+                className="text-[32px] font-extrabold bg-transparent border-b-2 border-transparent hover:border-border focus:outline-none focus:border-accent w-full p-0 text-foreground resize-none leading-tight overflow-hidden"
               />
-              <span className="inline-block w-[3px] h-[30px] bg-violet ml-0.5 align-text-bottom animate-blink" />
-            </div>
+            ) : (
+              <h1 className="text-[32px] font-extrabold leading-tight text-foreground whitespace-pre-wrap break-words">
+                {preview ? preview.title : title}
+              </h1>
+            )}
           </div>
-        ) : (
-          <textarea
-            ref={(el) => {
-              if (el) {
-                el.style.height = '0';
-                el.style.height = `${el.scrollHeight}px`;
-              }
+
+          <div className="flex items-center gap-1.5 mt-2 mb-4 flex-wrap">
+            <span className="inline-flex items-center text-[11px] font-medium text-muted-foreground bg-card border border-border px-2.5 py-0.5 rounded-full">
+              {formatDate(data.guide.createdAt)}
+            </span>
+            <span className="inline-flex items-center text-[11px] font-medium text-muted-foreground bg-card border border-border px-2.5 py-0.5 rounded-full">
+              {viewSteps.length !== 1
+                ? i18n.t('fullview_stepCountPlural', [String(viewSteps.length)])
+                : i18n.t('fullview_stepCount', [String(viewSteps.length)])}
+            </span>
+            {domain && (
+              <span className="inline-flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground bg-card border border-border pl-1.5 pr-2.5 py-0.5 rounded-full">
+                <FaviconImg domain={domain} size={14} className="rounded-full" />
+                {domain}
+              </span>
+            )}
+            {!preview && viewSteps.length > 0 && (
+              <button
+                onClick={() => {
+                  openSidebar();
+                  void sendMessage('startGuideMe', { guideId });
+                }}
+                disabled={!viewSteps.some((s) => s.elementMeta)}
+                className="inline-flex items-center gap-1.5 text-[11px] font-semibold text-primary-foreground bg-primary hover:bg-primary/90 px-3 py-0.5 rounded-full transition-colors disabled:opacity-30 disabled:cursor-not-allowed ml-auto"
+              >
+                <Play size={11} />
+                {i18n.t('fullview_guideMe')}
+              </button>
+            )}
+          </div>
+
+          <GuideStepList
+            guideId={guideId}
+            steps={viewSteps}
+            screenshots={viewScreenshots}
+            onDescriptionChange={handleDescriptionChange}
+            onDelete={handleDeleteStep}
+            onOpenEditor={handleOpenEditor}
+            onReorder={(newSteps) => setData((prev) => (prev ? { ...prev, steps: newSteps } : prev))}
+            readOnly={!editing || preview !== null}
+          />
+        </div>
+
+        {historyOpen && (
+          <VersionHistoryPanel
+            guideId={guideId}
+            selectedId={preview?.id ?? null}
+            refreshKey={historyRefreshKey}
+            onSelect={setPreview}
+            onRestored={loadGuide}
+            onClose={() => {
+              setHistoryOpen(false);
+              setPreview(null);
             }}
-            value={title}
-            rows={1}
-            onChange={(e) => {
-              setTitle(e.target.value);
-              setGuideTitle(e.target.value);
-              const el = e.target;
-              el.style.height = '0';
-              el.style.height = `${el.scrollHeight}px`;
-            }}
-            onBlur={handleTitleBlur}
-            className="text-[32px] font-extrabold bg-transparent border-b-2 border-transparent hover:border-border focus:outline-none focus:border-accent w-full p-0 text-foreground resize-none leading-tight overflow-hidden"
           />
         )}
       </div>
-
-      <div className="flex items-center gap-1.5 mt-2 mb-4 flex-wrap">
-        <span className="inline-flex items-center text-[11px] font-medium text-muted-foreground bg-card border border-border px-2.5 py-0.5 rounded-full">
-          {formatDate(data.guide.createdAt)}
-        </span>
-        <span className="inline-flex items-center text-[11px] font-medium text-muted-foreground bg-card border border-border px-2.5 py-0.5 rounded-full">
-          {data.steps.length !== 1
-            ? i18n.t('fullview_stepCountPlural', [String(data.steps.length)])
-            : i18n.t('fullview_stepCount', [String(data.steps.length)])}
-        </span>
-        {domain && (
-          <span className="inline-flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground bg-card border border-border pl-1.5 pr-2.5 py-0.5 rounded-full">
-            <FaviconImg domain={domain} size={14} className="rounded-full" />
-            {domain}
-          </span>
-        )}
-        {data.steps.length > 0 && (
-          <button
-            onClick={() => {
-              openSidebar();
-              void sendMessage('startGuideMe', { guideId });
-            }}
-            disabled={!data.steps.some((s) => s.elementMeta)}
-            className="inline-flex items-center gap-1.5 text-[11px] font-semibold text-primary-foreground bg-primary hover:bg-primary/90 px-3 py-0.5 rounded-full transition-colors disabled:opacity-30 disabled:cursor-not-allowed ml-auto"
-          >
-            <Play size={11} />
-            {i18n.t('fullview_guideMe')}
-          </button>
-        )}
-      </div>
-
-      <GuideStepList
-        guideId={guideId}
-        steps={data.steps}
-        screenshots={data.screenshots}
-        onDescriptionChange={handleDescriptionChange}
-        onDelete={handleDeleteStep}
-        onOpenEditor={handleOpenEditor}
-        onReorder={(newSteps) => setData((prev) => (prev ? { ...prev, steps: newSteps } : prev))}
-      />
     </div>
   );
 }

--- a/src/ui/fullview/GuideContent.tsx
+++ b/src/ui/fullview/GuideContent.tsx
@@ -63,6 +63,7 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
     setGuideExportData,
     scrollToStep,
     editing,
+    setEditing,
     historyOpen,
     setHistoryOpen,
     historyRefreshKey,
@@ -72,6 +73,7 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
     setGuideExportData: s.setGuideExportData,
     scrollToStep: s.scrollToStep,
     editing: s.editing,
+    setEditing: s.setEditing,
     historyOpen: s.historyOpen,
     setHistoryOpen: s.setHistoryOpen,
     historyRefreshKey: s.historyRefreshKey,
@@ -182,8 +184,8 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
   }, [preview]);
 
   useEffect(() => {
-    if (editing) setPreview(null);
-  }, [editing]);
+    if (editing || !historyOpen) setPreview(null);
+  }, [editing, historyOpen]);
 
   useEffect(() => {
     if (appliedInitialRef.current || !data || !initialStepId) return;
@@ -360,12 +362,12 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
             selectedId={preview?.id ?? null}
             refreshKey={historyRefreshKey}
             live={live}
-            onSelect={setPreview}
-            onRestored={loadGuide}
-            onClose={() => {
-              setHistoryOpen(false);
-              setPreview(null);
+            onSelect={(snapshot) => {
+              setPreview(snapshot);
+              if (snapshot) setEditing(false);
             }}
+            onRestored={loadGuide}
+            onClose={() => setHistoryOpen(false)}
           />
         )}
       </div>

--- a/src/ui/fullview/TopNav.tsx
+++ b/src/ui/fullview/TopNav.tsx
@@ -29,6 +29,7 @@ export default function TopNav({ route }: TopNavProps) {
     setSearchOpen,
     editing,
     setEditing,
+    historyOpen,
     setHistoryOpen,
     bumpHistoryRefresh,
   } = useFullview((s) => ({
@@ -39,6 +40,7 @@ export default function TopNav({ route }: TopNavProps) {
     setSearchOpen: s.setSearchOpen,
     editing: s.editing,
     setEditing: s.setEditing,
+    historyOpen: s.historyOpen,
     setHistoryOpen: s.setHistoryOpen,
     bumpHistoryRefresh: s.bumpHistoryRefresh,
   }));
@@ -130,10 +132,7 @@ export default function TopNav({ route }: TopNavProps) {
             <Button
               size="sm"
               variant="secondary"
-              onClick={() => {
-                setHistoryOpen(true);
-                setEditing(false);
-              }}
+              onClick={() => setHistoryOpen(!historyOpen)}
               title={i18n.t('editor.versionHistory')}
             >
               <History size={14} />

--- a/src/ui/fullview/TopNav.tsx
+++ b/src/ui/fullview/TopNav.tsx
@@ -1,27 +1,10 @@
-import {
-  Check,
-  ChevronRight,
-  Download,
-  FileText,
-  History,
-  MoreHorizontal,
-  Pencil,
-  Search,
-  Star,
-  Trash2,
-} from 'lucide-react';
+import { Check, ChevronRight, Download, FileText, History, Pencil, Search, Star, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { i18n } from '#imports';
 import { createSnapshot } from '@/core/guides/service';
 import { logger } from '@/lib/logger';
 import { useFullview } from '@/stores/fullview';
 import { Button } from '@/ui/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/ui/components/ui/dropdown-menu';
 import MascotIcon from '@/ui/shared/MascotIcon';
 import ExportPreviewModal from './ExportPreviewModal';
 import type { Route } from './router';
@@ -144,6 +127,19 @@ export default function TopNav({ route }: TopNavProps) {
               {editing ? <Check size={14} /> : <Pencil size={14} />}
               {editing ? i18n.t('editor.done') : i18n.t('editor.edit')}
             </Button>
+            <Button
+              size="icon-sm"
+              variant="ghost"
+              onClick={() => {
+                setHistoryOpen(true);
+                setEditing(false);
+              }}
+              aria-label={i18n.t('editor.versionHistory')}
+              title={i18n.t('editor.versionHistory')}
+              className="text-foreground hover:bg-foreground/10"
+            >
+              <History size={16} />
+            </Button>
             <Button size="sm" onClick={() => setExportOpen(true)}>
               <Download size={14} />
               {i18n.t('common.export')}
@@ -155,30 +151,6 @@ export default function TopNav({ route }: TopNavProps) {
               steps={exportData.steps}
               screenshots={exportData.screenshots}
             />
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  size="icon-sm"
-                  variant="ghost"
-                  aria-label={i18n.t('editor.moreActions')}
-                  title={i18n.t('editor.moreActions')}
-                  className="text-foreground hover:bg-foreground/10"
-                >
-                  <MoreHorizontal size={16} />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem
-                  onSelect={() => {
-                    setHistoryOpen(true);
-                    setEditing(false);
-                  }}
-                >
-                  <History size={14} />
-                  {i18n.t('editor.versionHistory')}
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
           </>
         )}
       </div>

--- a/src/ui/fullview/TopNav.tsx
+++ b/src/ui/fullview/TopNav.tsx
@@ -128,17 +128,16 @@ export default function TopNav({ route }: TopNavProps) {
               {editing ? i18n.t('editor.done') : i18n.t('editor.edit')}
             </Button>
             <Button
-              size="icon-sm"
-              variant="ghost"
+              size="sm"
+              variant="secondary"
               onClick={() => {
                 setHistoryOpen(true);
                 setEditing(false);
               }}
-              aria-label={i18n.t('editor.versionHistory')}
               title={i18n.t('editor.versionHistory')}
-              className="text-foreground hover:bg-foreground/10"
             >
-              <History size={16} />
+              <History size={14} />
+              {i18n.t('editor.versionHistory')}
             </Button>
             <Button size="sm" onClick={() => setExportOpen(true)}>
               <Download size={14} />

--- a/src/ui/fullview/TopNav.tsx
+++ b/src/ui/fullview/TopNav.tsx
@@ -1,8 +1,27 @@
-import { ChevronRight, Download, FileText, Search, Star, Trash2 } from 'lucide-react';
+import {
+  Check,
+  ChevronRight,
+  Download,
+  FileText,
+  History,
+  MoreHorizontal,
+  Pencil,
+  Search,
+  Star,
+  Trash2,
+} from 'lucide-react';
 import { useState } from 'react';
 import { i18n } from '#imports';
+import { createSnapshot } from '@/core/guides/service';
+import { logger } from '@/lib/logger';
 import { useFullview } from '@/stores/fullview';
 import { Button } from '@/ui/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/ui/components/ui/dropdown-menu';
 import MascotIcon from '@/ui/shared/MascotIcon';
 import ExportPreviewModal from './ExportPreviewModal';
 import type { Route } from './router';
@@ -25,14 +44,35 @@ export default function TopNav({ route }: TopNavProps) {
     guideStepCount,
     guideExportData: exportData,
     setSearchOpen,
+    editing,
+    setEditing,
+    setHistoryOpen,
+    bumpHistoryRefresh,
   } = useFullview((s) => ({
     counts: s.counts,
     guideTitle: s.guideTitle,
     guideStepCount: s.guideStepCount,
     guideExportData: s.guideExportData,
     setSearchOpen: s.setSearchOpen,
+    editing: s.editing,
+    setEditing: s.setEditing,
+    setHistoryOpen: s.setHistoryOpen,
+    bumpHistoryRefresh: s.bumpHistoryRefresh,
   }));
   const [exportOpen, setExportOpen] = useState(false);
+
+  const toggleEditing = (guideId: string) => {
+    if (editing) {
+      setEditing(false);
+      return;
+    }
+    setEditing(true);
+    createSnapshot(guideId)
+      .then((snapshot) => {
+        if (snapshot) bumpHistoryRefresh();
+      })
+      .catch((err) => logger.error(' Snapshot before editing failed', err));
+  };
 
   return (
     <header className="flex items-center gap-5 px-7 h-16 shrink-0 bg-gradient-to-br from-violet to-violet-light">
@@ -100,6 +140,10 @@ export default function TopNav({ route }: TopNavProps) {
         </Button>
         {route.page === 'guide' && exportData && (
           <>
+            <Button size="sm" variant="secondary" onClick={() => toggleEditing(exportData.guideId)}>
+              {editing ? <Check size={14} /> : <Pencil size={14} />}
+              {editing ? i18n.t('editor.done') : i18n.t('editor.edit')}
+            </Button>
             <Button size="sm" onClick={() => setExportOpen(true)}>
               <Download size={14} />
               {i18n.t('common.export')}
@@ -111,6 +155,30 @@ export default function TopNav({ route }: TopNavProps) {
               steps={exportData.steps}
               screenshots={exportData.screenshots}
             />
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  aria-label={i18n.t('editor.moreActions')}
+                  title={i18n.t('editor.moreActions')}
+                  className="text-foreground hover:bg-foreground/10"
+                >
+                  <MoreHorizontal size={16} />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  onSelect={() => {
+                    setHistoryOpen(true);
+                    setEditing(false);
+                  }}
+                >
+                  <History size={14} />
+                  {i18n.t('editor.versionHistory')}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </>
         )}
       </div>

--- a/src/ui/fullview/components/GuideStepList.tsx
+++ b/src/ui/fullview/components/GuideStepList.tsx
@@ -3,7 +3,7 @@ import { reorderSteps } from '@/core/guides/service';
 import type { Screenshot, Step } from '@/core/guides/types';
 import { useFullview } from '@/stores/fullview';
 import EmptyGuideState from '@/ui/shared/EmptyGuideState';
-import { siblingRatio } from '@/ui/shared/ImagePlaceholder';
+import { dominantRatio, siblingRatio } from '@/ui/shared/ImagePlaceholder';
 import StepCard from '@/ui/sidepanel/StepCard';
 
 interface GuideStepListProps {
@@ -38,6 +38,7 @@ export default function GuideStepList({
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
   const stepRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const placeholderRatio = siblingRatio(screenshots);
+  const frameRatio = dominantRatio(screenshots);
 
   useEffect(() => {
     if (scrollToStepId) {
@@ -98,6 +99,7 @@ export default function GuideStepList({
             step={step}
             screenshot={screenshots.get(step.id)}
             placeholderRatio={placeholderRatio}
+            frameRatio={frameRatio}
             onDescriptionChange={onDescriptionChange}
             onDelete={onDelete}
             onOpenEditor={onOpenEditor}

--- a/src/ui/fullview/components/GuideStepList.tsx
+++ b/src/ui/fullview/components/GuideStepList.tsx
@@ -14,6 +14,7 @@ interface GuideStepListProps {
   onDelete: (stepId: string) => void;
   onOpenEditor: (stepId: string, tool: 'annotate' | 'redact' | 'crop' | 'target') => void;
   onReorder: (newSteps: Step[]) => void;
+  readOnly?: boolean;
 }
 
 export default function GuideStepList({
@@ -24,6 +25,7 @@ export default function GuideStepList({
   onDelete,
   onOpenEditor,
   onReorder,
+  readOnly,
 }: GuideStepListProps) {
   const { scrollToStepId, setActiveStepId } = useFullview((s) => ({
     scrollToStepId: s.scrollToStepId,
@@ -97,17 +99,22 @@ export default function GuideStepList({
             onDescriptionChange={onDescriptionChange}
             onDelete={onDelete}
             onOpenEditor={onOpenEditor}
-            dragHandleProps={{
-              onDragStart: (e: React.DragEvent) => {
-                setDragIndex(idx);
-                e.dataTransfer.effectAllowed = 'move';
-              },
-              onDragOver: (e: React.DragEvent) => {
-                e.preventDefault();
-                setDragOverIndex(idx);
-              },
-              onDragEnd: handleDragEnd,
-            }}
+            readOnly={readOnly}
+            dragHandleProps={
+              readOnly
+                ? undefined
+                : {
+                    onDragStart: (e: React.DragEvent) => {
+                      setDragIndex(idx);
+                      e.dataTransfer.effectAllowed = 'move';
+                    },
+                    onDragOver: (e: React.DragEvent) => {
+                      e.preventDefault();
+                      setDragOverIndex(idx);
+                    },
+                    onDragEnd: handleDragEnd,
+                  }
+            }
           />
         </div>
       ))}

--- a/src/ui/fullview/components/GuideStepList.tsx
+++ b/src/ui/fullview/components/GuideStepList.tsx
@@ -3,7 +3,7 @@ import { reorderSteps } from '@/core/guides/service';
 import type { Screenshot, Step } from '@/core/guides/types';
 import { useFullview } from '@/stores/fullview';
 import EmptyGuideState from '@/ui/shared/EmptyGuideState';
-import { dominantRatio, siblingRatio } from '@/ui/shared/ImagePlaceholder';
+import { dominantRatio } from '@/ui/shared/ImagePlaceholder';
 import StepCard from '@/ui/sidepanel/StepCard';
 
 interface GuideStepListProps {
@@ -37,7 +37,6 @@ export default function GuideStepList({
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
   const stepRefs = useRef<Map<string, HTMLDivElement>>(new Map());
-  const placeholderRatio = siblingRatio(screenshots);
   const frameRatio = dominantRatio(screenshots);
 
   useEffect(() => {
@@ -98,7 +97,7 @@ export default function GuideStepList({
           <StepCard
             step={step}
             screenshot={screenshots.get(step.id)}
-            placeholderRatio={placeholderRatio}
+            placeholderRatio={frameRatio}
             frameRatio={frameRatio}
             onDescriptionChange={onDescriptionChange}
             onDelete={onDelete}

--- a/src/ui/fullview/components/GuideStepList.tsx
+++ b/src/ui/fullview/components/GuideStepList.tsx
@@ -15,6 +15,7 @@ interface GuideStepListProps {
   onOpenEditor: (stepId: string, tool: 'annotate' | 'redact' | 'crop' | 'target') => void;
   onReorder: (newSteps: Step[]) => void;
   readOnly?: boolean;
+  onChanged?: () => void;
 }
 
 export default function GuideStepList({
@@ -26,6 +27,7 @@ export default function GuideStepList({
   onOpenEditor,
   onReorder,
   readOnly,
+  onChanged,
 }: GuideStepListProps) {
   const { scrollToStepId, setActiveStepId } = useFullview((s) => ({
     scrollToStepId: s.scrollToStepId,
@@ -100,6 +102,7 @@ export default function GuideStepList({
             onDelete={onDelete}
             onOpenEditor={onOpenEditor}
             readOnly={readOnly}
+            onChanged={onChanged}
             dragHandleProps={
               readOnly
                 ? undefined

--- a/src/ui/fullview/components/VersionHistoryPanel.tsx
+++ b/src/ui/fullview/components/VersionHistoryPanel.tsx
@@ -1,5 +1,5 @@
 import { ChevronRight, RotateCcw, X } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { i18n } from '#imports';
 import { getSnapshots, revertToSnapshot } from '@/core/guides/service';
 import { groupSnapshots } from '@/core/guides/snapshot-groups';
@@ -13,6 +13,7 @@ function isQuotaError(e: unknown): boolean {
 interface VersionHistoryPanelProps {
   guideId: string;
   selectedId: string | null;
+  refreshKey: number;
   onSelect: (snapshot: Snapshot | null) => void;
   onRestored: () => void;
   onClose: () => void;
@@ -21,6 +22,7 @@ interface VersionHistoryPanelProps {
 export default function VersionHistoryPanel({
   guideId,
   selectedId,
+  refreshKey,
   onSelect,
   onRestored,
   onClose,
@@ -30,11 +32,16 @@ export default function VersionHistoryPanel({
   const [error, setError] = useState<string | null>(null);
   const [restoring, setRestoring] = useState(false);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const refreshRef = useRef(refreshKey);
 
   useEffect(() => {
+    const silent = refreshRef.current !== refreshKey;
+    refreshRef.current = refreshKey;
     let cancelled = false;
-    setLoading(true);
-    setError(null);
+    if (!silent) {
+      setLoading(true);
+      setError(null);
+    }
     getSnapshots(guideId)
       .then((list) => {
         if (!cancelled) setSnapshots(list);
@@ -48,7 +55,7 @@ export default function VersionHistoryPanel({
     return () => {
       cancelled = true;
     };
-  }, [guideId]);
+  }, [guideId, refreshKey]);
 
   const handleRestore = async (snapshot: Snapshot) => {
     if (restoring) return;

--- a/src/ui/fullview/components/VersionHistoryPanel.tsx
+++ b/src/ui/fullview/components/VersionHistoryPanel.tsx
@@ -1,0 +1,174 @@
+import { ChevronRight, RotateCcw, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { i18n } from '#imports';
+import { getSnapshots, revertToSnapshot } from '@/core/guides/service';
+import { groupSnapshots } from '@/core/guides/snapshot-groups';
+import type { Snapshot } from '@/core/guides/types';
+import { formatDateTime } from '@/lib/utils';
+
+function isQuotaError(e: unknown): boolean {
+  return e instanceof Error && (e.name === 'QuotaExceededError' || e.name === 'DexieError2QuotaExceededError');
+}
+
+interface VersionHistoryPanelProps {
+  guideId: string;
+  selectedId: string | null;
+  onSelect: (snapshot: Snapshot | null) => void;
+  onRestored: () => void;
+  onClose: () => void;
+}
+
+export default function VersionHistoryPanel({
+  guideId,
+  selectedId,
+  onSelect,
+  onRestored,
+  onClose,
+}: VersionHistoryPanelProps) {
+  const [snapshots, setSnapshots] = useState<Snapshot[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [restoring, setRestoring] = useState(false);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getSnapshots(guideId)
+      .then((list) => {
+        if (!cancelled) setSnapshots(list);
+      })
+      .catch(() => {
+        if (!cancelled) setError(i18n.t('history.loadError'));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [guideId]);
+
+  const handleRestore = async (snapshot: Snapshot) => {
+    if (restoring) return;
+    setRestoring(true);
+    setError(null);
+    try {
+      const undo = await revertToSnapshot(snapshot.id);
+      if (!undo) {
+        setError(i18n.t('history.restoreError'));
+        return;
+      }
+      setSnapshots(await getSnapshots(guideId));
+      setExpanded(new Set());
+      onSelect(null);
+      onRestored();
+    } catch (e) {
+      setError(i18n.t(isQuotaError(e) ? 'history.storageFull' : 'history.restoreError'));
+    } finally {
+      setRestoring(false);
+    }
+  };
+
+  const toggle = (key: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const entry = (snapshot: Snapshot) => {
+    const active = selectedId === snapshot.id;
+    return (
+      <div key={snapshot.id} className="relative pl-5 py-2.5">
+        <span
+          className={`absolute left-0 top-4 w-2 h-2 rounded-full border-2 ${
+            active ? 'bg-accent border-accent' : 'bg-card border-border'
+          }`}
+        />
+        <button
+          type="button"
+          aria-pressed={active}
+          onClick={() => onSelect(active ? null : snapshot)}
+          className={`block w-full text-left text-[12px] ${
+            active ? 'font-semibold text-foreground' : 'text-muted-foreground'
+          }`}
+        >
+          {formatDateTime(snapshot.createdAt)}
+        </button>
+        {active && (
+          <button
+            type="button"
+            disabled={restoring}
+            onClick={() => void handleRestore(snapshot)}
+            className="inline-flex items-center gap-1.5 mt-2 text-[11px] font-semibold text-accent disabled:opacity-50"
+          >
+            <RotateCcw size={11} />
+            {i18n.t('history.restore')}
+          </button>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <aside className="w-72 shrink-0 border-l border-border pl-4 flex flex-col gap-1">
+      <div className="flex items-center gap-2 h-10">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={i18n.t('common.close')}
+          className="p-1 text-muted-foreground hover:text-foreground"
+        >
+          <X size={14} />
+        </button>
+        <span className="text-[13px] font-semibold text-foreground">{i18n.t('history.title')}</span>
+      </div>
+
+      {error && (
+        <p role="alert" className="text-[11px] text-destructive py-2">
+          {error}
+        </p>
+      )}
+
+      {loading ? (
+        <p className="text-[11px] text-muted-foreground py-2">{i18n.t('common.loading')}</p>
+      ) : snapshots.length === 0 ? (
+        <p className="text-[11px] text-muted-foreground py-2">{i18n.t('history.empty')}</p>
+      ) : (
+        <div className="relative border-l border-dashed border-border ml-1 pl-2 flex-1 min-h-0 overflow-y-auto">
+          <div className="pl-5 py-2.5 relative">
+            <span className="absolute left-0 top-4 w-2 h-2 rounded-full bg-accent border-2 border-accent" />
+            <span className="text-[12px] font-semibold text-foreground">{i18n.t('history.current')}</span>
+          </div>
+          {groupSnapshots(snapshots).map((row) =>
+            row.kind === 'entry' ? (
+              entry(row.snapshot)
+            ) : (
+              <div key={row.snapshots[0].id}>
+                <button
+                  type="button"
+                  aria-expanded={expanded.has(row.snapshots[0].id)}
+                  onClick={() => toggle(row.snapshots[0].id)}
+                  className="flex items-center gap-1 py-2 text-[11px] text-muted-foreground hover:text-foreground"
+                >
+                  <ChevronRight
+                    size={11}
+                    className={
+                      expanded.has(row.snapshots[0].id) ? 'rotate-90 transition-transform' : 'transition-transform'
+                    }
+                  />
+                  {i18n.t('history.unchangedVersions', [String(row.snapshots.length)])}
+                </button>
+                {expanded.has(row.snapshots[0].id) && row.snapshots.map(entry)}
+              </div>
+            ),
+          )}
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/ui/fullview/components/VersionHistoryPanel.tsx
+++ b/src/ui/fullview/components/VersionHistoryPanel.tsx
@@ -26,8 +26,17 @@ function changeSummary(diff: SnapshotDiff): string {
   else if (diff.removed > 1) parts.push(i18n.t('history.changeStepsRemoved', [String(diff.removed)]));
   if (diff.edited === 1) parts.push(i18n.t('history.changeStepEdited', [String(diff.edited)]));
   else if (diff.edited > 1) parts.push(i18n.t('history.changeStepsEdited', [String(diff.edited)]));
-  if (diff.images === 1) parts.push(i18n.t('history.changeImage', [String(diff.images)]));
-  else if (diff.images > 1) parts.push(i18n.t('history.changeImages', [String(diff.images)]));
+  if (diff.urls === 1) parts.push(i18n.t('history.changeLink', [String(diff.urls)]));
+  else if (diff.urls > 1) parts.push(i18n.t('history.changeLinks', [String(diff.urls)]));
+  if (diff.replaced === 1) parts.push(i18n.t('history.changeImageReplaced', [String(diff.replaced)]));
+  else if (diff.replaced > 1) parts.push(i18n.t('history.changeImagesReplaced', [String(diff.replaced)]));
+  if (diff.cropped === 1) parts.push(i18n.t('history.changeImageCropped', [String(diff.cropped)]));
+  else if (diff.cropped > 1) parts.push(i18n.t('history.changeImagesCropped', [String(diff.cropped)]));
+  if (diff.annotated === 1) parts.push(i18n.t('history.changeImageAnnotated', [String(diff.annotated)]));
+  else if (diff.annotated > 1) parts.push(i18n.t('history.changeImagesAnnotated', [String(diff.annotated)]));
+  if (diff.blurred === 1) parts.push(i18n.t('history.changeImageBlurred', [String(diff.blurred)]));
+  else if (diff.blurred > 1) parts.push(i18n.t('history.changeImagesBlurred', [String(diff.blurred)]));
+  if (diff.altEdited) parts.push(i18n.t('history.changeAltText'));
   if (diff.reordered) parts.push(i18n.t('history.changeStepReordered'));
   return parts.join(' · ');
 }

--- a/src/ui/fullview/components/VersionHistoryPanel.tsx
+++ b/src/ui/fullview/components/VersionHistoryPanel.tsx
@@ -148,8 +148,21 @@ export default function VersionHistoryPanel({
       ) : (
         <div className="relative border-l border-dashed border-border ml-1 pl-2 flex-1 min-h-0 overflow-y-auto">
           <div className="pl-5 py-2.5 relative">
-            <span className="absolute left-0 top-4 w-2 h-2 rounded-full bg-accent border-2 border-accent" />
-            <span className="text-[12px] font-semibold text-foreground">{i18n.t('history.current')}</span>
+            <span
+              className={`absolute left-0 top-4 w-2 h-2 rounded-full border-2 ${
+                selectedId === null ? 'bg-accent border-accent' : 'bg-card border-border'
+              }`}
+            />
+            <button
+              type="button"
+              aria-pressed={selectedId === null}
+              onClick={() => onSelect(null)}
+              className={`block w-full text-left text-[12px] ${
+                selectedId === null ? 'font-semibold text-foreground' : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {i18n.t('history.current')}
+            </button>
           </div>
           {groupSnapshots(snapshots).map((row) =>
             row.kind === 'entry' ? (

--- a/src/ui/fullview/components/VersionHistoryPanel.tsx
+++ b/src/ui/fullview/components/VersionHistoryPanel.tsx
@@ -103,10 +103,16 @@ export default function VersionHistoryPanel({
   const diffs = useMemo(() => {
     const map = new Map<string, SnapshotDiff>();
     snapshots.forEach((snapshot, i) => {
-      map.set(snapshot.id, diffSnapshots(snapshot, i === 0 ? live : snapshots[i - 1]));
+      const older = snapshots[i + 1];
+      if (older) map.set(snapshot.id, diffSnapshots(older, snapshot));
     });
     return map;
-  }, [snapshots, live]);
+  }, [snapshots]);
+
+  const currentSummary = useMemo(
+    () => (snapshots.length > 0 ? changeSummary(diffSnapshots(snapshots[0], live)) : ''),
+    [snapshots, live],
+  );
 
   const named = useMemo(() => snapshots.filter((s) => s.name), [snapshots]);
 
@@ -312,6 +318,7 @@ export default function VersionHistoryPanel({
               >
                 {i18n.t('history.current')}
               </button>
+              {currentSummary && <p className="text-[11px] text-muted-foreground mt-0.5">{currentSummary}</p>}
             </div>
             {namedOnly ? (
               named.length === 0 ? (

--- a/src/ui/fullview/components/VersionHistoryPanel.tsx
+++ b/src/ui/fullview/components/VersionHistoryPanel.tsx
@@ -1,19 +1,50 @@
-import { ChevronRight, RotateCcw, X } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { ChevronRight, MoreVertical, RotateCcw, X } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { i18n } from '#imports';
-import { getSnapshots, revertToSnapshot } from '@/core/guides/service';
+import { getSnapshots, renameSnapshot, revertToSnapshot } from '@/core/guides/service';
+import { diffSnapshots, type SnapshotDiff, type SnapshotLike } from '@/core/guides/snapshot-diff';
 import { groupSnapshots } from '@/core/guides/snapshot-groups';
 import type { Snapshot } from '@/core/guides/types';
 import { formatDateTime } from '@/lib/utils';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/ui/components/ui/dropdown-menu';
 
 function isQuotaError(e: unknown): boolean {
   return e instanceof Error && (e.name === 'QuotaExceededError' || e.name === 'DexieError2QuotaExceededError');
+}
+
+function changeSummary(diff: SnapshotDiff): string {
+  const parts: string[] = [];
+  if (diff.titleChanged) parts.push(i18n.t('history.changeTitle'));
+  if (diff.added === 1) parts.push(i18n.t('history.changeStepAdded', [String(diff.added)]));
+  else if (diff.added > 1) parts.push(i18n.t('history.changeStepsAdded', [String(diff.added)]));
+  if (diff.removed === 1) parts.push(i18n.t('history.changeStepRemoved', [String(diff.removed)]));
+  else if (diff.removed > 1) parts.push(i18n.t('history.changeStepsRemoved', [String(diff.removed)]));
+  if (diff.edited === 1) parts.push(i18n.t('history.changeStepEdited', [String(diff.edited)]));
+  else if (diff.edited > 1) parts.push(i18n.t('history.changeStepsEdited', [String(diff.edited)]));
+  if (diff.images === 1) parts.push(i18n.t('history.changeImage', [String(diff.images)]));
+  else if (diff.images > 1) parts.push(i18n.t('history.changeImages', [String(diff.images)]));
+  if (diff.reordered) parts.push(i18n.t('history.changeStepReordered'));
+  return parts.join(' · ');
+}
+
+function filterPill(active: boolean): string {
+  return `px-2 py-0.5 rounded-full text-[10px] font-semibold border ${
+    active
+      ? 'bg-secondary border-border text-foreground'
+      : 'border-transparent text-muted-foreground hover:text-foreground'
+  }`;
 }
 
 interface VersionHistoryPanelProps {
   guideId: string;
   selectedId: string | null;
   refreshKey: number;
+  live: SnapshotLike;
   onSelect: (snapshot: Snapshot | null) => void;
   onRestored: () => void;
   onClose: () => void;
@@ -23,6 +54,7 @@ export default function VersionHistoryPanel({
   guideId,
   selectedId,
   refreshKey,
+  live,
   onSelect,
   onRestored,
   onClose,
@@ -32,7 +64,12 @@ export default function VersionHistoryPanel({
   const [error, setError] = useState<string | null>(null);
   const [restoring, setRestoring] = useState(false);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [namedOnly, setNamedOnly] = useState(false);
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [draft, setDraft] = useState('');
   const refreshRef = useRef(refreshKey);
+  const renamingRef = useRef<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     const silent = refreshRef.current !== refreshKey;
@@ -41,6 +78,8 @@ export default function VersionHistoryPanel({
     if (!silent) {
       setLoading(true);
       setError(null);
+      renamingRef.current = null;
+      setRenamingId(null);
     }
     getSnapshots(guideId)
       .then((list) => {
@@ -57,6 +96,20 @@ export default function VersionHistoryPanel({
     };
   }, [guideId, refreshKey]);
 
+  useEffect(() => {
+    if (renamingId) inputRef.current?.focus();
+  }, [renamingId]);
+
+  const diffs = useMemo(() => {
+    const map = new Map<string, SnapshotDiff>();
+    snapshots.forEach((snapshot, i) => {
+      map.set(snapshot.id, diffSnapshots(snapshot, i === 0 ? live : snapshots[i - 1]));
+    });
+    return map;
+  }, [snapshots, live]);
+
+  const named = useMemo(() => snapshots.filter((s) => s.name), [snapshots]);
+
   const handleRestore = async (snapshot: Snapshot) => {
     if (restoring) return;
     setRestoring(true);
@@ -69,12 +122,40 @@ export default function VersionHistoryPanel({
       }
       setSnapshots(await getSnapshots(guideId));
       setExpanded(new Set());
+      renamingRef.current = null;
+      setRenamingId(null);
       onSelect(null);
       onRestored();
     } catch (e) {
       setError(i18n.t(isQuotaError(e) ? 'history.storageFull' : 'history.restoreError'));
     } finally {
       setRestoring(false);
+    }
+  };
+
+  const startRename = (snapshot: Snapshot) => {
+    renamingRef.current = snapshot.id;
+    setRenamingId(snapshot.id);
+    setDraft(snapshot.name ?? '');
+  };
+
+  const cancelRename = () => {
+    renamingRef.current = null;
+    setRenamingId(null);
+  };
+
+  const commitRename = async (snapshot: Snapshot) => {
+    if (renamingRef.current !== snapshot.id) return;
+    renamingRef.current = null;
+    setRenamingId(null);
+    const trimmed = draft.trim();
+    const name = trimmed === '' ? undefined : trimmed;
+    if (name === snapshot.name) return;
+    try {
+      await renameSnapshot(snapshot.id, trimmed);
+      setSnapshots((prev) => prev.map((s) => (s.id === snapshot.id ? { ...s, name } : s)));
+    } catch {
+      setError(i18n.t('history.renameError'));
     }
   };
 
@@ -89,6 +170,8 @@ export default function VersionHistoryPanel({
 
   const entry = (snapshot: Snapshot) => {
     const active = selectedId === snapshot.id;
+    const diff = diffs.get(snapshot.id);
+    const summary = diff ? changeSummary(diff) : '';
     return (
       <div key={snapshot.id} className="relative pl-5 py-2.5">
         <span
@@ -96,27 +179,74 @@ export default function VersionHistoryPanel({
             active ? 'bg-accent border-accent' : 'bg-card border-border'
           }`}
         />
-        <button
-          type="button"
-          aria-pressed={active}
-          onClick={() => onSelect(active ? null : snapshot)}
-          className={`block w-full text-left text-[12px] ${
-            active ? 'font-semibold text-foreground' : 'text-muted-foreground'
-          }`}
-        >
-          {formatDateTime(snapshot.createdAt)}
-        </button>
-        {active && (
-          <button
-            type="button"
-            disabled={restoring}
-            onClick={() => void handleRestore(snapshot)}
-            className="inline-flex items-center gap-1.5 mt-2 text-[11px] font-semibold text-accent disabled:opacity-50"
-          >
-            <RotateCcw size={11} />
-            {i18n.t('history.restore')}
-          </button>
-        )}
+        <div className="flex items-start gap-1">
+          <div className="flex-1 min-w-0">
+            {renamingId === snapshot.id ? (
+              <input
+                ref={inputRef}
+                value={draft}
+                placeholder={i18n.t('history.namePlaceholder')}
+                aria-label={i18n.t('history.namePlaceholder')}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    void commitRename(snapshot);
+                  } else if (e.key === 'Escape') {
+                    e.preventDefault();
+                    cancelRename();
+                  }
+                }}
+                onBlur={() => void commitRename(snapshot)}
+                className="w-full text-[12px] font-semibold text-foreground bg-card border border-accent rounded px-1.5 py-0.5 focus:outline-none"
+              />
+            ) : (
+              <button
+                type="button"
+                aria-pressed={active}
+                onClick={() => onSelect(active ? null : snapshot)}
+                className={`block w-full text-left text-[12px] ${
+                  active ? 'font-semibold text-foreground' : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                <span className="block truncate">{snapshot.name || formatDateTime(snapshot.createdAt)}</span>
+                {snapshot.name && (
+                  <span className="block text-[10px] font-normal text-muted-foreground mt-0.5">
+                    {formatDateTime(snapshot.createdAt)}
+                  </span>
+                )}
+              </button>
+            )}
+            {summary && <p className="text-[10px] text-muted-foreground mt-0.5">{summary}</p>}
+            {active && (
+              <button
+                type="button"
+                disabled={restoring}
+                onClick={() => void handleRestore(snapshot)}
+                className="inline-flex items-center gap-1.5 mt-2 text-[11px] font-semibold text-accent disabled:opacity-50"
+              >
+                <RotateCcw size={11} />
+                {i18n.t('history.restore')}
+              </button>
+            )}
+          </div>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label={i18n.t('history.nameVersion')}
+                className="shrink-0 p-0.5 text-muted-foreground hover:text-foreground"
+              >
+                <MoreVertical size={13} />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" onCloseAutoFocus={(e) => e.preventDefault()}>
+              <DropdownMenuItem onSelect={() => startRename(snapshot)}>
+                {i18n.t('history.nameVersion')}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
     );
   };
@@ -146,48 +276,76 @@ export default function VersionHistoryPanel({
       ) : snapshots.length === 0 ? (
         <p className="text-[11px] text-muted-foreground py-2">{i18n.t('history.empty')}</p>
       ) : (
-        <div className="relative border-l border-dashed border-border ml-1 pl-2 flex-1 min-h-0 overflow-y-auto">
-          <div className="pl-5 py-2.5 relative">
-            <span
-              className={`absolute left-0 top-4 w-2 h-2 rounded-full border-2 ${
-                selectedId === null ? 'bg-accent border-accent' : 'bg-card border-border'
-              }`}
-            />
+        <>
+          <div className="flex items-center gap-1 pb-1">
             <button
               type="button"
-              aria-pressed={selectedId === null}
-              onClick={() => onSelect(null)}
-              className={`block w-full text-left text-[12px] ${
-                selectedId === null ? 'font-semibold text-foreground' : 'text-muted-foreground hover:text-foreground'
-              }`}
+              aria-pressed={!namedOnly}
+              onClick={() => setNamedOnly(false)}
+              className={filterPill(!namedOnly)}
             >
-              {i18n.t('history.current')}
+              {i18n.t('history.allVersions')}
+            </button>
+            <button
+              type="button"
+              aria-pressed={namedOnly}
+              onClick={() => setNamedOnly(true)}
+              className={filterPill(namedOnly)}
+            >
+              {i18n.t('history.namedOnly')}
             </button>
           </div>
-          {groupSnapshots(snapshots).map((row) =>
-            row.kind === 'entry' ? (
-              entry(row.snapshot)
+          <div className="relative border-l border-dashed border-border ml-1 pl-2 flex-1 min-h-0 overflow-y-auto">
+            <div className="pl-5 py-2.5 relative">
+              <span
+                className={`absolute left-0 top-4 w-2 h-2 rounded-full border-2 ${
+                  selectedId === null ? 'bg-accent border-accent' : 'bg-card border-border'
+                }`}
+              />
+              <button
+                type="button"
+                aria-pressed={selectedId === null}
+                onClick={() => onSelect(null)}
+                className={`block w-full text-left text-[12px] ${
+                  selectedId === null ? 'font-semibold text-foreground' : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {i18n.t('history.current')}
+              </button>
+            </div>
+            {namedOnly ? (
+              named.length === 0 ? (
+                <p className="text-[11px] text-muted-foreground py-2 pl-5">{i18n.t('history.emptyNamed')}</p>
+              ) : (
+                named.map(entry)
+              )
             ) : (
-              <div key={row.snapshots[0].id}>
-                <button
-                  type="button"
-                  aria-expanded={expanded.has(row.snapshots[0].id)}
-                  onClick={() => toggle(row.snapshots[0].id)}
-                  className="flex items-center gap-1 py-2 text-[11px] text-muted-foreground hover:text-foreground"
-                >
-                  <ChevronRight
-                    size={11}
-                    className={
-                      expanded.has(row.snapshots[0].id) ? 'rotate-90 transition-transform' : 'transition-transform'
-                    }
-                  />
-                  {i18n.t('history.unchangedVersions', [String(row.snapshots.length)])}
-                </button>
-                {expanded.has(row.snapshots[0].id) && row.snapshots.map(entry)}
-              </div>
-            ),
-          )}
-        </div>
+              groupSnapshots(snapshots).map((row) =>
+                row.kind === 'entry' ? (
+                  entry(row.snapshot)
+                ) : (
+                  <div key={row.snapshots[0].id}>
+                    <button
+                      type="button"
+                      aria-expanded={expanded.has(row.snapshots[0].id)}
+                      onClick={() => toggle(row.snapshots[0].id)}
+                      className="flex items-center gap-1 py-2 text-[11px] text-muted-foreground hover:text-foreground"
+                    >
+                      <ChevronRight
+                        size={11}
+                        className={
+                          expanded.has(row.snapshots[0].id) ? 'rotate-90 transition-transform' : 'transition-transform'
+                        }
+                      />
+                      {i18n.t('history.unchangedVersions', [String(row.snapshots.length)])}
+                    </button>
+                    {expanded.has(row.snapshots[0].id) && row.snapshots.map(entry)}
+                  </div>
+                ),
+              )
+            )}
+          </div>
+        </>
       )}
     </aside>
   );

--- a/src/ui/fullview/components/__tests__/version-history-panel.test.tsx
+++ b/src/ui/fullview/components/__tests__/version-history-panel.test.tsx
@@ -139,9 +139,10 @@ describe('VersionHistoryPanel change summary', () => {
   });
 
   it('uses the plural key for every counted cause above one', async () => {
+    const ids = ['e1', 'e2', 'u1', 'u2', 'rp1', 'rp2', 'cr1', 'cr2', 'an1', 'an2', 'bl1', 'bl2'];
     const snapshot = older({
       title: 'Before',
-      stepIds: ['x1', 'x2', 'e1', 'e2', 'u1', 'u2', 'p1', 'p2'],
+      stepIds: ['x1', 'x2', ...ids],
       steps: [
         step('x1', 'Gone one'),
         step('x2', 'Gone two'),
@@ -149,17 +150,29 @@ describe('VersionHistoryPanel change summary', () => {
         step('e2', 'Old e2'),
         step('u1', 'Same', undefined, 'https://a.test/one'),
         step('u2', 'Same', undefined, 'https://a.test/two'),
-        step('p1', 'Same', 'p1a'),
-        step('p2', 'Same', 'p2a'),
+        step('rp1', 'Same', 'rp1a'),
+        step('rp2', 'Same', 'rp2a'),
+        step('cr1', 'Same', 'cr1s'),
+        step('cr2', 'Same', 'cr2s'),
+        step('an1', 'Same', 'an1s'),
+        step('an2', 'Same', 'an2s'),
+        step('bl1', 'Same', 'bl1s'),
+        step('bl2', 'Same', 'bl2s'),
       ],
       screenshots: [
-        shot('p1a', 'p1', { viewport: viewportA, annotations: [box, redact], alt: 'before' }),
-        shot('p2a', 'p2', { viewport: viewportA, annotations: [box, redact], alt: 'before' }),
+        shot('rp1a', 'rp1'),
+        shot('rp2a', 'rp2'),
+        shot('cr1s', 'cr1', { viewport: viewportA, alt: 'before' }),
+        shot('cr2s', 'cr2', { viewport: viewportA }),
+        shot('an1s', 'an1', { annotations: [box] }),
+        shot('an2s', 'an2', { annotations: [box] }),
+        shot('bl1s', 'bl1', { annotations: [redact] }),
+        shot('bl2s', 'bl2', { annotations: [redact] }),
       ],
     });
     const live: SnapshotLike = {
       title: 'After',
-      stepIds: ['y1', 'y2', 'e2', 'e1', 'u1', 'u2', 'p1', 'p2'],
+      stepIds: ['y1', 'y2', 'e2', 'e1', ...ids.slice(2)],
       steps: [
         step('y1', 'New one'),
         step('y2', 'New two'),
@@ -167,12 +180,24 @@ describe('VersionHistoryPanel change summary', () => {
         step('e1', 'New e1'),
         step('u1', 'Same', undefined, 'https://b.test/one'),
         step('u2', 'Same', undefined, 'https://b.test/two'),
-        step('p1', 'Same', 'p1b'),
-        step('p2', 'Same', 'p2b'),
+        step('rp1', 'Same', 'rp1b'),
+        step('rp2', 'Same', 'rp2b'),
+        step('cr1', 'Same', 'cr1s'),
+        step('cr2', 'Same', 'cr2s'),
+        step('an1', 'Same', 'an1s'),
+        step('an2', 'Same', 'an2s'),
+        step('bl1', 'Same', 'bl1s'),
+        step('bl2', 'Same', 'bl2s'),
       ],
       screenshots: [
-        shot('p1b', 'p1', { viewport: viewportB, annotations: [otherBox, otherRedact], alt: 'after' }),
-        shot('p2b', 'p2', { viewport: viewportB, annotations: [otherBox, otherRedact], alt: 'after' }),
+        shot('rp1b', 'rp1'),
+        shot('rp2b', 'rp2'),
+        shot('cr1s', 'cr1', { viewport: viewportB, alt: 'after' }),
+        shot('cr2s', 'cr2', { viewport: viewportB }),
+        shot('an1s', 'an1', { annotations: [otherBox] }),
+        shot('an2s', 'an2', { annotations: [otherBox] }),
+        shot('bl1s', 'bl1', { annotations: [otherRedact] }),
+        shot('bl2s', 'bl2', { annotations: [otherRedact] }),
       ],
     };
 

--- a/src/ui/fullview/components/__tests__/version-history-panel.test.tsx
+++ b/src/ui/fullview/components/__tests__/version-history-panel.test.tsx
@@ -1,0 +1,213 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SnapshotLike } from '@/core/guides/snapshot-diff';
+import type { Screenshot, Snapshot, Step } from '@/core/guides/types';
+import type { Annotation, ScreenshotEdits } from '@/core/screenshot/types';
+
+const getSnapshots = vi.fn();
+
+vi.mock('@/core/guides/service', () => ({
+  getSnapshots: (...args: unknown[]) => getSnapshots(...args),
+  renameSnapshot: vi.fn(),
+  revertToSnapshot: vi.fn(),
+}));
+
+import VersionHistoryPanel from '../VersionHistoryPanel';
+
+const box: Annotation = { id: 'a1', type: 'box', x: 0, y: 0, w: 10, h: 10, color: '#000000' };
+const otherBox: Annotation = { id: 'a1', type: 'box', x: 4, y: 4, w: 10, h: 10, color: '#000000' };
+const redact: Annotation = { id: 'r1', type: 'redact', x: 0, y: 0, w: 5, h: 5, style: 'blur' };
+const otherRedact: Annotation = { id: 'r1', type: 'redact', x: 0, y: 0, w: 5, h: 5, style: 'solid' };
+const viewportA = { x: 0, y: 0, width: 100, height: 50 };
+const viewportB = { x: 5, y: 0, width: 90, height: 50 };
+
+function step(id: string, description: string, screenshotId?: string, url = 'https://a.test'): Step {
+  return {
+    id,
+    guideId: 'g1',
+    index: 0,
+    description,
+    action: 'click',
+    url,
+    timestamp: 1,
+    ...(screenshotId ? { screenshotId } : {}),
+  };
+}
+
+function shot(id: string, stepId: string, edits?: ScreenshotEdits): Omit<Screenshot, 'blob'> {
+  return { id, stepId, mimeType: 'image/png', width: 10, height: 10, ...(edits ? { edits } : {}) };
+}
+
+function older(overrides: Partial<Snapshot>): Snapshot {
+  return {
+    id: 'n1',
+    guideId: 'g1',
+    createdAt: 1_700_000_000_000,
+    contentHash: 'h1',
+    title: 'Guide',
+    stepIds: [],
+    steps: [],
+    screenshots: [],
+    ...overrides,
+  };
+}
+
+function setup(snapshot: Snapshot, live: SnapshotLike) {
+  getSnapshots.mockResolvedValue([snapshot]);
+  return render(
+    <VersionHistoryPanel
+      guideId="g1"
+      selectedId={null}
+      refreshKey={0}
+      live={live}
+      onSelect={vi.fn()}
+      onRestored={vi.fn()}
+      onClose={vi.fn()}
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('VersionHistoryPanel change summary', () => {
+  it('lists every cause once, in order, for a version that changed one of each', async () => {
+    const snapshot = older({
+      title: 'Before',
+      stepIds: ['s1', 's3', 's4', 's5', 's6', 's7', 's8', 's9'],
+      steps: [
+        step('s1', 'Gone'),
+        step('s3', 'Old three'),
+        step('s4', 'Same', undefined, 'https://a.test/one'),
+        step('s5', 'Same', 'sc5a'),
+        step('s6', 'Same', 'sc6'),
+        step('s7', 'Same', 'sc7'),
+        step('s8', 'Same', 'sc8'),
+        step('s9', 'Same', 'sc9'),
+      ],
+      screenshots: [
+        shot('sc5a', 's5'),
+        shot('sc6', 's6', { viewport: viewportA }),
+        shot('sc7', 's7', { annotations: [box] }),
+        shot('sc8', 's8', { annotations: [redact] }),
+        shot('sc9', 's9', { alt: 'before' }),
+      ],
+    });
+    const live: SnapshotLike = {
+      title: 'After',
+      stepIds: ['s2', 's4', 's3', 's5', 's6', 's7', 's8', 's9'],
+      steps: [
+        step('s2', 'New'),
+        step('s4', 'Same', undefined, 'https://a.test/two'),
+        step('s3', 'New three'),
+        step('s5', 'Same', 'sc5b'),
+        step('s6', 'Same', 'sc6'),
+        step('s7', 'Same', 'sc7'),
+        step('s8', 'Same', 'sc8'),
+        step('s9', 'Same', 'sc9'),
+      ],
+      screenshots: [
+        shot('sc5b', 's5'),
+        shot('sc6', 's6', { viewport: viewportB }),
+        shot('sc7', 's7', { annotations: [otherBox] }),
+        shot('sc8', 's8', { annotations: [otherRedact] }),
+        shot('sc9', 's9', { alt: 'after' }),
+      ],
+    };
+
+    setup(snapshot, live);
+
+    const expected = [
+      'history.changeTitle',
+      'history.changeStepAdded[1]',
+      'history.changeStepRemoved[1]',
+      'history.changeStepEdited[1]',
+      'history.changeLink[1]',
+      'history.changeImageReplaced[1]',
+      'history.changeImageCropped[1]',
+      'history.changeImageAnnotated[1]',
+      'history.changeImageBlurred[1]',
+      'history.changeAltText',
+      'history.changeStepReordered',
+    ].join(' · ');
+
+    await waitFor(() => {
+      expect(screen.getByText(expected)).toBeTruthy();
+    });
+  });
+
+  it('uses the plural key for every counted cause above one', async () => {
+    const snapshot = older({
+      title: 'Before',
+      stepIds: ['x1', 'x2', 'e1', 'e2', 'u1', 'u2', 'p1', 'p2'],
+      steps: [
+        step('x1', 'Gone one'),
+        step('x2', 'Gone two'),
+        step('e1', 'Old e1'),
+        step('e2', 'Old e2'),
+        step('u1', 'Same', undefined, 'https://a.test/one'),
+        step('u2', 'Same', undefined, 'https://a.test/two'),
+        step('p1', 'Same', 'p1a'),
+        step('p2', 'Same', 'p2a'),
+      ],
+      screenshots: [
+        shot('p1a', 'p1', { viewport: viewportA, annotations: [box, redact], alt: 'before' }),
+        shot('p2a', 'p2', { viewport: viewportA, annotations: [box, redact], alt: 'before' }),
+      ],
+    });
+    const live: SnapshotLike = {
+      title: 'After',
+      stepIds: ['y1', 'y2', 'e2', 'e1', 'u1', 'u2', 'p1', 'p2'],
+      steps: [
+        step('y1', 'New one'),
+        step('y2', 'New two'),
+        step('e2', 'New e2'),
+        step('e1', 'New e1'),
+        step('u1', 'Same', undefined, 'https://b.test/one'),
+        step('u2', 'Same', undefined, 'https://b.test/two'),
+        step('p1', 'Same', 'p1b'),
+        step('p2', 'Same', 'p2b'),
+      ],
+      screenshots: [
+        shot('p1b', 'p1', { viewport: viewportB, annotations: [otherBox, otherRedact], alt: 'after' }),
+        shot('p2b', 'p2', { viewport: viewportB, annotations: [otherBox, otherRedact], alt: 'after' }),
+      ],
+    };
+
+    setup(snapshot, live);
+
+    const expected = [
+      'history.changeTitle',
+      'history.changeStepsAdded[2]',
+      'history.changeStepsRemoved[2]',
+      'history.changeStepsEdited[2]',
+      'history.changeLinks[2]',
+      'history.changeImagesReplaced[2]',
+      'history.changeImagesCropped[2]',
+      'history.changeImagesAnnotated[2]',
+      'history.changeImagesBlurred[2]',
+      'history.changeAltText',
+      'history.changeStepReordered',
+    ].join(' · ');
+
+    await waitFor(() => {
+      expect(screen.getByText(expected)).toBeTruthy();
+    });
+  });
+
+  it('renders no summary when nothing changed', async () => {
+    const steps = [step('s1', 'One', 'sc1')];
+    const screenshots = [shot('sc1', 's1', { annotations: [box, redact], alt: 'same' })];
+    const snapshot = older({ stepIds: ['s1'], steps, screenshots });
+    const live: SnapshotLike = { title: 'Guide', stepIds: ['s1'], steps, screenshots };
+
+    setup(snapshot, live);
+
+    await waitFor(() => {
+      expect(screen.getByText('history.current')).toBeTruthy();
+    });
+    expect(screen.queryByText(/history\.change/)).toBeNull();
+  });
+});

--- a/src/ui/fullview/router.ts
+++ b/src/ui/fullview/router.ts
@@ -2,7 +2,13 @@ import { useEffect, useState } from 'react';
 
 export type Route =
   | { page: 'library'; category: 'all' | 'starred' | 'trash' }
-  | { page: 'guide'; guideId: string; stepId?: string; tool?: 'annotate' | 'redact' | 'crop' | 'target' };
+  | {
+      page: 'guide';
+      guideId: string;
+      stepId?: string;
+      tool?: 'annotate' | 'redact' | 'crop' | 'target';
+      history?: boolean;
+    };
 
 function parseHash(hash: string): Route {
   const h = hash.replace(/^#\/?/, '');
@@ -32,9 +38,13 @@ export function useRoute(): Route {
     if (guideId) {
       const stepId = params.get('stepId') ?? undefined;
       const toolParam = params.get('tool');
-      const tool = toolParam === 'annotate' || toolParam === 'redact' || toolParam === 'crop' ? toolParam : undefined;
+      const tool =
+        toolParam === 'annotate' || toolParam === 'redact' || toolParam === 'crop' || toolParam === 'target'
+          ? toolParam
+          : undefined;
+      const showHistory = params.get('history') === '1';
       window.history.replaceState(null, '', `${window.location.pathname}#guide/${guideId}`);
-      return { page: 'guide', guideId, stepId, tool };
+      return { page: 'guide', guideId, stepId, tool, history: showHistory };
     }
     return parseHash(window.location.hash);
   });

--- a/src/ui/fullview/router.ts
+++ b/src/ui/fullview/router.ts
@@ -7,7 +7,6 @@ export type Route =
       guideId: string;
       stepId?: string;
       tool?: 'annotate' | 'redact' | 'crop' | 'target';
-      history?: boolean;
     };
 
 function parseHash(hash: string): Route {
@@ -42,9 +41,8 @@ export function useRoute(): Route {
         toolParam === 'annotate' || toolParam === 'redact' || toolParam === 'crop' || toolParam === 'target'
           ? toolParam
           : undefined;
-      const showHistory = params.get('history') === '1';
       window.history.replaceState(null, '', `${window.location.pathname}#guide/${guideId}`);
-      return { page: 'guide', guideId, stepId, tool, history: showHistory };
+      return { page: 'guide', guideId, stepId, tool };
     }
     return parseHash(window.location.hash);
   });

--- a/src/ui/shared/ImagePlaceholder.tsx
+++ b/src/ui/shared/ImagePlaceholder.tsx
@@ -22,14 +22,6 @@ export default function ImagePlaceholder({ label, ratio = DEFAULT_RATIO, classNa
   );
 }
 
-export function siblingRatio(screenshots: Map<string, Screenshot>): number | undefined {
-  for (const screenshot of screenshots.values()) {
-    const viewport = resolveViewport(screenshot);
-    if (viewport.width && viewport.height) return viewport.width / viewport.height;
-  }
-  return undefined;
-}
-
 const RATIO_BUCKET_PRECISION = 100;
 
 export function dominantRatio(screenshots: Map<string, Screenshot>): number | undefined {

--- a/src/ui/shared/ImagePlaceholder.tsx
+++ b/src/ui/shared/ImagePlaceholder.tsx
@@ -1,16 +1,28 @@
+import { ImageUp } from 'lucide-react';
+import { useState } from 'react';
+import { i18n } from '#imports';
 import type { Screenshot } from '@/core/guides/types';
 import { resolveViewport } from '@/core/screenshot/geometry';
 import MascotIcon from '@/ui/shared/MascotIcon';
+import ReplaceImageDialog from '@/ui/shared/ReplaceImageDialog';
 
 interface ImagePlaceholderProps {
   label: string;
   ratio?: number;
   className?: string;
+  onUpload?: (file: File) => void | Promise<void>;
 }
 
 const DEFAULT_RATIO = 16 / 10;
 
-export default function ImagePlaceholder({ label, ratio = DEFAULT_RATIO, className = '' }: ImagePlaceholderProps) {
+export default function ImagePlaceholder({
+  label,
+  ratio = DEFAULT_RATIO,
+  className = '',
+  onUpload,
+}: ImagePlaceholderProps) {
+  const [uploadOpen, setUploadOpen] = useState(false);
+
   return (
     <div
       className={`flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border bg-secondary/60 text-muted-foreground ${className}`}
@@ -18,6 +30,26 @@ export default function ImagePlaceholder({ label, ratio = DEFAULT_RATIO, classNa
     >
       <MascotIcon size={64} pose="lookaway" tone="muted" />
       <span className="text-[12px] font-semibold text-muted-foreground">{label}</span>
+      {onUpload && (
+        <>
+          <button
+            type="button"
+            onClick={() => setUploadOpen(true)}
+            className="flex items-center gap-1.5 h-7 px-2.5 rounded-md border border-border bg-card/90 text-[11px] font-semibold text-foreground transition-colors hover:bg-secondary hover:text-accent"
+          >
+            <ImageUp size={13} />
+            {i18n.t('screenshotView.addImage')}
+          </button>
+          <ReplaceImageDialog
+            open={uploadOpen}
+            onSelect={(file) => {
+              setUploadOpen(false);
+              void onUpload(file);
+            }}
+            onCancel={() => setUploadOpen(false)}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/src/ui/shared/ImagePlaceholder.tsx
+++ b/src/ui/shared/ImagePlaceholder.tsx
@@ -29,3 +29,25 @@ export function siblingRatio(screenshots: Map<string, Screenshot>): number | und
   }
   return undefined;
 }
+
+const RATIO_BUCKET_PRECISION = 100;
+
+export function dominantRatio(screenshots: Map<string, Screenshot>): number | undefined {
+  const buckets = new Map<number, { ratio: number; count: number }>();
+
+  for (const screenshot of screenshots.values()) {
+    const viewport = resolveViewport(screenshot);
+    if (!viewport.width || !viewport.height) continue;
+    const ratio = viewport.width / viewport.height;
+    const key = Math.round(ratio * RATIO_BUCKET_PRECISION) / RATIO_BUCKET_PRECISION;
+    const bucket = buckets.get(key);
+    if (bucket) bucket.count += 1;
+    else buckets.set(key, { ratio, count: 1 });
+  }
+
+  let winner: { ratio: number; count: number } | undefined;
+  for (const bucket of buckets.values()) {
+    if (!winner || bucket.count > winner.count) winner = bucket;
+  }
+  return winner?.ratio;
+}

--- a/src/ui/shared/ScreenshotView.tsx
+++ b/src/ui/shared/ScreenshotView.tsx
@@ -27,6 +27,7 @@ interface ScreenshotViewProps {
   alt?: string;
   animate?: boolean;
   crop?: boolean;
+  frameRatio?: number;
   readOnly?: boolean;
   onOpenEditor?: (tool: 'annotate' | 'redact' | 'crop' | 'target') => void;
   onChanged?: () => void;
@@ -47,6 +48,7 @@ const ZOOM_OUT_FACTOR = 0.8;
 const VIEWPORT_EPSILON = 0.5;
 const FRAME_EASING = 'cubic-bezier(0.22, 1, 0.36, 1)';
 const FRAME_TRANSITION = `width 0.4s ${FRAME_EASING}, height 0.4s ${FRAME_EASING}, left 0.4s ${FRAME_EASING}, top 0.4s ${FRAME_EASING}`;
+const FRAME_RATIO_EPSILON = 0.01;
 
 function withFullViewport(screenshot: Screenshot): Screenshot {
   return {
@@ -61,6 +63,7 @@ export default function ScreenshotView({
   alt = '',
   animate = false,
   crop = false,
+  frameRatio,
   readOnly = false,
   onOpenEditor,
   onChanged,
@@ -268,7 +271,9 @@ export default function ScreenshotView({
     onChanged?.();
   };
 
-  const ratio = baseScreenshot.width && baseScreenshot.height ? baseScreenshot.width / baseScreenshot.height : 16 / 9;
+  const ownRatio =
+    baseScreenshot.width && baseScreenshot.height ? baseScreenshot.width / baseScreenshot.height : 16 / 9;
+  const ratio = frameRatio ?? ownRatio;
 
   if (deleted) {
     return <ImagePlaceholder label={i18n.t('screenshotView.imageDeleted')} ratio={ratio} className={className} />;
@@ -314,25 +319,41 @@ export default function ScreenshotView({
     transition: animate ? FRAME_TRANSITION : undefined,
   };
 
+  const vpRatio = displayedViewport.width / displayedViewport.height;
+  const letterbox =
+    frameRatio !== undefined && Math.abs(vpRatio - frameRatio) > FRAME_RATIO_EPSILON ? frameRatio : undefined;
+  const frameFit: React.CSSProperties | undefined =
+    letterbox === undefined ? undefined : vpRatio >= letterbox ? { width: '100%' } : { height: '100%' };
+
+  const frame = (
+    <div
+      data-screenshot-frame=""
+      className={letterbox === undefined ? 'relative overflow-hidden w-full' : 'relative overflow-hidden'}
+      style={{ aspectRatio: `${displayedViewport.width} / ${displayedViewport.height}`, ...frameFit }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerEnd}
+      onPointerCancel={handlePointerEnd}
+    >
+      <img
+        src={fullUrl}
+        alt={altText}
+        draggable={false}
+        className={`absolute block max-w-none ${showZoomControls && isZoomed ? 'cursor-grab active:cursor-grabbing' : ''}`}
+        style={imgStyle}
+      />
+    </div>
+  );
+
   return (
     <div className={`relative overflow-hidden rounded-lg border border-border ${className}`}>
-      <div
-        data-screenshot-frame=""
-        className="relative overflow-hidden w-full"
-        style={{ aspectRatio: `${displayedViewport.width} / ${displayedViewport.height}` }}
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerEnd}
-        onPointerCancel={handlePointerEnd}
-      >
-        <img
-          src={fullUrl}
-          alt={altText}
-          draggable={false}
-          className={`absolute block max-w-none ${showZoomControls && isZoomed ? 'cursor-grab active:cursor-grabbing' : ''}`}
-          style={imgStyle}
-        />
-      </div>
+      {letterbox === undefined ? (
+        frame
+      ) : (
+        <div className="w-full flex items-center justify-center bg-secondary" style={{ aspectRatio: letterbox }}>
+          {frame}
+        </div>
+      )}
       {showTopControls && (
         <div className="absolute top-2 right-2 z-10 flex items-center gap-1">
           <Popover>

--- a/src/ui/shared/ScreenshotView.tsx
+++ b/src/ui/shared/ScreenshotView.tsx
@@ -29,6 +29,7 @@ interface ScreenshotViewProps {
   crop?: boolean;
   readOnly?: boolean;
   onOpenEditor?: (tool: 'annotate' | 'redact' | 'crop' | 'target') => void;
+  onChanged?: () => void;
 }
 
 interface DragState {
@@ -62,6 +63,7 @@ export default function ScreenshotView({
   crop = false,
   readOnly = false,
   onOpenEditor,
+  onChanged,
 }: ScreenshotViewProps) {
   const [fullUrl, setFullUrl] = useState<string | null>(null);
   const [showViewport, setShowViewport] = useState(false);
@@ -244,6 +246,7 @@ export default function ScreenshotView({
       height,
     });
     setEditsOverride(nextEdits);
+    onChanged?.();
   };
 
   const handleDownload = async (which: 'edited' | 'original') => {
@@ -262,6 +265,7 @@ export default function ScreenshotView({
     setConfirmDelete(false);
     await deleteScreenshot(screenshot.stepId);
     setDeleted(true);
+    onChanged?.();
   };
 
   const ratio = baseScreenshot.width && baseScreenshot.height ? baseScreenshot.width / baseScreenshot.height : 16 / 9;

--- a/src/ui/shared/ScreenshotView.tsx
+++ b/src/ui/shared/ScreenshotView.tsx
@@ -98,6 +98,8 @@ export default function ScreenshotView({
     if (propScreenshotRef.current !== screenshot) {
       propScreenshotRef.current = screenshot;
       setDeleted(false);
+      setScreenshotOverride(null);
+      setEditsOverride(undefined);
     }
   }, [screenshot]);
 

--- a/src/ui/shared/ScreenshotView.tsx
+++ b/src/ui/shared/ScreenshotView.tsx
@@ -1,7 +1,7 @@
 import { Download, ImageUp, Pencil, Trash2, ZoomIn, ZoomOut } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { i18n } from '#imports';
-import { deleteScreenshot, updateScreenshotBlob, updateScreenshotEdits } from '@/core/guides/service';
+import { deleteScreenshot, replaceScreenshot, updateScreenshotEdits } from '@/core/guides/service';
 import type { Screenshot, ScreenshotBounds } from '@/core/guides/types';
 import { panBy, resolveViewport, zoomBy } from '@/core/screenshot/geometry';
 import { renderScreenshot } from '@/core/screenshot/render';
@@ -76,6 +76,7 @@ export default function ScreenshotView({
   const urlRef = useRef<string | null>(null);
   const idRef = useRef(screenshot.id);
   const propEditsRef = useRef(screenshot.edits);
+  const propScreenshotRef = useRef(screenshot);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const dragRef = useRef<DragState | null>(null);
@@ -92,6 +93,13 @@ export default function ScreenshotView({
       setDeleted(false);
     }
   }, [screenshot.id]);
+
+  useEffect(() => {
+    if (propScreenshotRef.current !== screenshot) {
+      propScreenshotRef.current = screenshot;
+      setDeleted(false);
+    }
+  }, [screenshot]);
 
   useEffect(() => {
     if (propEditsRef.current !== screenshot.edits) {
@@ -169,7 +177,7 @@ export default function ScreenshotView({
   const scheduleSave = (edits: ScreenshotEdits) => {
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     saveTimerRef.current = setTimeout(() => {
-      updateScreenshotEdits(screenshot.id, edits).then(() => {
+      updateScreenshotEdits(baseScreenshot.id, edits).then(() => {
         setSaved(true);
         if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
         savedTimerRef.current = setTimeout(() => setSaved(false), SAVED_MESSAGE_MS);
@@ -230,6 +238,7 @@ export default function ScreenshotView({
   };
 
   const handleReplaceFile = async (file: File) => {
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     setReplaceOpen(false);
 
     const bitmap = await createImageBitmap(file);
@@ -239,13 +248,18 @@ export default function ScreenshotView({
     const nextEdits: ScreenshotEdits = { ...effectiveEdits, target: null };
     delete nextEdits.viewport;
     delete nextEdits.alt;
-    const nextScreenshot: Screenshot = { ...baseScreenshot, blob: file, mimeType: file.type, width, height };
 
-    setScreenshotOverride(nextScreenshot);
+    const newId = await replaceScreenshot(screenshot.stepId, file, { width, height }, nextEdits);
+
+    setScreenshotOverride({
+      ...baseScreenshot,
+      id: newId,
+      blob: file,
+      mimeType: file.type,
+      width,
+      height,
+    });
     setEditsOverride(nextEdits);
-
-    await updateScreenshotBlob(screenshot.id, file, { width, height });
-    await updateScreenshotEdits(screenshot.id, nextEdits);
   };
 
   const handleDownload = async (which: 'edited' | 'original') => {
@@ -260,8 +274,9 @@ export default function ScreenshotView({
   };
 
   const handleDeleteImage = async () => {
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     setConfirmDelete(false);
-    await deleteScreenshot(screenshot.id, screenshot.stepId);
+    await deleteScreenshot(screenshot.stepId);
     setDeleted(true);
   };
 

--- a/src/ui/shared/ScreenshotView.tsx
+++ b/src/ui/shared/ScreenshotView.tsx
@@ -74,8 +74,6 @@ export default function ScreenshotView({
   const [replaceOpen, setReplaceOpen] = useState(false);
   const processedKeyRef = useRef<string | null>(null);
   const urlRef = useRef<string | null>(null);
-  const idRef = useRef(screenshot.id);
-  const propEditsRef = useRef(screenshot.edits);
   const propScreenshotRef = useRef(screenshot);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -86,29 +84,13 @@ export default function ScreenshotView({
   const effectiveScreenshot: Screenshot = { ...baseScreenshot, edits: effectiveEdits };
 
   useEffect(() => {
-    if (idRef.current !== screenshot.id) {
-      idRef.current = screenshot.id;
-      setEditsOverride(undefined);
-      setScreenshotOverride(null);
-      setDeleted(false);
-    }
-  }, [screenshot.id]);
-
-  useEffect(() => {
     if (propScreenshotRef.current !== screenshot) {
       propScreenshotRef.current = screenshot;
-      setDeleted(false);
-      setScreenshotOverride(null);
       setEditsOverride(undefined);
+      setScreenshotOverride(null);
+      setDeleted(false);
     }
   }, [screenshot]);
-
-  useEffect(() => {
-    if (propEditsRef.current !== screenshot.edits) {
-      propEditsRef.current = screenshot.edits;
-      setEditsOverride(undefined);
-    }
-  }, [screenshot.edits]);
 
   useEffect(() => {
     setAltDraft(effectiveEdits?.alt ?? '');

--- a/src/ui/shared/ScreenshotView.tsx
+++ b/src/ui/shared/ScreenshotView.tsx
@@ -4,7 +4,7 @@ import { i18n } from '#imports';
 import { deleteScreenshot, replaceScreenshot, updateScreenshotEdits } from '@/core/guides/service';
 import type { Screenshot, ScreenshotBounds } from '@/core/guides/types';
 import { panBy, resolveViewport, zoomBy } from '@/core/screenshot/geometry';
-import { renderScreenshot } from '@/core/screenshot/render';
+import { imageDimensions, renderScreenshot } from '@/core/screenshot/render';
 import type { ScreenshotEdits } from '@/core/screenshot/types';
 import {
   DropdownMenu,
@@ -230,9 +230,7 @@ export default function ScreenshotView({
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     setReplaceOpen(false);
 
-    const bitmap = await createImageBitmap(file);
-    const { width, height } = bitmap;
-    bitmap.close();
+    const { width, height } = await imageDimensions(file);
 
     const nextEdits: ScreenshotEdits = { ...effectiveEdits, target: null };
     delete nextEdits.viewport;
@@ -249,6 +247,7 @@ export default function ScreenshotView({
       height,
     });
     setEditsOverride(nextEdits);
+    setDeleted(false);
     onChanged?.();
   };
 
@@ -276,7 +275,14 @@ export default function ScreenshotView({
   const ratio = frameRatio ?? ownRatio;
 
   if (deleted) {
-    return <ImagePlaceholder label={i18n.t('screenshotView.imageDeleted')} ratio={ratio} className={className} />;
+    return (
+      <ImagePlaceholder
+        label={i18n.t('screenshotView.imageDeleted')}
+        ratio={ratio}
+        className={className}
+        onUpload={readOnly ? undefined : handleReplaceFile}
+      />
+    );
   }
 
   if (!fullUrl) {

--- a/src/ui/shared/__tests__/image-placeholder.test.ts
+++ b/src/ui/shared/__tests__/image-placeholder.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import type { Screenshot } from '@/core/guides/types';
+import { dominantRatio } from '@/ui/shared/ImagePlaceholder';
+
+function makeScreenshot(id: string, overrides: Partial<Screenshot> = {}): Screenshot {
+  return {
+    id,
+    stepId: `step-${id}`,
+    blob: new Blob(['x']),
+    mimeType: 'image/png',
+    width: 1600,
+    height: 1000,
+    ...overrides,
+  };
+}
+
+function toMap(screenshots: Screenshot[]): Map<string, Screenshot> {
+  return new Map(screenshots.map((s) => [s.stepId, s]));
+}
+
+describe('dominantRatio', () => {
+  it('returns undefined for an empty map', () => {
+    expect(dominantRatio(new Map())).toBeUndefined();
+  });
+
+  it('returns the shared ratio when every screenshot matches', () => {
+    const map = toMap([makeScreenshot('a'), makeScreenshot('b'), makeScreenshot('c')]);
+    expect(dominantRatio(map)).toBeCloseTo(1.6, 5);
+  });
+
+  it('ignores an outlier that loses to the majority', () => {
+    const map = toMap([
+      makeScreenshot('portrait', { width: 800, height: 1400 }),
+      makeScreenshot('b'),
+      makeScreenshot('c'),
+    ]);
+    expect(dominantRatio(map)).toBeCloseTo(1.6, 5);
+  });
+
+  it('breaks a tie in favour of the earliest bucket', () => {
+    const map = toMap([
+      makeScreenshot('a'),
+      makeScreenshot('portrait-1', { width: 800, height: 1400 }),
+      makeScreenshot('b'),
+      makeScreenshot('portrait-2', { width: 800, height: 1400 }),
+    ]);
+    expect(dominantRatio(map)).toBeCloseTo(1.6, 5);
+  });
+
+  it('breaks a tie in favour of the earliest bucket when the outlier comes first', () => {
+    const map = toMap([
+      makeScreenshot('portrait-1', { width: 800, height: 1400 }),
+      makeScreenshot('a'),
+      makeScreenshot('portrait-2', { width: 800, height: 1400 }),
+      makeScreenshot('b'),
+    ]);
+    expect(dominantRatio(map)).toBeCloseTo(800 / 1400, 5);
+  });
+
+  it('returns an observed ratio rather than the rounded bucket key', () => {
+    const map = toMap([makeScreenshot('a', { width: 1366, height: 768 })]);
+    expect(dominantRatio(map)).toBe(1366 / 768);
+  });
+
+  it('buckets near-identical ratios together', () => {
+    const map = toMap([
+      makeScreenshot('a', { width: 1600, height: 1000 }),
+      makeScreenshot('b', { width: 1601, height: 1000 }),
+      makeScreenshot('portrait', { width: 800, height: 1400 }),
+    ]);
+    expect(dominantRatio(map)).toBeCloseTo(1.6, 5);
+  });
+
+  it('skips screenshots with zero or missing dimensions', () => {
+    const map = toMap([
+      makeScreenshot('zero-width', { width: 0, height: 1000 }),
+      makeScreenshot('zero-height', { width: 1600, height: 0 }),
+      makeScreenshot('missing', { width: undefined as unknown as number, height: undefined as unknown as number }),
+      makeScreenshot('portrait', { width: 800, height: 1400 }),
+    ]);
+    expect(dominantRatio(map)).toBeCloseTo(800 / 1400, 5);
+  });
+
+  it('returns undefined when no screenshot has usable dimensions', () => {
+    const map = toMap([makeScreenshot('a', { width: 0, height: 0 }), makeScreenshot('b', { width: 1600, height: 0 })]);
+    expect(dominantRatio(map)).toBeUndefined();
+  });
+
+  it('counts a cropped screenshot by its viewport rather than its original size', () => {
+    const map = toMap([
+      makeScreenshot('cropped-1', { edits: { viewport: { x: 0, y: 0, width: 500, height: 500 } } }),
+      makeScreenshot('cropped-2', { edits: { viewport: { x: 10, y: 10, width: 300, height: 300 } } }),
+      makeScreenshot('uncropped'),
+    ]);
+    expect(dominantRatio(map)).toBe(1);
+  });
+});

--- a/src/ui/sidepanel/GuideEditor.tsx
+++ b/src/ui/sidepanel/GuideEditor.tsx
@@ -236,6 +236,7 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
                 onDelete={handleDeleteStep}
                 onOpenEditor={(stepId, tool) => openInFullView(guideId, { stepId, tool })}
                 readOnly={!editing}
+                onChanged={loadGuide}
                 dragHandleProps={
                   editing
                     ? {

--- a/src/ui/sidepanel/GuideEditor.tsx
+++ b/src/ui/sidepanel/GuideEditor.tsx
@@ -174,7 +174,7 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
           >
             <Maximize2 size={15} />
           </button>
-          {data.steps.length > 0 && (
+          {!editing && data.steps.length > 0 && (
             <button
               onClick={async () => {
                 await sendMessage('startGuideMe', { guideId });

--- a/src/ui/sidepanel/GuideEditor.tsx
+++ b/src/ui/sidepanel/GuideEditor.tsx
@@ -18,7 +18,7 @@ import { getMostCommonDomain } from '@/lib/utils';
 import { Input } from '@/ui/components/ui/input';
 import EmptyGuideState from '@/ui/shared/EmptyGuideState';
 import FaviconImg from '@/ui/shared/FaviconImg';
-import { siblingRatio } from '@/ui/shared/ImagePlaceholder';
+import { dominantRatio, siblingRatio } from '@/ui/shared/ImagePlaceholder';
 import ExportMenu from './ExportMenu';
 import StepCard from './StepCard';
 
@@ -232,6 +232,7 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
                 step={step}
                 screenshot={data.screenshots.get(step.id)}
                 placeholderRatio={siblingRatio(data.screenshots)}
+                frameRatio={dominantRatio(data.screenshots)}
                 onDescriptionChange={handleDescriptionChange}
                 onDelete={handleDeleteStep}
                 onOpenEditor={(stepId, tool) => openInFullView(guideId, { stepId, tool })}

--- a/src/ui/sidepanel/GuideEditor.tsx
+++ b/src/ui/sidepanel/GuideEditor.tsx
@@ -1,11 +1,26 @@
-import { ArrowLeft, Layers, Maximize2, Play } from 'lucide-react';
+import { ArrowLeft, Check, History, Layers, Maximize2, MoreHorizontal, Pencil, Play } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { i18n } from '#imports';
-import { deleteStep, getGuide, reorderSteps, updateGuideTitle, updateStepDescription } from '@/core/guides/service';
+import {
+  createSnapshot,
+  deleteStep,
+  getGuide,
+  onGuidesChanged,
+  reorderSteps,
+  updateGuideTitle,
+  updateStepDescription,
+} from '@/core/guides/service';
 import type { Guide, Screenshot, Step } from '@/core/guides/types';
 import { createTab, focusWindow, getExtensionURL, queryTabs, updateTab } from '@/lib/browser-api';
+import { logger } from '@/lib/logger';
 import { sendMessage } from '@/lib/messaging';
 import { getMostCommonDomain } from '@/lib/utils';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/ui/components/ui/dropdown-menu';
 import { Input } from '@/ui/components/ui/input';
 import EmptyGuideState from '@/ui/shared/EmptyGuideState';
 import FaviconImg from '@/ui/shared/FaviconImg';
@@ -19,10 +34,21 @@ interface GuideEditorProps {
   onGuideMe?: (guideId: string) => void;
 }
 
+interface OpenInFullViewOptions {
+  stepId?: string;
+  tool?: 'annotate' | 'redact' | 'crop' | 'target';
+  history?: boolean;
+}
+
 interface GuideData {
   guide: Guide;
   steps: Step[];
   screenshots: Map<string, Screenshot>;
+}
+
+function flushFocusedField() {
+  const el = document.activeElement;
+  if (el instanceof HTMLTextAreaElement || el instanceof HTMLInputElement) el.blur();
 }
 
 export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorProps) {
@@ -30,6 +56,7 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
   const [title, setTitle] = useState('');
+  const [editing, setEditing] = useState(false);
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
@@ -48,6 +75,12 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
   useEffect(() => {
     loadGuide();
   }, [loadGuide]);
+
+  useEffect(() => {
+    return onGuidesChanged(() => {
+      if (!editing) loadGuide();
+    });
+  }, [editing, loadGuide]);
 
   const handleTitleBlur = useCallback(async () => {
     if (!data || title === data.guide.title) return;
@@ -79,23 +112,37 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
     [guideId, loadGuide],
   );
 
-  const openInFullView = useCallback(
-    (targetGuideId: string, stepId?: string, tool?: 'annotate' | 'redact' | 'crop' | 'target') => {
-      const params = new URLSearchParams({ guideId: targetGuideId });
-      if (stepId) params.set('stepId', stepId);
-      if (tool) params.set('tool', tool);
-      const url = getExtensionURL(`/fullview.html?${params.toString()}`);
-      queryTabs({ url: getExtensionURL('/fullview.html') }).then((tabs) => {
-        if (tabs.length > 0 && tabs[0].id) {
-          updateTab(tabs[0].id, { active: true, url });
-          if (tabs[0].windowId) focusWindow(tabs[0].windowId);
-        } else {
-          createTab({ url });
-        }
-      });
-    },
-    [],
-  );
+  const openInFullView = useCallback((targetGuideId: string, options?: OpenInFullViewOptions) => {
+    const params = new URLSearchParams({ guideId: targetGuideId });
+    if (options?.stepId) params.set('stepId', options.stepId);
+    if (options?.tool) params.set('tool', options.tool);
+    if (options?.history) params.set('history', '1');
+    const url = getExtensionURL(`/fullview.html?${params.toString()}`);
+    queryTabs({ url: getExtensionURL('/fullview.html') }).then((tabs) => {
+      if (tabs.length > 0 && tabs[0].id) {
+        updateTab(tabs[0].id, { active: true, url });
+        if (tabs[0].windowId) focusWindow(tabs[0].windowId);
+      } else {
+        createTab({ url });
+      }
+    });
+  }, []);
+
+  const toggleEditing = useCallback(() => {
+    if (editing) {
+      flushFocusedField();
+      setEditing(false);
+      return;
+    }
+    setEditing(true);
+    createSnapshot(guideId).catch((err) => logger.error(' Snapshot before editing failed', err));
+  }, [editing, guideId]);
+
+  const openVersionHistory = useCallback(() => {
+    flushFocusedField();
+    setEditing(false);
+    openInFullView(guideId, { history: true });
+  }, [guideId, openInFullView]);
 
   if (loading) return <p className="text-sm text-purple p-4">{i18n.t('common.loading')}</p>;
 
@@ -122,12 +169,18 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
           >
             <ArrowLeft size={18} />
           </button>
-          <Input
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            onBlur={handleTitleBlur}
-            className="text-lg font-bold bg-transparent border-0 border-b border-transparent hover:border-border focus-visible:ring-0 focus-visible:border-accent shadow-none p-0 h-auto text-foreground"
-          />
+          {editing ? (
+            <Input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              onBlur={handleTitleBlur}
+              className="text-lg font-bold bg-transparent border-0 border-b border-transparent hover:border-border focus-visible:ring-0 focus-visible:border-accent shadow-none p-0 h-auto text-foreground"
+            />
+          ) : (
+            <h2 className="flex-1 min-w-0 text-lg font-bold truncate text-foreground" title={title}>
+              {title}
+            </h2>
+          )}
           <button
             onClick={() => openInFullView(guideId)}
             className="shrink-0 p-1.5 rounded-md transition-colors text-purple hover:text-accent hover:bg-secondary"
@@ -148,8 +201,35 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
               <Play size={15} />
             </button>
           )}
-          <div className="ml-auto shrink-0">
+          <div className="ml-auto shrink-0 flex items-center gap-1">
+            <button
+              onClick={toggleEditing}
+              className="shrink-0 p-1.5 rounded-md transition-colors text-purple hover:text-accent hover:bg-secondary"
+              title={editing ? i18n.t('editor.done') : i18n.t('editor.edit')}
+              aria-label={editing ? i18n.t('editor.done') : i18n.t('editor.edit')}
+            >
+              {editing ? <Check size={15} /> : <Pencil size={15} />}
+            </button>
             <ExportMenu guideId={guideId} guide={data.guide} steps={data.steps} screenshots={data.screenshots} />
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  onPointerDown={flushFocusedField}
+                  className="shrink-0 p-1.5 rounded-md transition-colors text-purple hover:text-accent hover:bg-secondary"
+                  title={i18n.t('editor.moreActions')}
+                  aria-label={i18n.t('editor.moreActions')}
+                >
+                  <MoreHorizontal size={15} />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onSelect={openVersionHistory}>
+                  <History size={14} />
+                  {i18n.t('editor.versionHistory')}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
         <div className="text-[11px] flex items-center gap-2 text-muted-foreground" style={{ marginLeft: '34px' }}>
@@ -187,34 +267,39 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
                 placeholderRatio={siblingRatio(data.screenshots)}
                 onDescriptionChange={handleDescriptionChange}
                 onDelete={handleDeleteStep}
-                onOpenEditor={(stepId, tool) => openInFullView(guideId, stepId, tool)}
-                dragHandleProps={{
-                  onDragStart: (e: React.DragEvent) => {
-                    setDragIndex(idx);
-                    e.dataTransfer.effectAllowed = 'move';
-                  },
-                  onDragOver: (e: React.DragEvent) => {
-                    e.preventDefault();
-                    setDragOverIndex(idx);
-                  },
-                  onDragEnd: () => {
-                    if (dragIndex !== null && dragOverIndex !== null && dragIndex !== dragOverIndex) {
-                      setData((prev) => {
-                        if (!prev) return prev;
-                        const newSteps = [...prev.steps];
-                        const [moved] = newSteps.splice(dragIndex, 1);
-                        newSteps.splice(dragOverIndex, 0, moved);
-                        reorderSteps(
-                          guideId,
-                          newSteps.map((s) => s.id),
-                        );
-                        return { ...prev, steps: newSteps };
-                      });
-                    }
-                    setDragIndex(null);
-                    setDragOverIndex(null);
-                  },
-                }}
+                onOpenEditor={(stepId, tool) => openInFullView(guideId, { stepId, tool })}
+                readOnly={!editing}
+                dragHandleProps={
+                  editing
+                    ? {
+                        onDragStart: (e: React.DragEvent) => {
+                          setDragIndex(idx);
+                          e.dataTransfer.effectAllowed = 'move';
+                        },
+                        onDragOver: (e: React.DragEvent) => {
+                          e.preventDefault();
+                          setDragOverIndex(idx);
+                        },
+                        onDragEnd: () => {
+                          if (dragIndex !== null && dragOverIndex !== null && dragIndex !== dragOverIndex) {
+                            setData((prev) => {
+                              if (!prev) return prev;
+                              const newSteps = [...prev.steps];
+                              const [moved] = newSteps.splice(dragIndex, 1);
+                              newSteps.splice(dragOverIndex, 0, moved);
+                              reorderSteps(
+                                guideId,
+                                newSteps.map((s) => s.id),
+                              );
+                              return { ...prev, steps: newSteps };
+                            });
+                          }
+                          setDragIndex(null);
+                          setDragOverIndex(null);
+                        },
+                      }
+                    : undefined
+                }
               />
             </div>
           ))

--- a/src/ui/sidepanel/GuideEditor.tsx
+++ b/src/ui/sidepanel/GuideEditor.tsx
@@ -18,7 +18,7 @@ import { getMostCommonDomain } from '@/lib/utils';
 import { Input } from '@/ui/components/ui/input';
 import EmptyGuideState from '@/ui/shared/EmptyGuideState';
 import FaviconImg from '@/ui/shared/FaviconImg';
-import { dominantRatio, siblingRatio } from '@/ui/shared/ImagePlaceholder';
+import { dominantRatio } from '@/ui/shared/ImagePlaceholder';
 import ExportMenu from './ExportMenu';
 import StepCard from './StepCard';
 
@@ -231,7 +231,7 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
               <StepCard
                 step={step}
                 screenshot={data.screenshots.get(step.id)}
-                placeholderRatio={siblingRatio(data.screenshots)}
+                placeholderRatio={dominantRatio(data.screenshots)}
                 frameRatio={dominantRatio(data.screenshots)}
                 onDescriptionChange={handleDescriptionChange}
                 onDelete={handleDeleteStep}

--- a/src/ui/sidepanel/GuideEditor.tsx
+++ b/src/ui/sidepanel/GuideEditor.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Check, History, Layers, Maximize2, MoreHorizontal, Pencil, Play } from 'lucide-react';
+import { ArrowLeft, Check, Layers, Maximize2, Pencil, Play } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { i18n } from '#imports';
 import {
@@ -15,12 +15,6 @@ import { createTab, focusWindow, getExtensionURL, queryTabs, updateTab } from '@
 import { logger } from '@/lib/logger';
 import { sendMessage } from '@/lib/messaging';
 import { getMostCommonDomain } from '@/lib/utils';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/ui/components/ui/dropdown-menu';
 import { Input } from '@/ui/components/ui/input';
 import EmptyGuideState from '@/ui/shared/EmptyGuideState';
 import FaviconImg from '@/ui/shared/FaviconImg';
@@ -37,7 +31,6 @@ interface GuideEditorProps {
 interface OpenInFullViewOptions {
   stepId?: string;
   tool?: 'annotate' | 'redact' | 'crop' | 'target';
-  history?: boolean;
 }
 
 interface GuideData {
@@ -116,7 +109,6 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
     const params = new URLSearchParams({ guideId: targetGuideId });
     if (options?.stepId) params.set('stepId', options.stepId);
     if (options?.tool) params.set('tool', options.tool);
-    if (options?.history) params.set('history', '1');
     const url = getExtensionURL(`/fullview.html?${params.toString()}`);
     queryTabs({ url: getExtensionURL('/fullview.html') }).then((tabs) => {
       if (tabs.length > 0 && tabs[0].id) {
@@ -137,12 +129,6 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
     setEditing(true);
     createSnapshot(guideId).catch((err) => logger.error(' Snapshot before editing failed', err));
   }, [editing, guideId]);
-
-  const openVersionHistory = useCallback(() => {
-    flushFocusedField();
-    setEditing(false);
-    openInFullView(guideId, { history: true });
-  }, [guideId, openInFullView]);
 
   if (loading) return <p className="text-sm text-purple p-4">{i18n.t('common.loading')}</p>;
 
@@ -211,25 +197,6 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
               {editing ? <Check size={15} /> : <Pencil size={15} />}
             </button>
             <ExportMenu guideId={guideId} guide={data.guide} steps={data.steps} screenshots={data.screenshots} />
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  type="button"
-                  onPointerDown={flushFocusedField}
-                  className="shrink-0 p-1.5 rounded-md transition-colors text-purple hover:text-accent hover:bg-secondary"
-                  title={i18n.t('editor.moreActions')}
-                  aria-label={i18n.t('editor.moreActions')}
-                >
-                  <MoreHorizontal size={15} />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onSelect={openVersionHistory}>
-                  <History size={14} />
-                  {i18n.t('editor.versionHistory')}
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
           </div>
         </div>
         <div className="text-[11px] flex items-center gap-2 text-muted-foreground" style={{ marginLeft: '34px' }}>

--- a/src/ui/sidepanel/StepCard.tsx
+++ b/src/ui/sidepanel/StepCard.tsx
@@ -1,8 +1,9 @@
 import { Check, Copy, Trash2 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { i18n } from '#imports';
+import { replaceScreenshot } from '@/core/guides/service';
 import type { Screenshot, Step } from '@/core/guides/types';
-import { renderScreenshot } from '@/core/screenshot/render';
+import { imageDimensions, renderScreenshot } from '@/core/screenshot/render';
 import { logger } from '@/lib/logger';
 import ConfirmDialog from '@/ui/shared/ConfirmDialog';
 import ImagePlaceholder from '@/ui/shared/ImagePlaceholder';
@@ -71,6 +72,11 @@ export default function StepCard({
     }
   };
 
+  const handleUpload = async (file: File) => {
+    await replaceScreenshot(step.id, file, await imageDimensions(file));
+    onChanged?.();
+  };
+
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
     setDragOver(true);
@@ -116,6 +122,7 @@ export default function StepCard({
           label={i18n.t('editor.noScreenshot')}
           ratio={placeholderRatio}
           className="w-full !rounded-none border-x-0 border-t-0"
+          onUpload={readOnly ? undefined : handleUpload}
         />
       )}
 

--- a/src/ui/sidepanel/StepCard.tsx
+++ b/src/ui/sidepanel/StepCard.tsx
@@ -23,6 +23,7 @@ interface StepCardProps {
   onOpenEditor?: (stepId: string, tool: 'annotate' | 'redact' | 'crop' | 'target') => void;
   onCopy?: (stepId: string) => void;
   placeholderRatio?: number;
+  readOnly?: boolean;
 }
 
 export default function StepCard({
@@ -33,6 +34,7 @@ export default function StepCard({
   dragHandleProps,
   onOpenEditor,
   placeholderRatio,
+  readOnly,
 }: StepCardProps) {
   const [description, setDescription] = useState(step.description);
   const [dragOver, setDragOver] = useState(false);
@@ -100,7 +102,8 @@ export default function StepCard({
           alt={`Step ${step.index + 1} screenshot`}
           className="!rounded-none !border-0"
           crop
-          onOpenEditor={onOpenEditor ? (tool) => onOpenEditor(step.id, tool) : undefined}
+          readOnly={readOnly}
+          onOpenEditor={!readOnly && onOpenEditor ? (tool) => onOpenEditor(step.id, tool) : undefined}
         />
       ) : (
         <ImagePlaceholder
@@ -115,13 +118,19 @@ export default function StepCard({
           <span className="flex items-center justify-center w-[22px] h-[22px] rounded-full text-[11px] font-bold shrink-0 bg-primary text-primary-foreground">
             {step.index + 1}
           </span>
-          <textarea
-            className="w-full text-[13px] font-medium resize-none outline-none border-0 bg-transparent p-0 leading-snug flex-1 text-foreground"
-            value={description}
-            rows={1}
-            onChange={(e) => setDescription(e.target.value)}
-            onBlur={handleDescriptionBlur}
-          />
+          {readOnly ? (
+            <p className="text-[13px] font-medium leading-snug flex-1 text-foreground whitespace-pre-wrap">
+              {step.description}
+            </p>
+          ) : (
+            <textarea
+              className="w-full text-[13px] font-medium resize-none outline-none border-0 bg-transparent p-0 leading-snug flex-1 text-foreground"
+              value={description}
+              rows={1}
+              onChange={(e) => setDescription(e.target.value)}
+              onBlur={handleDescriptionBlur}
+            />
+          )}
         </div>
         <div className="flex items-center justify-end mt-1">
           <div className="flex items-center gap-0.5">
@@ -134,13 +143,15 @@ export default function StepCard({
                 {copied ? <Check size={13} /> : <Copy size={13} />}
               </button>
             )}
-            <button
-              onClick={() => setConfirmDelete(true)}
-              className="p-1 rounded-md transition-colors text-border hover:text-destructive"
-              title={i18n.t('recording.deleteStep')}
-            >
-              <Trash2 size={13} />
-            </button>
+            {!readOnly && (
+              <button
+                onClick={() => setConfirmDelete(true)}
+                className="p-1 rounded-md transition-colors text-border hover:text-destructive"
+                title={i18n.t('recording.deleteStep')}
+              >
+                <Trash2 size={13} />
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/src/ui/sidepanel/StepCard.tsx
+++ b/src/ui/sidepanel/StepCard.tsx
@@ -23,6 +23,7 @@ interface StepCardProps {
   onOpenEditor?: (stepId: string, tool: 'annotate' | 'redact' | 'crop' | 'target') => void;
   onCopy?: (stepId: string) => void;
   placeholderRatio?: number;
+  frameRatio?: number;
   readOnly?: boolean;
   onChanged?: () => void;
 }
@@ -35,6 +36,7 @@ export default function StepCard({
   dragHandleProps,
   onOpenEditor,
   placeholderRatio,
+  frameRatio,
   readOnly,
   onChanged,
 }: StepCardProps) {
@@ -104,6 +106,7 @@ export default function StepCard({
           alt={`Step ${step.index + 1} screenshot`}
           className="!rounded-none !border-0"
           crop
+          frameRatio={frameRatio}
           readOnly={readOnly}
           onOpenEditor={!readOnly && onOpenEditor ? (tool) => onOpenEditor(step.id, tool) : undefined}
           onChanged={onChanged}

--- a/src/ui/sidepanel/StepCard.tsx
+++ b/src/ui/sidepanel/StepCard.tsx
@@ -24,6 +24,7 @@ interface StepCardProps {
   onCopy?: (stepId: string) => void;
   placeholderRatio?: number;
   readOnly?: boolean;
+  onChanged?: () => void;
 }
 
 export default function StepCard({
@@ -35,6 +36,7 @@ export default function StepCard({
   onOpenEditor,
   placeholderRatio,
   readOnly,
+  onChanged,
 }: StepCardProps) {
   const [description, setDescription] = useState(step.description);
   const [dragOver, setDragOver] = useState(false);
@@ -104,6 +106,7 @@ export default function StepCard({
           crop
           readOnly={readOnly}
           onOpenEditor={!readOnly && onOpenEditor ? (tool) => onOpenEditor(step.id, tool) : undefined}
+          onChanged={onChanged}
         />
       ) : (
         <ImagePlaceholder

--- a/src/ui/sidepanel/__tests__/step-card-upload.test.tsx
+++ b/src/ui/sidepanel/__tests__/step-card-upload.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { Step } from '@/core/guides/types';
+
+vi.mock('@/core/guides/service', () => ({ replaceScreenshot: vi.fn() }));
+vi.mock('@/core/screenshot/render', () => ({ imageDimensions: vi.fn(), renderScreenshot: vi.fn() }));
+
+import StepCard from '../StepCard';
+
+const step: Step = {
+  id: 's1',
+  guideId: 'g1',
+  index: 0,
+  description: 'Click the thing',
+  action: 'click',
+  url: 'https://a.test',
+  timestamp: 1,
+};
+
+function renderCard(readOnly: boolean) {
+  return render(
+    <StepCard
+      step={step}
+      screenshot={undefined}
+      readOnly={readOnly}
+      onDescriptionChange={vi.fn()}
+      onDelete={vi.fn()}
+      onChanged={vi.fn()}
+    />,
+  );
+}
+
+describe('StepCard without a screenshot', () => {
+  it('offers an upload when the step is editable', () => {
+    renderCard(false);
+    expect(screen.getByRole('button', { name: /screenshotView.addImage/ })).toBeTruthy();
+  });
+
+  it('offers no upload when the step is read-only', () => {
+    renderCard(true);
+    expect(screen.queryByRole('button', { name: /screenshotView.addImage/ })).toBeNull();
+  });
+});


### PR DESCRIPTION
Guides were editable in place with no way back — a bad crop or a deleted screenshot was permanent. Editing now sits behind an explicit Edit mode, which snapshots the guide into a new Dexie `snapshots` table.

The history panel summarises what changed per version, names them, and reverts — the revert is itself a version, so it is undoable. Screenshot replace and delete are append-only, so reverting recovers the original image. Steps letterbox to the guide's dominant ratio, and PDF export clamps image height so a tall upload cannot overflow a page.

Still broken: exporting while previewing an old version exports the live guide. `contentHash` is key-order sensitive, so on pre-existing guides the summary and the "Unchanged versions" grouping can disagree.

`pnpm lint`, 377 tests, Chrome and Firefox builds clean; the one lint warning is pre-existing on dev.
