### PR TITLE
feat(editor): rewrite selected description text with AI

### DIFF
--- a/src/core/capture/ai/__tests__/rewrite.test.ts
+++ b/src/core/capture/ai/__tests__/rewrite.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { REWRITE_PRESETS } from '../prompts';
+import { buildRewritePrompt, cleanRewrite } from '../rewrite';
+
+describe('cleanRewrite', () => {
+  it('trims surrounding whitespace', () => {
+    expect(cleanRewrite('  Click the Submit button  ')).toBe('Click the Submit button');
+  });
+
+  it('unwraps a fully quoted response', () => {
+    expect(cleanRewrite('"Click the Submit button"')).toBe('Click the Submit button');
+  });
+
+  it('unwraps smart quotes', () => {
+    expect(cleanRewrite('“Click the Submit button”')).toBe('Click the Submit button');
+  });
+
+  it('keeps an unmatched leading quote', () => {
+    expect(cleanRewrite('"Submit" is the button label')).toBe('"Submit" is the button label');
+  });
+
+  it('keeps quotes that are internal to the text', () => {
+    expect(cleanRewrite('Select the "Admin" role')).toBe('Select the "Admin" role');
+  });
+
+  it('unwraps across multiple lines', () => {
+    expect(cleanRewrite('"line one\nline two"')).toBe('line one\nline two');
+  });
+
+  it('returns empty string for a blank response', () => {
+    expect(cleanRewrite('   ')).toBe('');
+  });
+});
+
+describe('buildRewritePrompt', () => {
+  it('substitutes the selected text and the instruction', () => {
+    const prompt = buildRewritePrompt('Click Save', 'Make it shorter.', 'en');
+    expect(prompt).toContain('Click Save');
+    expect(prompt).toContain('Make it shorter.');
+    expect(prompt).not.toContain('{{text}}');
+    expect(prompt).not.toContain('{{instruction}}');
+  });
+
+  it('does not interpret dollar patterns in the selected text', () => {
+    const prompt = buildRewritePrompt('Enter $& in the Amount field', 'Fix grammar.', 'en');
+    expect(prompt).toContain('Enter $& in the Amount field');
+  });
+
+  it('does not interpret dollar patterns in the instruction', () => {
+    const prompt = buildRewritePrompt('Click Save', 'Replace $1 with $`', 'en');
+    expect(prompt).toContain('Replace $1 with $`');
+  });
+
+  it('appends a language suffix for non-English locales', () => {
+    expect(buildRewritePrompt('Click Save', 'Make it shorter.', 'fr')).toContain('French');
+  });
+
+  it('appends nothing for English', () => {
+    expect(buildRewritePrompt('Click Save', 'Make it shorter.', 'en')).not.toContain('IMPORTANT');
+  });
+
+  it('forbids inventing UI elements', () => {
+    expect(buildRewritePrompt('Click Save', 'Expand it.', 'en')).toMatch(/never introduce a UI element/i);
+  });
+
+  it('works with every preset instruction', () => {
+    for (const instruction of Object.values(REWRITE_PRESETS)) {
+      expect(buildRewritePrompt('Click Save', instruction, 'en')).toContain(instruction);
+    }
+  });
+});

--- a/src/core/capture/ai/prompts.ts
+++ b/src/core/capture/ai/prompts.ts
@@ -30,6 +30,33 @@ Examples of good descriptions:
 - "Reset a locked-out user's password from the Okta admin panel. For IT support staff."
 - "Configure which Slack channels send desktop notifications, and set a do-not-disturb schedule."`;
 
+export const REWRITE_PROMPT = `You are editing one span of text inside a browser workflow guide. The text describes a step a reader must perform, or summarises what the workflow accomplishes.
+
+Selected text:
+"""
+{{text}}
+"""
+
+Instruction: {{instruction}}
+
+Rules:
+- Keep it imperative and describing a single action when the original does.
+- Never introduce a UI element, button, page, or value that is absent from the original.
+- Preserve specific names, labels, and quoted strings exactly as written.
+- Match the length the instruction implies; otherwise stay close to the original length.
+
+Return only the rewritten text. No preamble, no quotes, no explanation.`;
+
+export const REWRITE_PRESETS = {
+  shorter: 'Make it shorter and tighter without losing any required detail.',
+  detail: 'Add detail that clarifies the action, using only information already present.',
+  grammar: 'Fix grammar, spelling, and punctuation. Change nothing else.',
+  formal: 'Make the tone more formal and professional.',
+  casual: 'Make the tone more casual and conversational.',
+} as const;
+
+export type RewritePreset = keyof typeof REWRITE_PRESETS;
+
 export const AI_LANGUAGES = [
   { code: 'en', label: 'English' },
   { code: 'es', label: 'Español' },

--- a/src/core/capture/ai/rewrite.ts
+++ b/src/core/capture/ai/rewrite.ts
@@ -1,0 +1,48 @@
+import { generateText } from 'ai';
+import { localStorage } from '@/lib/browser-api';
+import { logger } from '@/lib/logger';
+import type { RewriteSelectionResponse } from '@/lib/messaging';
+import { AI_PROVIDERS } from './models';
+import { getLanguageSuffix, REWRITE_PROMPT } from './prompts';
+import { createModel } from './provider';
+
+const WRAPPED_IN_QUOTES = /^["“'](.*)["”']$/s;
+
+export function cleanRewrite(raw: string): string {
+  const trimmed = raw.trim();
+  const unwrapped = trimmed.match(WRAPPED_IN_QUOTES);
+  return (unwrapped ? unwrapped[1] : trimmed).trim();
+}
+
+export function buildRewritePrompt(text: string, instruction: string, locale: string): string {
+  return (
+    REWRITE_PROMPT.replace('{{text}}', () => text).replace('{{instruction}}', () => instruction) +
+    getLanguageSuffix(locale)
+  );
+}
+
+export async function rewriteSelection(text: string, instruction: string): Promise<RewriteSelectionResponse> {
+  const settings = await localStorage.get(['aiApiKey', 'aiProvider', 'aiModel', 'aiLanguage']);
+  if (!settings.aiApiKey) return { error: 'no-api-key' };
+
+  const provider = (settings.aiProvider as string) || 'openai';
+
+  try {
+    const { text: raw } = await generateText({
+      model: createModel(
+        provider,
+        (settings.aiModel as string) || AI_PROVIDERS[provider].defaultModel,
+        settings.aiApiKey as string,
+      ),
+      prompt: buildRewritePrompt(text, instruction, (settings.aiLanguage as string) || 'en'),
+      maxOutputTokens: 400,
+    });
+
+    const cleaned = cleanRewrite(raw);
+    if (!cleaned) return { error: 'generation-failed' };
+    return { text: cleaned };
+  } catch (err) {
+    logger.error('Selection rewrite failed', err);
+    return { error: 'generation-failed' };
+  }
+}

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -1,4 +1,5 @@
 import { browser, defineBackground } from '#imports';
+import { rewriteSelection } from '@/core/capture/ai/rewrite';
 import { validateApiKey } from '@/core/capture/ai/validate';
 import { stepRequiresManual } from '@/core/guideme/manual';
 import { advanceSession, cancelSession, completeSession, getSession, startSession } from '@/core/guideme/session';
@@ -132,6 +133,8 @@ export default defineBackground(() => {
   onMessage('generateGuideDescription', ({ data }) => generateDescriptionOnDemand(data.guideId));
 
   onMessage('validateApiKey', ({ data }) => validateApiKey(data.provider, data.apiKey));
+
+  onMessage('rewriteSelection', ({ data }) => rewriteSelection(data.text, data.instruction));
 
   onMessage('captureStep', async ({ data }) => {
     await waitUntilReady();

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -92,6 +92,18 @@ export interface GenerateGuideDescriptionResponse {
   error?: GuideDescriptionError;
 }
 
+export type RewriteError = 'no-api-key' | 'generation-failed';
+
+export interface RewriteSelectionData {
+  text: string;
+  instruction: string;
+}
+
+export interface RewriteSelectionResponse {
+  text?: string;
+  error?: RewriteError;
+}
+
 export interface ValidateApiKeyData {
   provider: string;
   apiKey: string;
@@ -125,6 +137,7 @@ interface MimikProtocol {
   exitBlurMode(): ExitBlurModeResponse;
   generateGuideDescription(data: GenerateGuideDescriptionData): GenerateGuideDescriptionResponse;
   validateApiKey(data: ValidateApiKeyData): ValidateApiKeyResponse;
+  rewriteSelection(data: RewriteSelectionData): RewriteSelectionResponse;
 }
 
 export const { sendMessage, onMessage } = defineExtensionMessaging<MimikProtocol>();

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -162,6 +162,19 @@ editor:
   done: Fertig
   versionHistory: Versionsverlauf
   moreActions: Weitere Aktionen
+  rewriteAskAi: KI fragen
+  rewritePlaceholder: "Sag der KI, wie dieser Text bearbeitet werden soll…"
+  rewriteEnter: Enter
+  rewriteShorter: Kürzer
+  rewriteDetail: Mehr Details
+  rewriteGrammar: Grammatik korrigieren
+  rewriteFormal: Förmlicher
+  rewriteCasual: Lockerer
+  rewriteReplace: Ersetzen
+  rewriteDiscard: Verwerfen
+  rewriteErrorNoApiKey: Füge in den Einstellungen einen KI-API-Schlüssel hinzu, um Text umzuschreiben.
+  rewriteErrorFailed: Die Auswahl konnte nicht umgeschrieben werden. Versuche es erneut.
+  rewriteErrorStale: Der Text hat sich geändert. Wähle ihn erneut aus.
 
 history:
   title: Versionsverlauf

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -107,6 +107,9 @@ settings:
   starCtaTitle: "Gefällt dir, was du siehst?"
   starCtaMessage: Ein Stern auf GitHub hilft anderen, Mimik zu finden, und hält uns motiviert!
   starOnGithub: Auf GitHub favorisieren
+  validatingKey: "Schlüssel wird geprüft…"
+  keyValid: API-Schlüssel bestätigt.
+  keyInvalid: Dieser API-Schlüssel wurde abgelehnt. Prüfe ihn und versuche es erneut.
 
 blurPresets:
   email: E-Mail
@@ -128,6 +131,7 @@ fullview:
   stepCount: "$1 Schritt"
   stepCountPlural: "$1 Schritte"
   pageOf: "$1 / $2"
+  writingDescription: "Beschreibung wird geschrieben…"
 
 sort:
   recentFirst: Neueste zuerst
@@ -175,6 +179,15 @@ editor:
   rewriteErrorNoApiKey: Füge in den Einstellungen einen KI-API-Schlüssel hinzu, um Text umzuschreiben.
   rewriteErrorFailed: Die Auswahl konnte nicht umgeschrieben werden. Versuche es erneut.
   rewriteErrorStale: Der Text hat sich geändert. Wähle ihn erneut aus.
+  generateDescription: Beschreibung erstellen
+  regenerateDescription: Beschreibung neu erstellen
+  generatingDescription: "Wird erstellt…"
+  descriptionPlaceholder: Beschreibung hinzufügen
+  descriptionErrorNoApiKey: Füge in den Einstellungen einen KI-API-Schlüssel hinzu, um Beschreibungen zu erstellen.
+  descriptionErrorNoSteps: Diese Anleitung hat keine beschriebenen Schritte zum Zusammenfassen.
+  descriptionErrorFailed: Beschreibung konnte nicht erstellt werden. Versuche es erneut.
+  descriptionErrorSaveFailed: Die Beschreibung wurde erstellt, konnte aber nicht gespeichert werden. Versuche es erneut.
+  writingStepDescription: "Beschreibung wird geschrieben…"
 
 history:
   title: Versionsverlauf
@@ -240,11 +253,16 @@ exportPreview:
   download: "$1 exportieren"
   rendering: "Vorschau wird aktualisiert"
   truncated: "Vorschau zeigt die ersten $1 von $2 Schritten"
+  modeDocument: "Dokument"
+  modeVideo: "Video"
+  encodingVideo: "Videovorschau wird erstellt"
+  videoFailed: "Die Videovorschau konnte nicht erstellt werden"
 exportMenu:
   docx: "DOCX"
   html: HTML
   markdown: Markdown
   pdf: PDF
+  video: Video
 
 onboarding:
   welcomeBadge: Willkommen

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -175,6 +175,19 @@ editor:
   descriptionErrorFailed: Could not generate a description. Try again.
   descriptionErrorSaveFailed: Generated the description but could not save it. Try again.
   writingStepDescription: "Writing description\u2026"
+  rewriteAskAi: Ask AI
+  rewritePlaceholder: "Tell AI how to edit this text\u2026"
+  rewriteEnter: Enter
+  rewriteShorter: Shorter
+  rewriteDetail: More detail
+  rewriteGrammar: Fix grammar
+  rewriteFormal: More formal
+  rewriteCasual: More casual
+  rewriteReplace: Replace
+  rewriteDiscard: Discard
+  rewriteErrorNoApiKey: Add an AI API key in settings to rewrite text.
+  rewriteErrorFailed: Could not rewrite the selection. Try again.
+  rewriteErrorStale: The text changed. Select it again.
 
 history:
   title: Version History

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -166,6 +166,15 @@ editor:
   done: Done
   versionHistory: Version history
   moreActions: More actions
+  generateDescription: Generate description
+  regenerateDescription: Regenerate description
+  generatingDescription: "Generating\u2026"
+  descriptionPlaceholder: Add a description
+  descriptionErrorNoApiKey: Add an AI API key in settings to generate descriptions.
+  descriptionErrorNoSteps: This guide has no described steps to summarise.
+  descriptionErrorFailed: Could not generate a description. Try again.
+  descriptionErrorSaveFailed: Generated the description but could not save it. Try again.
+  writingStepDescription: "Writing description\u2026"
 
 history:
   title: Version History
@@ -202,15 +211,6 @@ history:
   changeImageBlurred: "$1 image blurred"
   changeImagesBlurred: "$1 images blurred"
   changeAltText: Alt text edited
-  generateDescription: Generate description
-  regenerateDescription: Regenerate description
-  generatingDescription: "Generating\u2026"
-  descriptionPlaceholder: Add a description
-  descriptionErrorNoApiKey: Add an AI API key in settings to generate descriptions.
-  descriptionErrorNoSteps: This guide has no described steps to summarise.
-  descriptionErrorFailed: Could not generate a description. Try again.
-  descriptionErrorSaveFailed: Generated the description but could not save it. Try again.
-  writingStepDescription: "Writing description\u2026"
 
 emptyGuide:
   title: This guide is empty

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -166,6 +166,15 @@ editor:
   done: Listo
   versionHistory: Historial de versiones
   moreActions: Más acciones
+  generateDescription: Generar descripción
+  regenerateDescription: Regenerar descripción
+  generatingDescription: "Generando\u2026"
+  descriptionPlaceholder: Añadir una descripción
+  descriptionErrorNoApiKey: Añade una clave de API de IA en los ajustes para generar descripciones.
+  descriptionErrorNoSteps: Esta guía no tiene pasos descritos que resumir.
+  descriptionErrorFailed: No se pudo generar una descripción. Inténtalo de nuevo.
+  descriptionErrorSaveFailed: Se generó la descripción pero no se pudo guardar. Inténtalo de nuevo.
+  writingStepDescription: "Escribiendo descripci\xF3n\u2026"
 
 history:
   title: Historial de versiones
@@ -202,15 +211,6 @@ history:
   changeImageBlurred: "$1 imagen desenfocada"
   changeImagesBlurred: "$1 imágenes desenfocadas"
   changeAltText: Texto alternativo editado
-  generateDescription: Generar descripción
-  regenerateDescription: Regenerar descripción
-  generatingDescription: "Generando\u2026"
-  descriptionPlaceholder: Añadir una descripción
-  descriptionErrorNoApiKey: Añade una clave de API de IA en los ajustes para generar descripciones.
-  descriptionErrorNoSteps: Esta guía no tiene pasos descritos que resumir.
-  descriptionErrorFailed: No se pudo generar una descripción. Inténtalo de nuevo.
-  descriptionErrorSaveFailed: Se generó la descripción pero no se pudo guardar. Inténtalo de nuevo.
-  writingStepDescription: "Escribiendo descripci\xF3n\u2026"
 
 emptyGuide:
   title: Esta guía está vacía

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -103,7 +103,7 @@ settings:
   saved: Guardado
   validatingKey: "Comprobando clave\u2026"
   keyValid: Clave de API verificada.
-  keyInvalid: Esa clave de API fue rechazada. Compru\xE9bala e int\xE9ntalo de nuevo.
+  keyInvalid: "Esa clave de API fue rechazada. Compru\xE9bala e int\xE9ntalo de nuevo."
   smartBlur: Desenfoque inteligente
   privacyNotice: Tu clave API se guarda en tu navegador y solo se envía al proveedor de IA que elijas. Nada más sale de aquí.
   bugReport: "¿Encontraste un bug? Repórtalo en GitHub"

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -175,6 +175,19 @@ editor:
   descriptionErrorFailed: No se pudo generar una descripción. Inténtalo de nuevo.
   descriptionErrorSaveFailed: Se generó la descripción pero no se pudo guardar. Inténtalo de nuevo.
   writingStepDescription: "Escribiendo descripci\xF3n\u2026"
+  rewriteAskAi: Preguntar a la IA
+  rewritePlaceholder: "Dile a la IA c\xF3mo editar este texto\u2026"
+  rewriteEnter: Intro
+  rewriteShorter: "M\xE1s corto"
+  rewriteDetail: "M\xE1s detalle"
+  rewriteGrammar: "Corregir gram\xE1tica"
+  rewriteFormal: "M\xE1s formal"
+  rewriteCasual: "M\xE1s informal"
+  rewriteReplace: Reemplazar
+  rewriteDiscard: Descartar
+  rewriteErrorNoApiKey: "A\xF1ade una clave de API de IA en los ajustes para reescribir texto."
+  rewriteErrorFailed: "No se pudo reescribir la selecci\xF3n. Int\xE9ntalo de nuevo."
+  rewriteErrorStale: "El texto cambi\xF3. Vuelve a seleccionarlo."
 
 history:
   title: Historial de versiones

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -166,6 +166,15 @@ editor:
   done: Terminé
   versionHistory: Historique des versions
   moreActions: "Plus d'actions"
+  generateDescription: "Générer une description"
+  regenerateDescription: "Régénérer la description"
+  generatingDescription: "Génération\u2026"
+  descriptionPlaceholder: "Ajouter une description"
+  descriptionErrorNoApiKey: "Ajoutez une clé API d'IA dans les paramètres pour générer des descriptions."
+  descriptionErrorNoSteps: "Ce guide n'a aucune étape décrite à résumer."
+  descriptionErrorFailed: "Impossible de générer une description. Réessayez."
+  descriptionErrorSaveFailed: "Description générée mais impossible de l'enregistrer. Réessayez."
+  writingStepDescription: "R\xE9daction de la description\u2026"
 
 history:
   title: Historique des versions
@@ -202,15 +211,6 @@ history:
   changeImageBlurred: "$1 image floutée"
   changeImagesBlurred: "$1 images floutées"
   changeAltText: Texte alternatif modifié
-  generateDescription: "Générer une description"
-  regenerateDescription: "Régénérer la description"
-  generatingDescription: "Génération\u2026"
-  descriptionPlaceholder: "Ajouter une description"
-  descriptionErrorNoApiKey: "Ajoutez une clé API d'IA dans les paramètres pour générer des descriptions."
-  descriptionErrorNoSteps: "Ce guide n'a aucune étape décrite à résumer."
-  descriptionErrorFailed: "Impossible de générer une description. Réessayez."
-  descriptionErrorSaveFailed: "Description générée mais impossible de l'enregistrer. Réessayez."
-  writingStepDescription: "R\xE9daction de la description\u2026"
 
 emptyGuide:
   title: Ce guide est vide

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -175,6 +175,19 @@ editor:
   descriptionErrorFailed: "Impossible de générer une description. Réessayez."
   descriptionErrorSaveFailed: "Description générée mais impossible de l'enregistrer. Réessayez."
   writingStepDescription: "R\xE9daction de la description\u2026"
+  rewriteAskAi: "Demander \xE0 l'IA"
+  rewritePlaceholder: "Dites \xE0 l'IA comment modifier ce texte\u2026"
+  rewriteEnter: "Entr\xE9e"
+  rewriteShorter: Plus court
+  rewriteDetail: "Plus de d\xE9tails"
+  rewriteGrammar: Corriger la grammaire
+  rewriteFormal: Plus formel
+  rewriteCasual: "Plus d\xE9contract\xE9"
+  rewriteReplace: Remplacer
+  rewriteDiscard: Abandonner
+  rewriteErrorNoApiKey: "Ajoutez une cl\xE9 d'API d'IA dans les r\xE9glages pour r\xE9\xE9crire du texte."
+  rewriteErrorFailed: "Impossible de r\xE9\xE9crire la s\xE9lection. R\xE9essayez."
+  rewriteErrorStale: "Le texte a chang\xE9. S\xE9lectionnez-le \xE0 nouveau."
 
 history:
   title: Historique des versions

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -102,8 +102,8 @@ settings:
   saveSettings: "Enregistrer"
   saved: "Enregistré"
   validatingKey: "V\xE9rification de la cl\xE9\u2026"
-  keyValid: Cl\xE9 API v\xE9rifi\xE9e.
-  keyInvalid: Cette cl\xE9 API a \xE9t\xE9 refus\xE9e. V\xE9rifiez-la et r\xE9essayez.
+  keyValid: "Cl\xE9 API v\xE9rifi\xE9e."
+  keyInvalid: "Cette cl\xE9 API a \xE9t\xE9 refus\xE9e. V\xE9rifiez-la et r\xE9essayez."
   smartBlur: Flou intelligent
   privacyNotice: "Votre clé API reste dans votre navigateur et n'est envoyée qu'au fournisseur IA choisi. Rien d'autre ne sort d'ici."
   bugReport: "Un bug ? Signalez-le sur GitHub"

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -175,6 +175,19 @@ editor:
   descriptionErrorFailed: Não foi possível gerar uma descrição. Tente novamente.
   descriptionErrorSaveFailed: A descrição foi gerada mas não foi possível salvá-la. Tente novamente.
   writingStepDescription: "Escrevendo descri\xE7\xE3o\u2026"
+  rewriteAskAi: "Perguntar \xE0 IA"
+  rewritePlaceholder: "Diga \xE0 IA como editar este texto\u2026"
+  rewriteEnter: Enter
+  rewriteShorter: Mais curto
+  rewriteDetail: Mais detalhes
+  rewriteGrammar: "Corrigir gram\xE1tica"
+  rewriteFormal: Mais formal
+  rewriteCasual: Mais informal
+  rewriteReplace: Substituir
+  rewriteDiscard: Descartar
+  rewriteErrorNoApiKey: Adicione uma chave de API de IA nos ajustes para reescrever textos.
+  rewriteErrorFailed: "N\xE3o foi poss\xEDvel reescrever a sele\xE7\xE3o. Tente novamente."
+  rewriteErrorStale: O texto mudou. Selecione-o novamente.
 
 history:
   title: Histórico de versões

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -166,6 +166,15 @@ editor:
   done: Pronto
   versionHistory: Histórico de versões
   moreActions: Mais ações
+  generateDescription: Gerar descrição
+  regenerateDescription: Regenerar descrição
+  generatingDescription: "Gerando\u2026"
+  descriptionPlaceholder: Adicionar uma descrição
+  descriptionErrorNoApiKey: Adicione uma chave de API de IA nos ajustes para gerar descrições.
+  descriptionErrorNoSteps: Este guia não tem etapas descritas para resumir.
+  descriptionErrorFailed: Não foi possível gerar uma descrição. Tente novamente.
+  descriptionErrorSaveFailed: A descrição foi gerada mas não foi possível salvá-la. Tente novamente.
+  writingStepDescription: "Escrevendo descri\xE7\xE3o\u2026"
 
 history:
   title: Histórico de versões
@@ -202,15 +211,6 @@ history:
   changeImageBlurred: "$1 imagem desfocada"
   changeImagesBlurred: "$1 imagens desfocadas"
   changeAltText: Texto alternativo editado
-  generateDescription: Gerar descrição
-  regenerateDescription: Regenerar descrição
-  generatingDescription: "Gerando\u2026"
-  descriptionPlaceholder: Adicionar uma descrição
-  descriptionErrorNoApiKey: Adicione uma chave de API de IA nos ajustes para gerar descrições.
-  descriptionErrorNoSteps: Este guia não tem etapas descritas para resumir.
-  descriptionErrorFailed: Não foi possível gerar uma descrição. Tente novamente.
-  descriptionErrorSaveFailed: A descrição foi gerada mas não foi possível salvá-la. Tente novamente.
-  writingStepDescription: "Escrevendo descri\xE7\xE3o\u2026"
 
 emptyGuide:
   title: Esse guia tá vazio

--- a/src/ui/fullview/GuideContent.tsx
+++ b/src/ui/fullview/GuideContent.tsx
@@ -20,6 +20,7 @@ import { sendMessage } from '@/lib/messaging';
 import { formatDate, getMostCommonDomain } from '@/lib/utils';
 import { useFullview } from '@/stores/fullview';
 import AnnotationEditor from '@/ui/shared/AnnotationEditor';
+import { useAskAi } from '@/ui/shared/AskAi';
 import FaviconImg from '@/ui/shared/FaviconImg';
 import { guideDescriptionErrorMessage } from '@/ui/shared/guide-description-error';
 import Toast from '@/ui/shared/Toast';
@@ -146,6 +147,17 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
     }
     editingDescriptionRef.current = false;
   }, [data, guideId, description]);
+
+  const commitGuideDescription = useCallback(
+    (next: string) => {
+      setDescription(next);
+      void updateGuideDescription(guideId, next);
+      setData((prev) => (prev ? { ...prev, guide: { ...prev.guide, description: next } } : prev));
+    },
+    [guideId],
+  );
+
+  const askAi = useAskAi(description, commitGuideDescription, hasApiKey);
 
   const handleGenerateDescription = useCallback(async () => {
     setGenerating(true);
@@ -363,28 +375,32 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
                 </div>
               ) : editing ? (
                 <div className="flex items-start gap-2 max-w-[720px]">
-                  <textarea
-                    ref={(el) => {
-                      if (el) {
+                  <div className="flex-1 min-w-0">
+                    <textarea
+                      ref={(el) => {
+                        if (el) {
+                          el.style.height = '0';
+                          el.style.height = `${el.scrollHeight}px`;
+                        }
+                      }}
+                      value={description}
+                      rows={2}
+                      onChange={(e) => {
+                        setDescription(e.target.value);
+                        const el = e.target;
                         el.style.height = '0';
                         el.style.height = `${el.scrollHeight}px`;
-                      }
-                    }}
-                    value={description}
-                    rows={2}
-                    onChange={(e) => {
-                      setDescription(e.target.value);
-                      const el = e.target;
-                      el.style.height = '0';
-                      el.style.height = `${el.scrollHeight}px`;
-                    }}
-                    onFocus={() => {
-                      editingDescriptionRef.current = true;
-                    }}
-                    onBlur={handleGuideDescriptionBlur}
-                    placeholder={i18n.t('editor.descriptionPlaceholder')}
-                    className="flex-1 resize-none overflow-hidden bg-transparent p-0 text-[15px] leading-relaxed text-muted-foreground placeholder:text-muted-foreground/60 border-b-2 border-transparent hover:border-border focus:outline-none focus:border-accent"
-                  />
+                      }}
+                      onFocus={() => {
+                        editingDescriptionRef.current = true;
+                      }}
+                      onSelect={askAi.onSelect}
+                      onBlur={handleGuideDescriptionBlur}
+                      placeholder={i18n.t('editor.descriptionPlaceholder')}
+                      className="w-full resize-none overflow-hidden bg-transparent p-0 text-[15px] leading-relaxed text-muted-foreground placeholder:text-muted-foreground/60 border-b-2 border-transparent hover:border-border focus:outline-none focus:border-accent"
+                    />
+                    {askAi.panel}
+                  </div>
                   {hasApiKey && (
                     <button
                       type="button"
@@ -451,6 +467,7 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
             onOpenEditor={handleOpenEditor}
             onReorder={(newSteps) => setData((prev) => (prev ? { ...prev, steps: newSteps } : prev))}
             readOnly={!editing || preview !== null}
+            hasApiKey={hasApiKey}
             onChanged={loadGuide}
           />
         </div>

--- a/src/ui/fullview/GuideContent.tsx
+++ b/src/ui/fullview/GuideContent.tsx
@@ -375,32 +375,30 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
                 </div>
               ) : editing ? (
                 <div className="flex items-start gap-2 max-w-[720px]">
-                  <div className="flex-1 min-w-0">
-                    <textarea
-                      ref={(el) => {
-                        if (el) {
-                          el.style.height = '0';
-                          el.style.height = `${el.scrollHeight}px`;
-                        }
-                      }}
-                      value={description}
-                      rows={2}
-                      onChange={(e) => {
-                        setDescription(e.target.value);
-                        const el = e.target;
+                  <textarea
+                    ref={(el) => {
+                      if (el) {
                         el.style.height = '0';
                         el.style.height = `${el.scrollHeight}px`;
-                      }}
-                      onFocus={() => {
-                        editingDescriptionRef.current = true;
-                      }}
-                      onSelect={askAi.onSelect}
-                      onBlur={handleGuideDescriptionBlur}
-                      placeholder={i18n.t('editor.descriptionPlaceholder')}
-                      className="w-full resize-none overflow-hidden bg-transparent p-0 text-[15px] leading-relaxed text-muted-foreground placeholder:text-muted-foreground/60 border-b-2 border-transparent hover:border-border focus:outline-none focus:border-accent"
-                    />
-                    {askAi.panel}
-                  </div>
+                      }
+                    }}
+                    value={description}
+                    rows={2}
+                    onChange={(e) => {
+                      setDescription(e.target.value);
+                      const el = e.target;
+                      el.style.height = '0';
+                      el.style.height = `${el.scrollHeight}px`;
+                    }}
+                    onFocus={() => {
+                      editingDescriptionRef.current = true;
+                    }}
+                    onSelect={askAi.onSelect}
+                    onBlur={handleGuideDescriptionBlur}
+                    placeholder={i18n.t('editor.descriptionPlaceholder')}
+                    className="flex-1 resize-none overflow-hidden bg-transparent p-0 text-[15px] leading-relaxed text-muted-foreground placeholder:text-muted-foreground/60 border-b-2 border-transparent hover:border-border focus:outline-none focus:border-accent"
+                  />
+                  {hasApiKey && <span className="shrink-0 mt-0.5">{askAi.trigger}</span>}
                   {hasApiKey && (
                     <button
                       type="button"

--- a/src/ui/fullview/components/GuideStepList.tsx
+++ b/src/ui/fullview/components/GuideStepList.tsx
@@ -16,6 +16,7 @@ interface GuideStepListProps {
   onReorder: (newSteps: Step[]) => void;
   readOnly?: boolean;
   onChanged?: () => void;
+  hasApiKey?: boolean;
 }
 
 export default function GuideStepList({
@@ -28,6 +29,7 @@ export default function GuideStepList({
   onReorder,
   readOnly,
   onChanged,
+  hasApiKey,
 }: GuideStepListProps) {
   const { scrollToStepId, setActiveStepId } = useFullview((s) => ({
     scrollToStepId: s.scrollToStepId,
@@ -103,6 +105,7 @@ export default function GuideStepList({
             onDelete={onDelete}
             onOpenEditor={onOpenEditor}
             readOnly={readOnly}
+            hasApiKey={hasApiKey}
             onChanged={onChanged}
             dragHandleProps={
               readOnly

--- a/src/ui/shared/AskAi.tsx
+++ b/src/ui/shared/AskAi.tsx
@@ -1,0 +1,177 @@
+import { Loader2, Sparkles } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { i18n } from '#imports';
+import { REWRITE_PRESETS, type RewritePreset } from '@/core/capture/ai/prompts';
+import { sendMessage } from '@/lib/messaging';
+import { rewriteErrorMessage } from '@/ui/shared/rewrite-error';
+import Toast from '@/ui/shared/Toast';
+
+const PRESET_LABEL_KEYS = {
+  shorter: 'editor.rewriteShorter',
+  detail: 'editor.rewriteDetail',
+  grammar: 'editor.rewriteGrammar',
+  formal: 'editor.rewriteFormal',
+  casual: 'editor.rewriteCasual',
+} as const satisfies Record<RewritePreset, string>;
+
+const PRESET_ORDER = Object.keys(PRESET_LABEL_KEYS) as RewritePreset[];
+
+interface Span {
+  start: number;
+  end: number;
+  lead: string;
+  core: string;
+  trail: string;
+}
+
+function readSpan(value: string, start: number, end: number): Span | null {
+  const raw = value.slice(start, end);
+  const core = raw.trim();
+  if (!core) return null;
+  const lead = raw.slice(0, raw.indexOf(core[0]));
+  return { start, end, lead, core, trail: raw.slice(lead.length + core.length) };
+}
+
+export function useAskAi(value: string, onReplace: (next: string) => void, enabled = true) {
+  const [span, setSpan] = useState<Span | null>(null);
+  const [active, setActive] = useState<Span | null>(null);
+  const [instruction, setInstruction] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (active && result === null) inputRef.current?.focus();
+  }, [active, result]);
+
+  const reset = useCallback(() => {
+    setActive(null);
+    setSpan(null);
+    setInstruction('');
+    setResult(null);
+  }, []);
+
+  const onSelect = useCallback((e: React.SyntheticEvent<HTMLTextAreaElement>) => {
+    const el = e.currentTarget;
+    setSpan(readSpan(el.value, el.selectionStart, el.selectionEnd));
+  }, []);
+
+  const run = useCallback(
+    async (target: Span, prompt: string) => {
+      if (!prompt.trim() || busy) return;
+      setBusy(true);
+      setError(null);
+      try {
+        const response = await sendMessage('rewriteSelection', { text: target.core, instruction: prompt });
+        if (response.error) {
+          setError(rewriteErrorMessage(response.error));
+          return;
+        }
+        if (response.text) setResult(response.text);
+      } catch {
+        setError(rewriteErrorMessage('generation-failed'));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [busy],
+  );
+
+  const replace = useCallback(() => {
+    if (!active || !result) return;
+    if (value.slice(active.start, active.end) !== active.lead + active.core + active.trail) {
+      setError(i18n.t('editor.rewriteErrorStale'));
+      reset();
+      return;
+    }
+    onReplace(value.slice(0, active.start) + active.lead + result + active.trail + value.slice(active.end));
+    reset();
+  }, [active, result, value, onReplace, reset]);
+
+  const panel = !enabled ? null : (
+    <>
+      {span && !active && (
+        <button
+          type="button"
+          onClick={() => setActive(span)}
+          className="mt-1 flex items-center gap-1 text-[11px] font-medium text-accent hover:text-deep"
+        >
+          <Sparkles size={11} />
+          {i18n.t('editor.rewriteAskAi')}
+        </button>
+      )}
+
+      {active && (
+        <div className="mt-1.5 rounded-lg border border-border bg-card overflow-hidden">
+          {result === null ? (
+            <>
+              <div className="flex items-center gap-1.5 px-2 py-1.5 border-b border-border">
+                <Sparkles size={12} className="shrink-0 text-accent" />
+                <input
+                  ref={inputRef}
+                  value={instruction}
+                  disabled={busy}
+                  onChange={(e) => setInstruction(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      void run(active, instruction);
+                    }
+                    if (e.key === 'Escape') reset();
+                  }}
+                  placeholder={i18n.t('editor.rewritePlaceholder')}
+                  className="flex-1 min-w-0 bg-transparent p-0 text-[12px] text-foreground placeholder:text-muted-foreground/60 focus:outline-none disabled:opacity-50"
+                />
+                {busy ? (
+                  <Loader2 size={12} className="shrink-0 animate-spin text-accent" />
+                ) : (
+                  <span className="shrink-0 text-[10px] text-muted-foreground">{i18n.t('editor.rewriteEnter')}</span>
+                )}
+              </div>
+              <div className="py-1">
+                {PRESET_ORDER.map((preset) => (
+                  <button
+                    key={preset}
+                    type="button"
+                    disabled={busy}
+                    onClick={() => void run(active, REWRITE_PRESETS[preset])}
+                    className="w-full px-2.5 py-1 text-left text-[12px] text-foreground hover:bg-secondary disabled:opacity-50"
+                  >
+                    {i18n.t(PRESET_LABEL_KEYS[preset])}
+                  </button>
+                ))}
+              </div>
+            </>
+          ) : (
+            <>
+              <p className="px-2.5 py-2 text-[12px] leading-snug text-foreground whitespace-pre-wrap border-b border-border">
+                {result}
+              </p>
+              <div className="flex items-center gap-1 px-2 py-1.5">
+                <button
+                  type="button"
+                  onClick={replace}
+                  className="rounded-md bg-accent px-2 py-1 text-[11px] font-medium text-primary-foreground hover:bg-deep"
+                >
+                  {i18n.t('editor.rewriteReplace')}
+                </button>
+                <button
+                  type="button"
+                  onClick={reset}
+                  className="rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground hover:bg-secondary"
+                >
+                  {i18n.t('editor.rewriteDiscard')}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      <Toast message={error} onDismiss={() => setError(null)} />
+    </>
+  );
+
+  return { onSelect, panel };
+}

--- a/src/ui/shared/AskAi.tsx
+++ b/src/ui/shared/AskAi.tsx
@@ -1,5 +1,6 @@
-import { Loader2, Sparkles } from 'lucide-react';
+import { Loader2, Sparkles, Wand2 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { i18n } from '#imports';
 import { REWRITE_PRESETS, type RewritePreset } from '@/core/capture/ai/prompts';
 import { sendMessage } from '@/lib/messaging';
@@ -15,6 +16,10 @@ const PRESET_LABEL_KEYS = {
 } as const satisfies Record<RewritePreset, string>;
 
 const PRESET_ORDER = Object.keys(PRESET_LABEL_KEYS) as RewritePreset[];
+
+const PANEL_WIDTH = 320;
+const PANEL_GAP = 6;
+const VIEWPORT_MARGIN = 8;
 
 interface Span {
   start: number;
@@ -35,27 +40,77 @@ function readSpan(value: string, start: number, end: number): Span | null {
 export function useAskAi(value: string, onReplace: (next: string) => void, enabled = true) {
   const [span, setSpan] = useState<Span | null>(null);
   const [active, setActive] = useState<Span | null>(null);
+  const [anchor, setAnchor] = useState<{ top: number; left: number } | null>(null);
   const [instruction, setInstruction] = useState('');
   const [busy, setBusy] = useState(false);
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  const reset = useCallback(() => {
+    setActive(null);
+    setInstruction('');
+    setResult(null);
+  }, []);
+
+  const place = useCallback(() => {
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const maxLeft = window.innerWidth - PANEL_WIDTH - VIEWPORT_MARGIN;
+    setAnchor({
+      top: rect.bottom + PANEL_GAP,
+      left: Math.min(Math.max(VIEWPORT_MARGIN, rect.left), Math.max(VIEWPORT_MARGIN, maxLeft)),
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!active) return;
+    place();
+    const reposition = () => place();
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition);
+    return () => {
+      window.removeEventListener('scroll', reposition, true);
+      window.removeEventListener('resize', reposition);
+    };
+  }, [active, place]);
+
+  useEffect(() => {
+    if (!active) return;
+    const onPointerDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (panelRef.current?.contains(target) || triggerRef.current?.contains(target)) return;
+      reset();
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') reset();
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [active, reset]);
 
   useEffect(() => {
     if (active && result === null) inputRef.current?.focus();
   }, [active, result]);
 
-  const reset = useCallback(() => {
-    setActive(null);
-    setSpan(null);
-    setInstruction('');
-    setResult(null);
-  }, []);
-
   const onSelect = useCallback((e: React.SyntheticEvent<HTMLTextAreaElement>) => {
     const el = e.currentTarget;
     setSpan(readSpan(el.value, el.selectionStart, el.selectionEnd));
   }, []);
+
+  const open = useCallback(() => {
+    const target = span ?? readSpan(value, 0, value.length);
+    if (!target) return;
+    setResult(null);
+    setInstruction('');
+    setActive(target);
+  }, [span, value]);
 
   const run = useCallback(
     async (target: Span, prompt: string) => {
@@ -86,92 +141,104 @@ export function useAskAi(value: string, onReplace: (next: string) => void, enabl
       return;
     }
     onReplace(value.slice(0, active.start) + active.lead + result + active.trail + value.slice(active.end));
+    setSpan(null);
     reset();
   }, [active, result, value, onReplace, reset]);
 
-  const panel = !enabled ? null : (
-    <>
-      {span && !active && (
-        <button
-          type="button"
-          onClick={() => setActive(span)}
-          className="mt-1 flex items-center gap-1 text-[11px] font-medium text-accent hover:text-deep"
-        >
-          <Sparkles size={11} />
-          {i18n.t('editor.rewriteAskAi')}
-        </button>
-      )}
-
-      {active && (
-        <div className="mt-1.5 rounded-lg border border-border bg-card overflow-hidden">
-          {result === null ? (
-            <>
-              <div className="flex items-center gap-1.5 px-2 py-1.5 border-b border-border">
-                <Sparkles size={12} className="shrink-0 text-accent" />
-                <input
-                  ref={inputRef}
-                  value={instruction}
-                  disabled={busy}
-                  onChange={(e) => setInstruction(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      e.preventDefault();
-                      void run(active, instruction);
-                    }
-                    if (e.key === 'Escape') reset();
-                  }}
-                  placeholder={i18n.t('editor.rewritePlaceholder')}
-                  className="flex-1 min-w-0 bg-transparent p-0 text-[12px] text-foreground placeholder:text-muted-foreground/60 focus:outline-none disabled:opacity-50"
-                />
-                {busy ? (
-                  <Loader2 size={12} className="shrink-0 animate-spin text-accent" />
-                ) : (
-                  <span className="shrink-0 text-[10px] text-muted-foreground">{i18n.t('editor.rewriteEnter')}</span>
-                )}
-              </div>
-              <div className="py-1">
-                {PRESET_ORDER.map((preset) => (
-                  <button
-                    key={preset}
-                    type="button"
+  const panel =
+    active && anchor
+      ? createPortal(
+          <div
+            ref={panelRef}
+            style={{ top: anchor.top, left: anchor.left, width: PANEL_WIDTH }}
+            className="fixed z-[2147483000] rounded-lg border border-border bg-card shadow-lg overflow-hidden"
+          >
+            <p className="px-2.5 pt-2 pb-1.5 text-[11px] leading-snug text-muted-foreground border-b border-border line-clamp-2">
+              {active.core}
+            </p>
+            {result === null ? (
+              <>
+                <div className="flex items-center gap-1.5 px-2 py-1.5 border-b border-border">
+                  <Sparkles size={12} className="shrink-0 text-accent" />
+                  <input
+                    ref={inputRef}
+                    value={instruction}
                     disabled={busy}
-                    onClick={() => void run(active, REWRITE_PRESETS[preset])}
-                    className="w-full px-2.5 py-1 text-left text-[12px] text-foreground hover:bg-secondary disabled:opacity-50"
+                    onChange={(e) => setInstruction(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        void run(active, instruction);
+                      }
+                    }}
+                    placeholder={i18n.t('editor.rewritePlaceholder')}
+                    className="flex-1 min-w-0 bg-transparent p-0 text-[12px] text-foreground placeholder:text-muted-foreground/60 focus:outline-none disabled:opacity-50"
+                  />
+                  {busy ? (
+                    <Loader2 size={12} className="shrink-0 animate-spin text-accent" />
+                  ) : (
+                    <span className="shrink-0 text-[10px] text-muted-foreground">{i18n.t('editor.rewriteEnter')}</span>
+                  )}
+                </div>
+                <div className="py-1">
+                  {PRESET_ORDER.map((preset) => (
+                    <button
+                      key={preset}
+                      type="button"
+                      disabled={busy}
+                      onClick={() => void run(active, REWRITE_PRESETS[preset])}
+                      className="w-full px-2.5 py-1.5 text-left text-[12px] text-foreground hover:bg-secondary disabled:opacity-50"
+                    >
+                      {i18n.t(PRESET_LABEL_KEYS[preset])}
+                    </button>
+                  ))}
+                </div>
+              </>
+            ) : (
+              <>
+                <p className="px-2.5 py-2 text-[12px] leading-snug text-foreground whitespace-pre-wrap border-b border-border">
+                  {result}
+                </p>
+                <div className="flex items-center gap-1 px-2 py-1.5">
+                  <button
+                    type="button"
+                    onClick={replace}
+                    className="rounded-md bg-accent px-2 py-1 text-[11px] font-medium text-primary-foreground hover:bg-deep"
                   >
-                    {i18n.t(PRESET_LABEL_KEYS[preset])}
+                    {i18n.t('editor.rewriteReplace')}
                   </button>
-                ))}
-              </div>
-            </>
-          ) : (
-            <>
-              <p className="px-2.5 py-2 text-[12px] leading-snug text-foreground whitespace-pre-wrap border-b border-border">
-                {result}
-              </p>
-              <div className="flex items-center gap-1 px-2 py-1.5">
-                <button
-                  type="button"
-                  onClick={replace}
-                  className="rounded-md bg-accent px-2 py-1 text-[11px] font-medium text-primary-foreground hover:bg-deep"
-                >
-                  {i18n.t('editor.rewriteReplace')}
-                </button>
-                <button
-                  type="button"
-                  onClick={reset}
-                  className="rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground hover:bg-secondary"
-                >
-                  {i18n.t('editor.rewriteDiscard')}
-                </button>
-              </div>
-            </>
-          )}
-        </div>
-      )}
+                  <button
+                    type="button"
+                    onClick={reset}
+                    className="rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground hover:bg-secondary"
+                  >
+                    {i18n.t('editor.rewriteDiscard')}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>,
+          document.body,
+        )
+      : null;
 
+  const trigger = !enabled ? null : (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={open}
+        disabled={!value.trim()}
+        title={i18n.t('editor.rewriteAskAi')}
+        aria-label={i18n.t('editor.rewriteAskAi')}
+        className={`p-1 rounded-md transition-colors disabled:opacity-40 ${active ? 'text-accent' : 'text-border hover:text-accent'}`}
+      >
+        <Wand2 size={14} />
+      </button>
+      {panel}
       <Toast message={error} onDismiss={() => setError(null)} />
     </>
   );
 
-  return { onSelect, panel };
+  return { onSelect, trigger };
 }

--- a/src/ui/shared/rewrite-error.ts
+++ b/src/ui/shared/rewrite-error.ts
@@ -1,0 +1,11 @@
+import { i18n } from '#imports';
+import type { RewriteError } from '@/lib/messaging';
+
+const REWRITE_ERROR_KEYS = {
+  'no-api-key': 'editor.rewriteErrorNoApiKey',
+  'generation-failed': 'editor.rewriteErrorFailed',
+} as const satisfies Record<RewriteError, string>;
+
+export function rewriteErrorMessage(error: RewriteError): string {
+  return i18n.t(REWRITE_ERROR_KEYS[error]);
+}

--- a/src/ui/sidepanel/GuideEditor.tsx
+++ b/src/ui/sidepanel/GuideEditor.tsx
@@ -282,22 +282,24 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
             className="w-full resize-none overflow-hidden bg-transparent p-0 text-xs leading-snug text-muted-foreground placeholder:text-muted-foreground/60 border-b border-transparent hover:border-border focus:outline-none focus:border-accent"
           />
           {hasApiKey && (
-            <button
-              type="button"
-              onClick={handleGenerateDescription}
-              disabled={generating || metaGenerating}
-              title={description ? i18n.t('editor.regenerateDescription') : i18n.t('editor.generateDescription')}
-              className="mt-1 flex items-center gap-1 text-[11px] font-medium text-accent hover:text-deep disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {generating || metaGenerating ? <Loader2 size={11} className="animate-spin" /> : <Sparkles size={11} />}
-              {generating || metaGenerating
-                ? i18n.t('editor.generatingDescription')
-                : description
-                  ? i18n.t('editor.regenerateDescription')
-                  : i18n.t('editor.generateDescription')}
-            </button>
+            <div className="mt-1 flex items-center gap-1.5">
+              {askAi.trigger}
+              <button
+                type="button"
+                onClick={handleGenerateDescription}
+                disabled={generating || metaGenerating}
+                title={description ? i18n.t('editor.regenerateDescription') : i18n.t('editor.generateDescription')}
+                className="flex items-center gap-1 text-[11px] font-medium text-accent hover:text-deep disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {generating || metaGenerating ? <Loader2 size={11} className="animate-spin" /> : <Sparkles size={11} />}
+                {generating || metaGenerating
+                  ? i18n.t('editor.generatingDescription')
+                  : description
+                    ? i18n.t('editor.regenerateDescription')
+                    : i18n.t('editor.generateDescription')}
+              </button>
+            </div>
           )}
-          {askAi.panel}
           <Toast message={descriptionError} onDismiss={() => setDescriptionError(null)} />
         </div>
         <div className="text-[11px] flex items-center gap-2 text-muted-foreground" style={{ marginLeft: '34px' }}>

--- a/src/ui/sidepanel/GuideEditor.tsx
+++ b/src/ui/sidepanel/GuideEditor.tsx
@@ -17,6 +17,7 @@ import { logger } from '@/lib/logger';
 import { sendMessage } from '@/lib/messaging';
 import { getMostCommonDomain } from '@/lib/utils';
 import { Input } from '@/ui/components/ui/input';
+import { useAskAi } from '@/ui/shared/AskAi';
 import EmptyGuideState from '@/ui/shared/EmptyGuideState';
 import FaviconImg from '@/ui/shared/FaviconImg';
 import { guideDescriptionErrorMessage } from '@/ui/shared/guide-description-error';
@@ -105,6 +106,17 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
     }
     editingDescriptionRef.current = false;
   }, [data, guideId, description]);
+
+  const commitGuideDescription = useCallback(
+    (next: string) => {
+      setDescription(next);
+      void updateGuideDescription(guideId, next);
+      setData((prev) => (prev ? { ...prev, guide: { ...prev.guide, description: next } } : prev));
+    },
+    [guideId],
+  );
+
+  const askAi = useAskAi(description, commitGuideDescription, hasApiKey);
 
   const handleGenerateDescription = useCallback(async () => {
     setGenerating(true);
@@ -264,6 +276,7 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
             onFocus={() => {
               editingDescriptionRef.current = true;
             }}
+            onSelect={askAi.onSelect}
             onBlur={handleGuideDescriptionBlur}
             placeholder={i18n.t('editor.descriptionPlaceholder')}
             className="w-full resize-none overflow-hidden bg-transparent p-0 text-xs leading-snug text-muted-foreground placeholder:text-muted-foreground/60 border-b border-transparent hover:border-border focus:outline-none focus:border-accent"
@@ -284,6 +297,7 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
                   : i18n.t('editor.generateDescription')}
             </button>
           )}
+          {askAi.panel}
           <Toast message={descriptionError} onDismiss={() => setDescriptionError(null)} />
         </div>
         <div className="text-[11px] flex items-center gap-2 text-muted-foreground" style={{ marginLeft: '34px' }}>
@@ -324,6 +338,7 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
                 onDelete={handleDeleteStep}
                 onOpenEditor={(stepId, tool) => openInFullView(guideId, { stepId, tool })}
                 readOnly={!editing}
+                hasApiKey={hasApiKey}
                 onChanged={loadGuide}
                 dragHandleProps={
                   editing

--- a/src/ui/sidepanel/StepCard.tsx
+++ b/src/ui/sidepanel/StepCard.tsx
@@ -5,6 +5,7 @@ import { replaceScreenshot } from '@/core/guides/service';
 import type { Screenshot, Step } from '@/core/guides/types';
 import { imageDimensions, renderScreenshot } from '@/core/screenshot/render';
 import { logger } from '@/lib/logger';
+import { useAskAi } from '@/ui/shared/AskAi';
 import ConfirmDialog from '@/ui/shared/ConfirmDialog';
 import ImagePlaceholder from '@/ui/shared/ImagePlaceholder';
 import ScreenshotView from '@/ui/shared/ScreenshotView';
@@ -27,6 +28,7 @@ interface StepCardProps {
   frameRatio?: number;
   readOnly?: boolean;
   onChanged?: () => void;
+  hasApiKey?: boolean;
 }
 
 export default function StepCard({
@@ -40,6 +42,7 @@ export default function StepCard({
   frameRatio,
   readOnly,
   onChanged,
+  hasApiKey,
 }: StepCardProps) {
   const [description, setDescription] = useState(step.description);
   const [dragOver, setDragOver] = useState(false);
@@ -54,6 +57,15 @@ export default function StepCard({
   const handleDescriptionBlur = () => {
     if (description !== step.description) onDescriptionChange(step.id, description);
   };
+
+  const askAi = useAskAi(
+    description,
+    (next) => {
+      setDescription(next);
+      onDescriptionChange(step.id, next);
+    },
+    !readOnly && !step.aiPending && Boolean(hasApiKey),
+  );
 
   const handleDelete = () => {
     setConfirmDelete(false);
@@ -146,10 +158,12 @@ export default function StepCard({
               value={description}
               rows={1}
               onChange={(e) => setDescription(e.target.value)}
+              onSelect={askAi.onSelect}
               onBlur={handleDescriptionBlur}
             />
           )}
         </div>
+        {askAi.panel}
         <div className="flex items-center justify-end mt-1">
           <div className="flex items-center gap-0.5">
             {screenshot && (

--- a/src/ui/sidepanel/StepCard.tsx
+++ b/src/ui/sidepanel/StepCard.tsx
@@ -163,9 +163,9 @@ export default function StepCard({
             />
           )}
         </div>
-        {askAi.panel}
         <div className="flex items-center justify-end mt-1">
           <div className="flex items-center gap-0.5">
+            {askAi.trigger}
             {screenshot && (
               <button
                 onClick={handleCopy}


### PR DESCRIPTION
An Ask AI button sits beside every editable step and guide description: type a free-form instruction or pick one of five presets. Select text and it rewrites only that span; select nothing and it takes the whole description. Then Replace or Discard.

The prompt knows the text is a workflow step — imperative, one action, never introduce a UI element absent from the original. It runs in the background worker on the existing BYOK provider, so no new dependency or key.

Three i18n bugs fixed here: #23's description keys sat under `history:` but are read as `editor.*`, so none resolved; `keyValid`/`keyInvalid` were unquoted with escapes, printing a literal `\xE9` in fr and es; de was 18 keys behind. All five locales now compile complete.

Ask AI still requires edit mode; the rewrite does not stream.

lint, 499 tests, chrome + firefox builds clean; tsc unchanged at its 90-error baseline.
