### PR TITLE
feat(guides): add heading and callout blocks

### DIFF
--- a/src/core/export/__tests__/markdown-export.test.ts
+++ b/src/core/export/__tests__/markdown-export.test.ts
@@ -138,4 +138,65 @@ describe('exportGuideAsMarkdown', () => {
     const b64 = btoa('pixel-data');
     expect(md).toContain(b64);
   });
+
+  it('renders a heading block as an H2 without a step number', async () => {
+    const guide = makeGuide();
+    const steps = [makeStep({ id: 'block-1', blockType: 'heading', description: 'Section title', url: '' })];
+
+    const md = await exportGuideAsMarkdown(guide, steps, new Map());
+    expect(md).toContain('## Section title');
+    expect(md).not.toContain('export.stepLabel');
+  });
+
+  it('renders a callout block as a blockquote with its variant label', async () => {
+    const guide = makeGuide();
+    const steps = [
+      makeStep({
+        id: 'block-1',
+        blockType: 'callout',
+        calloutVariant: 'warning',
+        description: 'Do not skip this',
+        url: '',
+      }),
+    ];
+
+    const md = await exportGuideAsMarkdown(guide, steps, new Map());
+    expect(md).toContain('> **blocks.variantWarning**');
+    expect(md).toContain('> Do not skip this');
+  });
+
+  it('prefixes every line of a multi-line callout', async () => {
+    const guide = makeGuide();
+    const steps = [makeStep({ id: 'block-1', blockType: 'callout', description: 'First line\nSecond line', url: '' })];
+
+    const md = await exportGuideAsMarkdown(guide, steps, new Map());
+    expect(md).toContain('> First line\n> Second line');
+  });
+
+  it('keeps step numbering sequential across an interleaved block', async () => {
+    const guide = makeGuide();
+    const steps = [
+      makeStep({ index: 0, description: 'First action' }),
+      makeStep({ id: 'block-1', index: 1, blockType: 'heading', description: 'Section title', url: '' }),
+      makeStep({ id: 'step-2', index: 2, description: 'Second action' }),
+    ];
+
+    const md = await exportGuideAsMarkdown(guide, steps, new Map());
+    expect(md).toContain('## export.stepLabel[01]: First action');
+    expect(md).toContain('## export.stepLabel[02]: Second action');
+    expect(md).not.toContain('export.stepLabel[03]');
+  });
+
+  it('counts only action steps in the metadata line', async () => {
+    const guide = makeGuide();
+    const steps = [
+      makeStep({ index: 0 }),
+      makeStep({ id: 'block-1', index: 1, blockType: 'heading', description: 'Section title', url: '' }),
+      makeStep({ id: 'block-2', index: 2, blockType: 'callout', description: 'Heads up', url: '' }),
+      makeStep({ id: 'step-2', index: 3, description: 'Type text' }),
+    ];
+
+    const md = await exportGuideAsMarkdown(guide, steps, new Map());
+    expect(md).toContain('export.stepsCount[2]');
+  });
 });

--- a/src/core/export/docx-export.ts
+++ b/src/core/export/docx-export.ts
@@ -9,6 +9,7 @@ import {
   Packer,
   PageNumber,
   Paragraph,
+  ShadingType,
   Table,
   TableCell,
   TableLayoutType,
@@ -22,6 +23,7 @@ import { i18n } from '#imports';
 import { type Branding, dataUrlToBytes, fitLogo, loadBranding } from '@/core/export/branding';
 import { type ExportOptions, IMAGE_SCALE_FACTORS, loadExportOptions } from '@/core/export/options';
 import { blobToArrayBuffer, extractDomain, formatDate } from '@/core/export/utils';
+import { actionSteps, calloutAccent, isBlock, stepNumbers, tint } from '@/core/guides/blocks';
 import type { Guide, Screenshot, Step } from '@/core/guides/types';
 import { logger } from '@/lib/logger';
 
@@ -44,6 +46,13 @@ const TEXT_COL_MM = CONTENT_MM - NUM_COL_MM - COL_GAP_MM;
 const META_COL_MM = 43;
 const LOGO_MAX_W = px(34);
 const LOGO_MAX_H = px(15);
+const BLOCK_SPACING_AFTER = 200;
+const BLOCK_RULE_SIZE = 6;
+const HEADING_SIZE = 28;
+const CALLOUT_SIZE = 22;
+const CALLOUT_BAR_SIZE = 18;
+const CALLOUT_PAD_X_MM = 3;
+const CALLOUT_PAD_Y_MM = 2;
 
 const INK = '1E1B4B';
 const MUTED = '6B7280';
@@ -166,7 +175,7 @@ function buildCover(guide: Guide, steps: Step[], domain: string | null, brand: B
       new Paragraph({
         children: [
           new TextRun({
-            text: String(steps.length).padStart(2, '0'),
+            text: String(actionSteps(steps).length).padStart(2, '0'),
             bold: true,
             color: accent,
             size: 60,
@@ -255,14 +264,62 @@ async function buildImageParagraph(
   }
 }
 
+function buildHeadingParagraph(step: Step): Paragraph {
+  return new Paragraph({
+    border: { bottom: { style: BorderStyle.SINGLE, size: BLOCK_RULE_SIZE, color: INK, space: 4 } },
+    children: [
+      new TextRun({ text: step.description, bold: true, color: INK, size: HEADING_SIZE, font: DOCX_FONT_FAMILY }),
+    ],
+  });
+}
+
+function buildCalloutTable(step: Step): Table {
+  const accent = calloutAccent(step);
+
+  return new Table({
+    width: { size: dxa(CONTENT_MM), type: WidthType.DXA },
+    layout: TableLayoutType.FIXED,
+    columnWidths: [dxa(CONTENT_MM)],
+    rows: [
+      new TableRow({
+        cantSplit: true,
+        children: [
+          new TableCell({
+            borders: {
+              ...NO_BORDERS,
+              left: { style: BorderStyle.SINGLE, size: CALLOUT_BAR_SIZE, color: bare(accent) },
+            },
+            shading: { type: ShadingType.CLEAR, color: 'auto', fill: bare(tint(accent)) },
+            width: { size: dxa(CONTENT_MM), type: WidthType.DXA },
+            margins: {
+              top: dxa(CALLOUT_PAD_Y_MM),
+              bottom: dxa(CALLOUT_PAD_Y_MM),
+              left: dxa(CALLOUT_PAD_X_MM),
+              right: dxa(CALLOUT_PAD_X_MM),
+            },
+            children: [
+              new Paragraph({
+                children: [
+                  new TextRun({ text: step.description, color: INK, size: CALLOUT_SIZE, font: DOCX_FONT_FAMILY }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      }),
+    ],
+  });
+}
+
 async function buildStepTable(
   step: Step,
+  number: number,
   screenshot: Screenshot | undefined,
   brand: Branding,
   opts: ExportOptions,
 ): Promise<Table> {
   const accent = bare(brand.accent);
-  const stepNumber = String(step.index + 1).padStart(2, '0');
+  const stepNumber = String(number).padStart(2, '0');
 
   const textChildren: Paragraph[] = [
     new Paragraph({
@@ -424,12 +481,26 @@ export async function exportGuideAsDOCX(
   const brand = await loadBranding();
 
   const children: Array<Paragraph | Table> = opts.cover ? buildCover(guide, steps, domain, brand) : [];
+  const numbers = stepNumbers(steps);
 
   for (const [i, step] of steps.entries()) {
     if (i === 0 && opts.cover) {
       children.push(new Paragraph({ pageBreakBefore: true, spacing: { after: 120 }, children: [] }));
     }
-    children.push(await buildStepTable(step, opts.screenshots ? screenshots.get(step.id) : undefined, brand, opts));
+    if (isBlock(step)) {
+      children.push(step.blockType === 'heading' ? buildHeadingParagraph(step) : buildCalloutTable(step));
+      children.push(new Paragraph({ spacing: { after: BLOCK_SPACING_AFTER }, children: [] }));
+      continue;
+    }
+    children.push(
+      await buildStepTable(
+        step,
+        numbers.get(step.id) ?? 0,
+        opts.screenshots ? screenshots.get(step.id) : undefined,
+        brand,
+        opts,
+      ),
+    );
     children.push(new Paragraph({ spacing: { after: 300 }, children: [] }));
   }
 

--- a/src/core/export/html-export.ts
+++ b/src/core/export/html-export.ts
@@ -2,11 +2,28 @@ import { i18n } from '#imports';
 import { fitLogo, loadBranding } from '@/core/export/branding';
 import { type ExportOptions, IMAGE_SCALE_FACTORS, loadExportOptions } from '@/core/export/options';
 import { blobToBase64, escapeHtml, extractDomain, formatDate } from '@/core/export/utils';
+import { actionSteps, calloutAccent, isBlock, stepNumbers, tint, variantLabel } from '@/core/guides/blocks';
 import type { Guide, Screenshot, Step } from '@/core/guides/types';
 import { renderScreenshot } from '@/core/screenshot/render';
 
 const LOGO_MAX_WIDTH = 148;
 const LOGO_MAX_HEIGHT = 56;
+
+function blockSection(step: Step): string {
+  if (step.blockType === 'heading') {
+    return `
+      <section data-block="heading" style="margin-bottom:26px;">
+        <h2 style="font-size:24px;font-weight:700;line-height:1.3;color:#1E1B4B;white-space:pre-wrap;padding-bottom:10px;border-bottom:2px solid #1E1B4B;">${escapeHtml(step.description)}</h2>
+      </section>`;
+  }
+
+  const accent = calloutAccent(step);
+  const label = variantLabel(step.calloutVariant ?? 'info');
+  return `
+      <section data-block="callout" role="note" aria-label="${escapeHtml(label)}" style="margin-bottom:52px;padding:14px 18px;border-left:3px solid ${accent};border-radius:8px;background:${tint(accent)};">
+        <p style="margin:0;font-size:15px;line-height:1.6;color:#1E1B4B;white-space:pre-wrap;">${escapeHtml(step.description)}</p>
+      </section>`;
+}
 
 function stepUrlLabel(url: string): string {
   try {
@@ -29,25 +46,32 @@ export async function exportGuideAsHTML(
   const accent = brand.accent;
   const imgWidthPct = Math.round(IMAGE_SCALE_FACTORS[opts.imageScale] * 100);
   const domain = extractDomain(steps);
+  const numbers = stepNumbers(steps);
   const stepSections: string[] = [];
 
   for (const step of steps) {
+    if (isBlock(step)) {
+      stepSections.push(blockSection(step));
+      continue;
+    }
+
+    const number = numbers.get(step.id) ?? 0;
     const screenshot = opts.screenshots ? screenshots.get(step.id) : undefined;
     let imgHtml = '';
     if (screenshot) {
       const b64 = await blobToBase64(await renderScreenshot(screenshot));
-      const altText = screenshot.edits?.alt || i18n.t('export.stepLabel', [String(step.index + 1)]);
+      const altText = screenshot.edits?.alt || i18n.t('export.stepLabel', [String(number)]);
       imgHtml = `<img src="data:${screenshot.mimeType};base64,${b64}" alt="${escapeHtml(altText)}" style="display:block;width:${imgWidthPct}%;margin-top:14px;border:1px solid #CBD5E1;" />`;
     }
 
-    const stepNumber = String(step.index + 1).padStart(2, '0');
+    const stepNumber = String(number).padStart(2, '0');
     const urlHtml =
       step.url && opts.stepUrls
         ? `<a href="${escapeHtml(step.url)}" target="_blank" rel="noopener" style="font-size:14px;font-weight:400;color:${accent};">${escapeHtml(stepUrlLabel(step.url))}</a>`
         : '';
 
     stepSections.push(`
-      <section data-step="${step.index + 1}" style="display:flex;gap:26px;margin-bottom:52px;">
+      <section data-step="${number}" style="display:flex;gap:26px;margin-bottom:52px;">
         <div style="flex:0 0 76px;font-size:34px;font-weight:700;color:${accent};line-height:.9;">${stepNumber}</div>
         <div style="flex:1;min-width:0;border-top:1px solid #1E1B4B;padding-top:12px;">
           <p style="margin:0;font-size:17px;font-weight:700;line-height:1.45;color:#1E1B4B;">${escapeHtml(step.description)}${
@@ -92,7 +116,7 @@ export async function exportGuideAsHTML(
     <div style="border-top:2px solid #1E1B4B;padding-top:18px;display:flex;align-items:baseline;">
       <div style="flex:0 0 190px;">
         <div style="font-size:11px;font-weight:700;color:#6B7280;letter-spacing:0.06em;">${i18n.t('export.steps').toUpperCase()}</div>
-        <div style="font-size:38px;font-weight:700;color:${accent};line-height:1;margin-top:2px;">${String(steps.length).padStart(2, '0')}</div>
+        <div style="font-size:38px;font-weight:700;color:${accent};line-height:1;margin-top:2px;">${String(actionSteps(steps).length).padStart(2, '0')}</div>
       </div>
       ${metaCell(i18n.t('export.created').toUpperCase(), formatDate(guide.createdAt))}
       ${

--- a/src/core/export/markdown-export.ts
+++ b/src/core/export/markdown-export.ts
@@ -1,7 +1,15 @@
 import { i18n } from '#imports';
 import { blobToBase64, extractDomain, formatDate } from '@/core/export/utils';
+import { actionSteps, isBlock, stepNumbers, variantLabel } from '@/core/guides/blocks';
 import type { Guide, Screenshot, Step } from '@/core/guides/types';
 import { renderScreenshot } from '@/core/screenshot/render';
+
+function blockLines(step: Step): string[] {
+  if (step.blockType === 'heading') return [`## ${step.description}`];
+  const label = variantLabel(step.calloutVariant ?? 'info');
+  const body = step.description.split('\n').map((line) => (line ? `> ${line}` : '>'));
+  return [`> **${label}**`, '>', ...body];
+}
 
 export async function exportGuideAsMarkdown(
   guide: Guide,
@@ -9,8 +17,9 @@ export async function exportGuideAsMarkdown(
   screenshots: Map<string, Screenshot>,
 ): Promise<string> {
   const domain = extractDomain(steps);
+  const numbers = stepNumbers(steps);
   const meta = [
-    i18n.t('export.stepsCount', [String(steps.length)]),
+    i18n.t('export.stepsCount', [String(actionSteps(steps).length)]),
     i18n.t('export.createdLabel', [formatDate(guide.createdAt)]),
     ...(domain ? [i18n.t('export.sourceLabel', [domain])] : []),
   ].join(' · ');
@@ -20,7 +29,12 @@ export async function exportGuideAsMarkdown(
   lines.push(`*${meta}*`, '', '---', '');
 
   for (const step of steps) {
-    const num = String(step.index + 1).padStart(2, '0');
+    if (isBlock(step)) {
+      lines.push(...blockLines(step), '');
+      continue;
+    }
+
+    const num = String(numbers.get(step.id) ?? 0).padStart(2, '0');
     lines.push(`## ${i18n.t('export.stepLabel', [num])}: ${step.description}`, '');
 
     const screenshot = screenshots.get(step.id);

--- a/src/core/export/pdf-export.ts
+++ b/src/core/export/pdf-export.ts
@@ -3,6 +3,7 @@ import { i18n } from '#imports';
 import { fitLogo, loadBranding } from '@/core/export/branding';
 import { type ExportOptions, IMAGE_SCALE_FACTORS, loadExportOptions } from '@/core/export/options';
 import { blobToDataUrl, extractDomain, fitImage, formatDate } from '@/core/export/utils';
+import { actionSteps, calloutAccent, isBlock, stepNumbers, tint } from '@/core/guides/blocks';
 import type { Guide, Screenshot, Step } from '@/core/guides/types';
 import { hexToRgb } from '@/core/screenshot/color';
 import { resolveViewport } from '@/core/screenshot/geometry';
@@ -30,10 +31,23 @@ const HEAD_LOGO_W = 18;
 const HEAD_LOGO_H = 7;
 const META_COL_W = 43;
 const META_DROP = 9;
+const BLOCK_GAP = 9;
+const HEADING_SIZE = 14;
+const HEADING_LINE_H = 6.5;
+const HEADING_BASELINE = 5;
+const HEADING_RULE_GAP = 3.2;
+const CALLOUT_SIZE = 11;
+const CALLOUT_LINE_H = 5;
+const CALLOUT_BASELINE = 4;
+const CALLOUT_PAD_X = 5;
+const CALLOUT_PAD_Y = 4;
+const CALLOUT_BAR_W = 2;
+const CALLOUT_RADIUS = 2;
 
 const INK: [number, number, number] = [30, 27, 75];
 const MUTED: [number, number, number] = [107, 114, 128];
 const HAIR: [number, number, number] = [229, 231, 235];
+const PAPER: [number, number, number] = [255, 255, 255];
 
 export async function exportGuideAsPDF(
   guide: Guide,
@@ -43,6 +57,8 @@ export async function exportGuideAsPDF(
 ): Promise<Blob> {
   const opts = options ?? (await loadExportOptions());
   const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
+  const actions = actionSteps(steps);
+  const numbers = stepNumbers(steps);
   const domain = extractDomain(steps);
   const brand = await loadBranding();
   const accent = hexToRgb(brand.accent) ?? [79, 70, 229];
@@ -95,7 +111,7 @@ export async function exportGuideAsPDF(
     doc.setFontSize(30);
     doc.setFont('helvetica', 'bold');
     doc.setTextColor(...accent);
-    doc.text(String(steps.length).padStart(2, '0'), MARGIN, yValue);
+    doc.text(String(actions.length).padStart(2, '0'), MARGIN, yValue);
 
     drawLabel(i18n.t('export.created').toUpperCase(), MARGIN + META_COL_W);
     doc.setFontSize(11);
@@ -145,7 +161,11 @@ export async function exportGuideAsPDF(
   let sy = startStepPage();
 
   for (const step of steps) {
-    const stepNum = String(step.index + 1).padStart(2, '0');
+    if (isBlock(step)) {
+      sy = drawBlock(doc, step, sy, startStepPage);
+      continue;
+    }
+    const stepNum = String(numbers.get(step.id) ?? 0).padStart(2, '0');
 
     doc.setFontSize(11);
     doc.setFont('helvetica', 'bold');
@@ -177,7 +197,7 @@ export async function exportGuideAsPDF(
     if (sy + blockH > FOOTER_Y - 8 && sy > STEP_TOP) {
       sy = startStepPage();
     }
-    pageSteps[pageSteps.length - 1].push(step.index + 1);
+    pageSteps[pageSteps.length - 1].push(numbers.get(step.id) ?? 0);
 
     doc.setFontSize(30);
     doc.setFont('helvetica', 'bold');
@@ -239,8 +259,8 @@ export async function exportGuideAsPDF(
     if (onPage?.length) {
       const range =
         onPage.length > 1
-          ? i18n.t('export.stepsRange', [String(onPage[0]), String(onPage[onPage.length - 1]), String(steps.length)])
-          : i18n.t('export.stepOf', [String(onPage[0]), String(steps.length)]);
+          ? i18n.t('export.stepsRange', [String(onPage[0]), String(onPage[onPage.length - 1]), String(actions.length)])
+          : i18n.t('export.stepOf', [String(onPage[0]), String(actions.length)]);
       doc.text(range, headRight, MARGIN + 3, { align: 'right' });
     }
 
@@ -254,6 +274,42 @@ export async function exportGuideAsPDF(
   }
 
   return doc.output('blob');
+}
+
+function drawBlock(doc: jsPDF, step: Step, y: number, nextPage: () => number): number {
+  if (step.blockType === 'heading') {
+    doc.setFontSize(HEADING_SIZE);
+    doc.setFont('helvetica', 'bold');
+    const lines = doc.splitTextToSize(step.description, CONTENT_W);
+    const blockH = HEADING_BASELINE + (lines.length - 1) * HEADING_LINE_H + HEADING_RULE_GAP;
+    let sy = y;
+    if (sy + blockH > FOOTER_Y - 8 && sy > STEP_TOP) sy = nextPage();
+    doc.setTextColor(...INK);
+    doc.text(lines, MARGIN, sy + HEADING_BASELINE);
+    const ruleY = sy + blockH;
+    doc.setDrawColor(...INK);
+    doc.setLineWidth(0.3);
+    doc.line(MARGIN, ruleY, RIGHT, ruleY);
+    return ruleY + BLOCK_GAP;
+  }
+
+  const accent = calloutAccent(step);
+  const bar = hexToRgb(accent) ?? INK;
+  const fill = hexToRgb(tint(accent)) ?? PAPER;
+  const textX = MARGIN + CALLOUT_BAR_W + CALLOUT_PAD_X;
+  doc.setFontSize(CALLOUT_SIZE);
+  doc.setFont('helvetica', 'normal');
+  const lines = doc.splitTextToSize(step.description, RIGHT - CALLOUT_PAD_X - textX);
+  const boxH = CALLOUT_PAD_Y * 2 + lines.length * CALLOUT_LINE_H;
+  let sy = y;
+  if (sy + boxH > FOOTER_Y - 8 && sy > STEP_TOP) sy = nextPage();
+  doc.setFillColor(...fill);
+  doc.roundedRect(MARGIN, sy, CONTENT_W, boxH, CALLOUT_RADIUS, CALLOUT_RADIUS, 'F');
+  doc.setFillColor(...bar);
+  doc.rect(MARGIN, sy + CALLOUT_RADIUS, CALLOUT_BAR_W, boxH - CALLOUT_RADIUS * 2, 'F');
+  doc.setTextColor(...INK);
+  doc.text(lines, textX, sy + CALLOUT_PAD_Y + CALLOUT_BASELINE);
+  return sy + boxH + BLOCK_GAP;
 }
 
 function stepUrlLabel(url: string): string {

--- a/src/core/export/video-export.ts
+++ b/src/core/export/video-export.ts
@@ -5,7 +5,8 @@ import type { ExportOptions } from '@/core/export/options';
 import { loadExportOptions } from '@/core/export/options';
 import { extractDomain, formatDate } from '@/core/export/utils';
 import { FRAME_HEIGHT, FRAME_WIDTH, pickContainer } from '@/core/export/video-support';
-import type { Guide, Screenshot, Step } from '@/core/guides/types';
+import { actionSteps, calloutAccent, isBlock } from '@/core/guides/blocks';
+import type { BlockType, Guide, Screenshot, Step } from '@/core/guides/types';
 import type { Ctx } from '@/core/screenshot/draw';
 import { drawRoundedRect } from '@/core/screenshot/draw';
 import { clamp, resolveTarget, resolveViewport } from '@/core/screenshot/geometry';
@@ -40,6 +41,22 @@ const FRAME_PADDING = 20;
 
 const COVER_MARGIN = 96;
 const COVER_CELL_WIDTH = 300;
+
+const RENDER_OPTIONS = { format: 'image/webp', quality: 0.9 } as const;
+
+const BLOCK_BLUR = 'blur(24px)';
+const BLOCK_OVERSCAN = 1.12;
+const BLOCK_WASH = 'rgba(30, 27, 75, 0.7)';
+const BLOCK_WASH_FLAT = 'rgba(30, 27, 75, 0.86)';
+const BLOCK_MAX_WIDTH_RATIO = 0.72;
+const HEADING_FONT_SIZE = 58;
+const HEADING_LINE_HEIGHT = 74;
+const HEADING_MAX_LINES = 3;
+const CALLOUT_FONT_SIZE = 36;
+const CALLOUT_LINE_HEIGHT = 50;
+const CALLOUT_MAX_LINES = 4;
+const CALLOUT_BAR_WIDTH = 6;
+const CALLOUT_BAR_GAP = 26;
 
 export const STEP_SECONDS = STEP_ZOOMED_OUT_SEC + STEP_ZOOM_TRANSITION_SEC + STEP_ZOOMED_IN_SEC;
 
@@ -134,6 +151,13 @@ export function letterbox(srcWidth: number, srcHeight: number, dstWidth: number,
   return { scale, width, height, x: (dstWidth - width) / 2, y: (dstHeight - height) / 2 };
 }
 
+function coverFit(source: Size, overscan: number): Rect {
+  const scale = Math.max(FRAME_WIDTH / source.width, FRAME_HEIGHT / source.height) * overscan;
+  const width = source.width * scale;
+  const height = source.height * scale;
+  return { x: (FRAME_WIDTH - width) / 2, y: (FRAME_HEIGHT - height) / 2, width, height };
+}
+
 export function wrapLines(
   text: string,
   maxWidth: number,
@@ -207,15 +231,75 @@ function drawTooltip(ctx: Ctx, text: string, target: Rect) {
   });
 }
 
-interface StepLayer {
+interface ScreenshotLayer {
+  kind: 'screenshot';
   bitmap: ImageBitmap;
   fit: ReturnType<typeof letterbox>;
   target: Rect | null;
   description: string;
 }
 
-async function loadStepLayer(step: Step, screenshot: Screenshot): Promise<StepLayer> {
-  const rendered = await renderScreenshot(screenshot, { format: 'image/webp', quality: 0.9 });
+interface BlockLayer {
+  kind: 'block';
+  blockType: BlockType;
+  accent: string;
+  description: string;
+  backdrop: ImageBitmap | null;
+  blurred: boolean;
+}
+
+type StepLayer = ScreenshotLayer | BlockLayer;
+
+function detectCanvasFilter(): boolean {
+  try {
+    const ctx = new OffscreenCanvas(1, 1).getContext('2d');
+    if (!ctx || !('filter' in ctx)) return false;
+    ctx.filter = BLOCK_BLUR;
+    const applied = ctx.filter !== 'none';
+    ctx.filter = 'none';
+    return applied;
+  } catch {
+    return false;
+  }
+}
+
+let filterSupport: boolean | undefined;
+
+function supportsCanvasFilter(): boolean {
+  filterSupport ??= detectCanvasFilter();
+  return filterSupport;
+}
+
+async function blurBackdrop(screenshot: Screenshot): Promise<Pick<BlockLayer, 'backdrop' | 'blurred'>> {
+  const canvas = new OffscreenCanvas(FRAME_WIDTH, FRAME_HEIGHT);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas 2D context unavailable');
+
+  const rendered = await renderScreenshot(screenshot, RENDER_OPTIONS);
+  const source = await createImageBitmap(rendered);
+  const blurred = supportsCanvasFilter();
+  const at = coverFit(source, blurred ? BLOCK_OVERSCAN : 1);
+
+  if (blurred) ctx.filter = BLOCK_BLUR;
+  ctx.drawImage(source, at.x, at.y, at.width, at.height);
+  ctx.filter = 'none';
+  source.close();
+
+  return { backdrop: await createImageBitmap(canvas), blurred };
+}
+
+async function loadBlockLayer(step: Step, behind: Screenshot | undefined): Promise<BlockLayer> {
+  return {
+    kind: 'block',
+    blockType: step.blockType ?? 'callout',
+    accent: calloutAccent(step),
+    description: step.description,
+    ...(behind ? await blurBackdrop(behind) : { backdrop: null, blurred: false }),
+  };
+}
+
+async function loadScreenshotLayer(step: Step, screenshot: Screenshot): Promise<ScreenshotLayer> {
+  const rendered = await renderScreenshot(screenshot, RENDER_OPTIONS);
   const bitmap = await createImageBitmap(rendered);
   const viewport = resolveViewport(screenshot);
   const target = resolveTarget(screenshot);
@@ -223,6 +307,7 @@ async function loadStepLayer(step: Step, screenshot: Screenshot): Promise<StepLa
   const sy = bitmap.height / viewport.height;
 
   return {
+    kind: 'screenshot',
     bitmap,
     fit: letterbox(bitmap.width, bitmap.height, FRAME_WIDTH, FRAME_HEIGHT),
     target: target
@@ -237,7 +322,64 @@ async function loadStepLayer(step: Step, screenshot: Screenshot): Promise<StepLa
   };
 }
 
+function releaseLayer(layer: StepLayer) {
+  if (layer.kind === 'screenshot') layer.bitmap.close();
+  else layer.backdrop?.close();
+}
+
+function drawBlockText(ctx: Ctx, layer: BlockLayer) {
+  const heading = layer.blockType === 'heading';
+  const fontSize = heading ? HEADING_FONT_SIZE : CALLOUT_FONT_SIZE;
+  const lineHeight = heading ? HEADING_LINE_HEIGHT : CALLOUT_LINE_HEIGHT;
+
+  ctx.font = `700 ${fontSize}px Poppins, sans-serif`;
+  const lines = wrapLines(
+    layer.description,
+    FRAME_WIDTH * BLOCK_MAX_WIDTH_RATIO,
+    (line) => ctx.measureText(line).width,
+    heading ? HEADING_MAX_LINES : CALLOUT_MAX_LINES,
+  );
+  if (lines.length === 0) return;
+
+  const middle = FRAME_HEIGHT / 2;
+  const height = lines.length * lineHeight;
+  const textWidth = Math.max(...lines.map((line) => ctx.measureText(line).width));
+  const centerX = FRAME_WIDTH / 2 + (heading ? 0 : (CALLOUT_BAR_WIDTH + CALLOUT_BAR_GAP) / 2);
+
+  if (!heading) {
+    ctx.fillStyle = layer.accent;
+    const barX = centerX - textWidth / 2 - CALLOUT_BAR_GAP - CALLOUT_BAR_WIDTH;
+    drawRoundedRect(ctx, barX, middle - height / 2, CALLOUT_BAR_WIDTH, height, CALLOUT_BAR_WIDTH / 2);
+    ctx.fill();
+  }
+
+  ctx.fillStyle = ON_DARK;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  lines.forEach((line, i) => {
+    ctx.fillText(line, centerX, middle + (i - (lines.length - 1) / 2) * lineHeight);
+  });
+}
+
+function drawBlockFrame(ctx: Ctx, layer: BlockLayer) {
+  ctx.save();
+  if (layer.backdrop) {
+    ctx.drawImage(layer.backdrop, 0, 0, FRAME_WIDTH, FRAME_HEIGHT);
+    ctx.fillStyle = layer.blurred ? BLOCK_WASH : BLOCK_WASH_FLAT;
+  } else {
+    ctx.fillStyle = BACKDROP;
+  }
+  ctx.fillRect(0, 0, FRAME_WIDTH, FRAME_HEIGHT);
+  drawBlockText(ctx, layer);
+  ctx.restore();
+}
+
 function drawStepFrame(ctx: Ctx, layer: StepLayer, frame: number) {
+  if (layer.kind === 'block') {
+    drawBlockFrame(ctx, layer);
+    return;
+  }
+
   const crop = zoomCrop(layer.bitmap, layer.target, easeInOut(zoomProgress(frame)));
   const { fit } = layer;
   ctx.drawImage(layer.bitmap, crop.x, crop.y, crop.width, crop.height, fit.x, fit.y, fit.width, fit.height);
@@ -336,7 +478,7 @@ export async function exportGuideAsVideo(
   exportOptions?: VideoOptions,
   controls: VideoExportControls = {},
 ): Promise<VideoExportResult> {
-  const frames = steps.filter((step) => screenshots.has(step.id));
+  const frames = steps.filter((step) => isBlock(step) || screenshots.has(step.id));
   if (frames.length === 0) throw new Error('This guide has no screenshots to turn into a video');
 
   const { BufferTarget, CanvasSource, Mp4OutputFormat, Output, QUALITY_HIGH, WebMOutputFormat } = await import(
@@ -379,10 +521,21 @@ export async function exportGuideAsVideo(
   const { onProgress, signal } = controls;
   let done = 0;
 
+  const backdropFor = (index: number) => {
+    for (let i = index - 1; i >= 0; i--) {
+      const behind = screenshots.get(frames[i].id);
+      if (behind) return behind;
+    }
+    return undefined;
+  };
+
   const layerAt = async (index: number) => {
     const cached = loaded.get(index);
     if (cached) return cached;
-    const layer = await loadStepLayer(frames[index], screenshots.get(frames[index].id) as Screenshot);
+    const step = frames[index];
+    const layer = isBlock(step)
+      ? await loadBlockLayer(step, backdropFor(index))
+      : await loadScreenshotLayer(step, screenshots.get(step.id) as Screenshot);
     loaded.set(index, layer);
     return layer;
   };
@@ -390,7 +543,7 @@ export async function exportGuideAsVideo(
   const releaseBefore = (index: number) => {
     for (const [key, layer] of loaded) {
       if (key < index) {
-        layer.bitmap.close();
+        releaseLayer(layer);
         loaded.delete(key);
       }
     }
@@ -405,7 +558,7 @@ export async function exportGuideAsVideo(
 
     if (options.cover) {
       abortIfRequested();
-      await drawCoverFrame(ctx, guide, frames, brand);
+      await drawCoverFrame(ctx, guide, actionSteps(frames), brand);
       await source.add(0, COVER_SECONDS);
       done += 1;
       onProgress?.(done, total);
@@ -445,7 +598,7 @@ export async function exportGuideAsVideo(
     await output.cancel();
     throw error;
   } finally {
-    for (const layer of loaded.values()) layer.bitmap.close();
+    for (const layer of loaded.values()) releaseLayer(layer);
     loaded.clear();
   }
 

--- a/src/core/guides/__tests__/blocks.test.ts
+++ b/src/core/guides/__tests__/blocks.test.ts
@@ -1,0 +1,271 @@
+import 'fake-indexeddb/auto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.hoisted(() => {
+  globalThis.BroadcastChannel = class BroadcastChannel {
+    name: string;
+    constructor(name: string) {
+      this.name = name;
+    }
+    postMessage() {}
+    addEventListener() {}
+    removeEventListener() {}
+    close() {}
+    onmessage = null;
+    onmessageerror = null;
+    dispatchEvent() {
+      return true;
+    }
+  } as unknown as typeof BroadcastChannel;
+});
+
+import { hexToRgb } from '@/core/screenshot/color';
+import { actionSteps, calloutAccent, DEFAULT_CALLOUT_COLOR, stepNumbers, tint } from '../blocks';
+import { db } from '../db';
+import { insertBlock } from '../service';
+import type { BlockType, CalloutVariant, Guide, Step } from '../types';
+
+const HEX = /^#[0-9A-F]{6}$/;
+
+function makeStep(overrides: Partial<Step> & { id: string }): Step {
+  return {
+    guideId: 'g1',
+    index: 0,
+    description: 'Click Save',
+    action: 'click',
+    url: 'https://example.com',
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeBlock(id: string, blockType: BlockType, overrides?: Partial<Step>): Step {
+  return makeStep({ id, action: blockType, url: '', blockType, ...overrides });
+}
+
+function makeCallout(overrides?: Partial<Step>): Step {
+  return makeBlock('c1', 'callout', overrides);
+}
+
+async function seedGuide(id: string, steps: Step[]): Promise<Guide> {
+  const guide: Guide = {
+    id,
+    title: 'Test Guide',
+    createdAt: Date.now(),
+    updatedAt: 100,
+    stepIds: steps.map((s) => s.id),
+    starred: false,
+    deletedAt: null,
+  };
+  await db.guides.add(guide);
+  await db.steps.bulkAdd(steps.map((step, index) => ({ ...step, guideId: id, index })));
+  return guide;
+}
+
+async function storedSteps(guideId: string): Promise<Step[]> {
+  return db.steps.where('guideId').equals(guideId).sortBy('index');
+}
+
+afterEach(async () => {
+  await db.guides.clear();
+  await db.steps.clear();
+});
+
+describe('stepNumbers', () => {
+  it('numbers actions from 1 and skips blocks wherever they sit', () => {
+    const steps = [
+      makeBlock('b-first', 'heading'),
+      makeStep({ id: 'a1' }),
+      makeBlock('b-mid-1', 'callout'),
+      makeBlock('b-mid-2', 'heading'),
+      makeStep({ id: 'a2' }),
+      makeStep({ id: 'a3' }),
+      makeBlock('b-last', 'callout'),
+    ];
+
+    const numbers = stepNumbers(steps);
+
+    expect([...numbers]).toEqual([
+      ['a1', 1],
+      ['a2', 2],
+      ['a3', 3],
+    ]);
+    for (const id of ['b-first', 'b-mid-1', 'b-mid-2', 'b-last']) {
+      expect(numbers.has(id)).toBe(false);
+    }
+  });
+
+  it('numbers by position in the list, not by the stored index field', () => {
+    const numbers = stepNumbers([makeStep({ id: 'a1', index: 7 }), makeStep({ id: 'a2', index: 42 })]);
+
+    expect(numbers.get('a1')).toBe(1);
+    expect(numbers.get('a2')).toBe(2);
+  });
+
+  it('returns an empty map for no steps and for blocks only', () => {
+    expect(stepNumbers([]).size).toBe(0);
+    expect(stepNumbers([makeBlock('b1', 'heading'), makeBlock('b2', 'callout')]).size).toBe(0);
+  });
+});
+
+describe('actionSteps', () => {
+  it('keeps captured actions in order and drops every block', () => {
+    const a1 = makeStep({ id: 'a1' });
+    const a2 = makeStep({ id: 'a2' });
+
+    const result = actionSteps([makeBlock('b1', 'heading'), a1, makeBlock('b2', 'callout'), a2]);
+
+    expect(result).toEqual([a1, a2]);
+    expect(result[0]).toBe(a1);
+  });
+
+  it('returns everything when there are no blocks and nothing when there are only blocks', () => {
+    const actions = [makeStep({ id: 'a1' }), makeStep({ id: 'a2' })];
+    expect(actionSteps(actions)).toEqual(actions);
+    expect(actionSteps([makeBlock('b1', 'callout')])).toEqual([]);
+  });
+});
+
+describe('calloutAccent', () => {
+  it('gives every preset variant its own valid accent', () => {
+    const presets: CalloutVariant[] = ['info', 'warning', 'error', 'success'];
+    const accents = presets.map((calloutVariant) => calloutAccent(makeCallout({ calloutVariant })));
+
+    for (const accent of accents) expect(accent).toMatch(HEX);
+    expect(new Set(accents).size).toBe(presets.length);
+  });
+
+  it('treats a callout without a variant as info', () => {
+    expect(calloutAccent(makeCallout())).toBe(calloutAccent(makeCallout({ calloutVariant: 'info' })));
+  });
+
+  it('ignores calloutColor unless the variant is custom', () => {
+    const accent = calloutAccent(makeCallout({ calloutVariant: 'warning', calloutColor: '#000000' }));
+
+    expect(accent).not.toBe('#000000');
+    expect(accent).toBe(calloutAccent(makeCallout({ calloutVariant: 'warning' })));
+  });
+
+  it('reads the custom colour and normalizes it', () => {
+    expect(calloutAccent(makeCallout({ calloutVariant: 'custom', calloutColor: '#123456' }))).toBe('#123456');
+    expect(calloutAccent(makeCallout({ calloutVariant: 'custom', calloutColor: '#abc' }))).toBe('#AABBCC');
+  });
+
+  it('falls back to the default colour on a malformed custom hex', () => {
+    for (const calloutColor of ['', 'indigo', '#12345', '#1234567', 'ffffff!']) {
+      expect(calloutAccent(makeCallout({ calloutVariant: 'custom', calloutColor }))).toBe(DEFAULT_CALLOUT_COLOR);
+    }
+    expect(calloutAccent(makeCallout({ calloutVariant: 'custom' }))).toBe(DEFAULT_CALLOUT_COLOR);
+  });
+});
+
+describe('tint', () => {
+  it('lightens every channel without passing white', () => {
+    const source = '#4F46E5';
+    const result = tint(source);
+
+    expect(result).toMatch(HEX);
+    expect(result).not.toBe(source);
+
+    const before = hexToRgb(source)!;
+    const after = hexToRgb(result)!;
+    for (let i = 0; i < 3; i++) {
+      expect(after[i]).toBeGreaterThan(before[i]);
+      expect(after[i]).toBeLessThanOrEqual(255);
+    }
+  });
+
+  it('scales between the original colour and white', () => {
+    expect(tint('#4F46E5', 1)).toBe('#4F46E5');
+    expect(tint('#4F46E5', 0)).toBe('#FFFFFF');
+    expect(tint('#000000', 0.12)).toBe('#E0E0E0');
+  });
+
+  it('leans further toward white as the ratio shrinks', () => {
+    const light = hexToRgb(tint('#4F46E5', 0.1))!;
+    const dark = hexToRgb(tint('#4F46E5', 0.5))!;
+
+    for (let i = 0; i < 3; i++) expect(light[i]).toBeGreaterThan(dark[i]);
+  });
+
+  it('returns white for an unparseable colour', () => {
+    expect(tint('nope')).toBe('#FFFFFF');
+  });
+});
+
+describe('insertBlock', () => {
+  it('places the block at the requested index and re-indexes the rest contiguously', async () => {
+    await seedGuide('g1', [makeStep({ id: 's1' }), makeStep({ id: 's2' }), makeStep({ id: 's3' })]);
+
+    const blockId = await insertBlock('g1', 1, 'heading', 'Set up the account');
+
+    const steps = await storedSteps('g1');
+    expect(steps.map((s) => s.id)).toEqual(['s1', blockId, 's2', 's3']);
+    expect(steps.map((s) => s.index)).toEqual([0, 1, 2, 3]);
+
+    const guide = await db.guides.get('g1');
+    expect(guide!.stepIds).toEqual(['s1', blockId, 's2', 's3']);
+    expect(guide!.updatedAt).toBeGreaterThan(100);
+  });
+
+  it('stores the block text as the description and leaves capture fields empty', async () => {
+    await seedGuide('g1', [makeStep({ id: 's1' })]);
+
+    const blockId = await insertBlock('g1', 1, 'heading', 'Set up the account');
+
+    const block = await db.steps.get(blockId);
+    expect(block!.blockType).toBe('heading');
+    expect(block!.description).toBe('Set up the account');
+    expect(block!.url).toBe('');
+    expect(block!.screenshotId).toBeUndefined();
+    expect(block!.elementMeta).toBeUndefined();
+    expect(block!.calloutVariant).toBeUndefined();
+  });
+
+  it('defaults a callout to the info variant', async () => {
+    await seedGuide('g1', []);
+
+    const blockId = await insertBlock('g1', 0, 'callout', 'Watch out');
+
+    const block = await db.steps.get(blockId);
+    expect(block!.calloutVariant).toBe('info');
+    expect(calloutAccent(block!)).toBe(calloutAccent(makeCallout({ calloutVariant: 'info' })));
+  });
+
+  it('inserts at 0 ahead of every existing step', async () => {
+    await seedGuide('g1', [makeStep({ id: 's1' }), makeStep({ id: 's2' })]);
+
+    const blockId = await insertBlock('g1', 0, 'heading', 'Before you start');
+
+    const steps = await storedSteps('g1');
+    expect(steps.map((s) => s.id)).toEqual([blockId, 's1', 's2']);
+    expect(steps.map((s) => s.index)).toEqual([0, 1, 2]);
+    expect((await db.guides.get('g1'))!.stepIds).toEqual([blockId, 's1', 's2']);
+  });
+
+  it('appends when the index is past the end', async () => {
+    await seedGuide('g1', [makeStep({ id: 's1' }), makeStep({ id: 's2' })]);
+
+    const blockId = await insertBlock('g1', 99, 'callout', 'All done');
+
+    const steps = await storedSteps('g1');
+    expect(steps.map((s) => s.id)).toEqual(['s1', 's2', blockId]);
+    expect(steps.map((s) => s.index)).toEqual([0, 1, 2]);
+    expect((await db.guides.get('g1'))!.stepIds).toEqual(['s1', 's2', blockId]);
+  });
+
+  it('leaves the action numbering untouched once a block is in the middle', async () => {
+    await seedGuide('g1', [makeStep({ id: 's1' }), makeStep({ id: 's2' }), makeStep({ id: 's3' })]);
+
+    const blockId = await insertBlock('g1', 2, 'heading', 'Finish up');
+
+    const steps = await storedSteps('g1');
+    expect(actionSteps(steps).map((s) => s.id)).toEqual(['s1', 's2', 's3']);
+
+    const numbers = stepNumbers(steps);
+    expect(numbers.get('s1')).toBe(1);
+    expect(numbers.get('s2')).toBe(2);
+    expect(numbers.get('s3')).toBe(3);
+    expect(numbers.has(blockId)).toBe(false);
+  });
+});

--- a/src/core/guides/blocks.ts
+++ b/src/core/guides/blocks.ts
@@ -1,0 +1,57 @@
+import { i18n } from '#imports';
+import { hexToRgb, normalizeHex, rgbToHex } from '@/core/screenshot/color';
+import type { CalloutVariant, Step } from './types';
+
+export const CALLOUT_VARIANTS: CalloutVariant[] = ['info', 'warning', 'error', 'success', 'custom'];
+
+const VARIANT_LABEL_KEYS = {
+  info: 'blocks.variantInfo',
+  warning: 'blocks.variantWarning',
+  error: 'blocks.variantError',
+  success: 'blocks.variantSuccess',
+  custom: 'blocks.variantCustom',
+} as const satisfies Record<CalloutVariant, string>;
+
+export function variantLabel(variant: CalloutVariant): string {
+  return i18n.t(VARIANT_LABEL_KEYS[variant]);
+}
+
+export const DEFAULT_CALLOUT_COLOR = '#4F46E5';
+
+const VARIANT_ACCENTS: Record<CalloutVariant, string> = {
+  info: '#4F46E5',
+  warning: '#D97706',
+  error: '#DC2626',
+  success: '#059669',
+  custom: DEFAULT_CALLOUT_COLOR,
+};
+
+export function isBlock(step: Step): boolean {
+  return step.blockType !== undefined;
+}
+
+export function actionSteps(steps: Step[]): Step[] {
+  return steps.filter((step) => step.blockType === undefined);
+}
+
+export function stepNumbers(steps: Step[]): Map<string, number> {
+  const numbers = new Map<string, number>();
+  let n = 0;
+  for (const step of steps) {
+    if (step.blockType === undefined) numbers.set(step.id, ++n);
+  }
+  return numbers;
+}
+
+export function calloutAccent(step: Step): string {
+  const variant = step.calloutVariant ?? 'info';
+  if (variant === 'custom') return normalizeHex(step.calloutColor ?? '') ?? DEFAULT_CALLOUT_COLOR;
+  return VARIANT_ACCENTS[variant];
+}
+
+export function tint(hex: string, ratio = 0.12): string {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return '#FFFFFF';
+  const [r, g, b] = rgb.map((channel) => 255 + (channel - 255) * ratio);
+  return rgbToHex(r, g, b);
+}

--- a/src/core/guides/service.ts
+++ b/src/core/guides/service.ts
@@ -2,7 +2,7 @@ import { i18n } from '#imports';
 import type { ScreenshotEdits } from '@/core/screenshot/types';
 import { db } from './db';
 import { hashPayload } from './snapshot-hash';
-import type { Guide, Screenshot, Snapshot, Step } from './types';
+import type { BlockType, CalloutVariant, Guide, Screenshot, Snapshot, Step } from './types';
 
 export type GuideChangeEvent = { type: 'starred'; id: string; starred: boolean } | { type: 'mutated' };
 
@@ -137,6 +137,37 @@ export async function reorderSteps(guideId: string, orderedStepIds: string[]): P
 
 export async function createStep(step: Step): Promise<void> {
   await db.steps.add(step);
+}
+
+export async function insertBlock(
+  guideId: string,
+  atIndex: number,
+  blockType: BlockType,
+  description: string,
+): Promise<string> {
+  const id = crypto.randomUUID();
+  await db.transaction('rw', db.steps, db.guides, async () => {
+    const steps = await db.steps.where('guideId').equals(guideId).sortBy('index');
+    const block: Step = {
+      id,
+      guideId,
+      index: 0,
+      description,
+      action: blockType,
+      url: '',
+      timestamp: Date.now(),
+      blockType,
+      ...(blockType === 'callout' ? { calloutVariant: 'info' as const } : {}),
+    };
+    steps.splice(Math.max(0, Math.min(atIndex, steps.length)), 0, block);
+    await db.steps.bulkPut(steps.map((step, index) => ({ ...step, index })));
+    await db.guides.update(guideId, { stepIds: steps.map((step) => step.id), updatedAt: Date.now() });
+  });
+  return id;
+}
+
+export async function updateCallout(stepId: string, variant: CalloutVariant, color?: string): Promise<void> {
+  await db.steps.update(stepId, { calloutVariant: variant, calloutColor: color });
 }
 
 export async function updateStepDescription(stepId: string, description: string): Promise<void> {

--- a/src/core/guides/types.ts
+++ b/src/core/guides/types.ts
@@ -11,6 +11,10 @@ export interface Guide {
   deletedAt: number | null;
 }
 
+export type BlockType = 'heading' | 'callout';
+
+export type CalloutVariant = 'info' | 'warning' | 'error' | 'success' | 'custom';
+
 export interface Step {
   id: string;
   guideId: string;
@@ -23,6 +27,9 @@ export interface Step {
   elementMeta?: ElementMeta;
   inputValue?: string;
   aiPending?: boolean;
+  blockType?: BlockType;
+  calloutVariant?: CalloutVariant;
+  calloutColor?: string;
 }
 
 export interface ScreenshotBounds {

--- a/src/entrypoints/background/guide-meta.ts
+++ b/src/entrypoints/background/guide-meta.ts
@@ -1,6 +1,7 @@
 import { i18n } from '#imports';
 import { generateGuideMeta } from '@/core/capture/ai/meta';
 import { AI_PROVIDERS } from '@/core/capture/ai/models';
+import { actionSteps } from '@/core/guides/blocks';
 import { getGuideDomain, getStepsForGuide, updateGuideDescription, updateGuideTitle } from '@/core/guides/service';
 import { localStorage } from '@/lib/browser-api';
 import { logger } from '@/lib/logger';
@@ -16,7 +17,7 @@ async function resolveGuideMetaInputs(guideId: string): Promise<GuideMetaInputs>
   const settings = await localStorage.get(['aiApiKey', 'aiProvider', 'aiModel']);
   if (!settings.aiApiKey) return { ok: false, reason: 'no-api-key' };
 
-  const steps = await getStepsForGuide(guideId);
+  const steps = actionSteps(await getStepsForGuide(guideId));
   const described = steps.filter((s) => s.description).map((s) => ({ description: s.description, url: s.url }));
   if (described.length === 0) return { ok: false, reason: 'no-steps' };
 

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -3,6 +3,7 @@ import { rewriteSelection } from '@/core/capture/ai/rewrite';
 import { validateApiKey } from '@/core/capture/ai/validate';
 import { stepRequiresManual } from '@/core/guideme/manual';
 import { advanceSession, cancelSession, completeSession, getSession, startSession } from '@/core/guideme/session';
+import { actionSteps } from '@/core/guides/blocks';
 import { createGuide, getScreenshotsForSteps, getStepsForGuide } from '@/core/guides/service';
 import type { Step } from '@/core/guides/types';
 import { getActiveTab, localStorage, sendMessageToTab, setSidePanelBehavior, updateTab } from '@/lib/browser-api';
@@ -154,7 +155,7 @@ export default defineBackground(() => {
   });
 
   onMessage('startGuideMe', async ({ data }) => {
-    const steps = await getStepsForGuide(data.guideId);
+    const steps = actionSteps(await getStepsForGuide(data.guideId));
     if (steps.length === 0) return { started: false, error: 'No steps' };
 
     const firstStep = steps.find((s) => s.elementMeta) ?? steps[0];
@@ -175,7 +176,7 @@ export default defineBackground(() => {
     const session = sessionData.guideMeSession as { guideId: string } | undefined;
     if (!session) return { advanced: false };
 
-    const steps = await getStepsForGuide(session.guideId);
+    const steps = actionSteps(await getStepsForGuide(session.guideId));
     const nextIndex = data.stepIndex + 1;
 
     if (nextIndex >= steps.length) {
@@ -208,7 +209,7 @@ export default defineBackground(() => {
     const session = sessionData.guideMeSession as { guideId: string } | undefined;
     if (!session) return { moved: false };
 
-    const steps = await getStepsForGuide(session.guideId);
+    const steps = actionSteps(await getStepsForGuide(session.guideId));
     const target = steps[data.stepIndex];
     if (!target) return { moved: false };
     await advanceSession(target, data.stepIndex, await resolveManual(target));

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -189,6 +189,20 @@ editor:
   descriptionErrorSaveFailed: Die Beschreibung wurde erstellt, konnte aber nicht gespeichert werden. Versuche es erneut.
   writingStepDescription: "Beschreibung wird geschrieben…"
 
+blocks:
+  add: "Block hinzufügen"
+  heading: "Überschrift"
+  callout: Hinweis
+  headingPlaceholder: Abschnittstitel
+  calloutPlaceholder: Hinweis schreiben
+  deleteHeading: "Diese Überschrift löschen?"
+  deleteCallout: "Diesen Hinweis löschen?"
+  variantInfo: Info
+  variantWarning: Warnung
+  variantError: Fehler
+  variantSuccess: Erfolg
+  variantCustom: Benutzerdefiniert
+
 history:
   title: Versionsverlauf
   current: Aktuell

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -189,6 +189,20 @@ editor:
   rewriteErrorFailed: Could not rewrite the selection. Try again.
   rewriteErrorStale: The text changed. Select it again.
 
+blocks:
+  add: Add block
+  heading: Heading
+  callout: Note
+  headingPlaceholder: Section title
+  calloutPlaceholder: Write a note
+  deleteHeading: "Delete this heading?"
+  deleteCallout: "Delete this note?"
+  variantInfo: Info
+  variantWarning: Warning
+  variantError: Error
+  variantSuccess: Success
+  variantCustom: Custom
+
 history:
   title: Version History
   current: Current

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -189,6 +189,20 @@ editor:
   rewriteErrorFailed: "No se pudo reescribir la selecci\xF3n. Int\xE9ntalo de nuevo."
   rewriteErrorStale: "El texto cambi\xF3. Vuelve a seleccionarlo."
 
+blocks:
+  add: "Añadir bloque"
+  heading: Encabezado
+  callout: Nota
+  headingPlaceholder: "Título de sección"
+  calloutPlaceholder: Escribe una nota
+  deleteHeading: "¿Eliminar este encabezado?"
+  deleteCallout: "¿Eliminar esta nota?"
+  variantInfo: "Información"
+  variantWarning: Advertencia
+  variantError: Error
+  variantSuccess: "Éxito"
+  variantCustom: Personalizado
+
 history:
   title: Historial de versiones
   current: Actual

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -189,6 +189,20 @@ editor:
   rewriteErrorFailed: "Impossible de r\xE9\xE9crire la s\xE9lection. R\xE9essayez."
   rewriteErrorStale: "Le texte a chang\xE9. S\xE9lectionnez-le \xE0 nouveau."
 
+blocks:
+  add: Ajouter un bloc
+  heading: Titre
+  callout: Note
+  headingPlaceholder: "Titre de section"
+  calloutPlaceholder: "Écrivez une note"
+  deleteHeading: "Supprimer ce titre ?"
+  deleteCallout: "Supprimer cette note ?"
+  variantInfo: Information
+  variantWarning: Avertissement
+  variantError: Erreur
+  variantSuccess: "Succès"
+  variantCustom: "Personnalisé"
+
 history:
   title: Historique des versions
   current: Actuelle

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -189,6 +189,20 @@ editor:
   rewriteErrorFailed: "N\xE3o foi poss\xEDvel reescrever a sele\xE7\xE3o. Tente novamente."
   rewriteErrorStale: O texto mudou. Selecione-o novamente.
 
+blocks:
+  add: Adicionar bloco
+  heading: "Título"
+  callout: Nota
+  headingPlaceholder: "Título da seção"
+  calloutPlaceholder: Escreva uma nota
+  deleteHeading: "Excluir este título?"
+  deleteCallout: "Excluir esta nota?"
+  variantInfo: "Informação"
+  variantWarning: Aviso
+  variantError: Erro
+  variantSuccess: Sucesso
+  variantCustom: Personalizado
+
 history:
   title: Histórico de versões
   current: Atual

--- a/src/ui/fullview/GuideContent.tsx
+++ b/src/ui/fullview/GuideContent.tsx
@@ -2,6 +2,7 @@ import { History, Loader2, Play, Sparkles } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { TypeAnimation } from 'react-type-animation';
 import { i18n } from '#imports';
+import { actionSteps } from '@/core/guides/blocks';
 import {
   deleteStep,
   getGuide,
@@ -118,7 +119,7 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
       }
       document.title = `${newTitle} — ${i18n.t('app_name')}`;
       setGuideTitle(newTitle);
-      setGuideStepCount(result.steps.length);
+      setGuideStepCount(actionSteps(result.steps).length);
       setGuideExportData({ guideId, ...result });
     }
     setLoading(false);
@@ -287,6 +288,7 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
   const previewView = preview && previewData?.snapshotId === preview.id ? previewData : null;
   const viewSteps = previewView ? previewView.steps : data.steps;
   const viewScreenshots = previewView ? previewView.screenshots : data.screenshots;
+  const actionCount = actionSteps(viewSteps).length;
   const domain = getMostCommonDomain(viewSteps);
   const editingScreenshot = editingStepId ? data.screenshots.get(editingStepId) : undefined;
   const animatingTitle = preview ? null : typingTitle;
@@ -431,9 +433,9 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
               {formatDate(data.guide.createdAt)}
             </span>
             <span className="inline-flex items-center text-[11px] font-medium text-muted-foreground bg-card border border-border px-2.5 py-0.5 rounded-full">
-              {viewSteps.length !== 1
-                ? i18n.t('fullview_stepCountPlural', [String(viewSteps.length)])
-                : i18n.t('fullview_stepCount', [String(viewSteps.length)])}
+              {actionCount !== 1
+                ? i18n.t('fullview_stepCountPlural', [String(actionCount)])
+                : i18n.t('fullview_stepCount', [String(actionCount)])}
             </span>
             {domain && (
               <span className="inline-flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground bg-card border border-border pl-1.5 pr-2.5 py-0.5 rounded-full">

--- a/src/ui/fullview/TopNav.tsx
+++ b/src/ui/fullview/TopNav.tsx
@@ -138,10 +138,12 @@ export default function TopNav({ route }: TopNavProps) {
               <History size={14} />
               {i18n.t('editor.versionHistory')}
             </Button>
-            <Button size="sm" onClick={() => setExportOpen(true)}>
-              <Download size={14} />
-              {i18n.t('common.export')}
-            </Button>
+            {!editing && (
+              <Button size="sm" onClick={() => setExportOpen(true)}>
+                <Download size={14} />
+                {i18n.t('common.export')}
+              </Button>
+            )}
             <ExportPreviewModal
               open={exportOpen}
               onOpenChange={setExportOpen}

--- a/src/ui/fullview/components/GuideStepList.tsx
+++ b/src/ui/fullview/components/GuideStepList.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
-import { reorderSteps } from '@/core/guides/service';
-import type { Screenshot, Step } from '@/core/guides/types';
+import { isBlock, stepNumbers } from '@/core/guides/blocks';
+import { insertBlock, reorderSteps } from '@/core/guides/service';
+import type { BlockType, Screenshot, Step } from '@/core/guides/types';
 import { useFullview } from '@/stores/fullview';
+import BlockCard from '@/ui/shared/BlockCard';
 import EmptyGuideState from '@/ui/shared/EmptyGuideState';
 import { dominantRatio } from '@/ui/shared/ImagePlaceholder';
+import InsertBlockMenu from '@/ui/shared/InsertBlockMenu';
 import StepCard from '@/ui/sidepanel/StepCard';
 
 interface GuideStepListProps {
@@ -40,6 +43,7 @@ export default function GuideStepList({
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
   const stepRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const frameRatio = dominantRatio(screenshots);
+  const numbers = stepNumbers(steps);
 
   useEffect(() => {
     if (scrollToStepId) {
@@ -78,12 +82,38 @@ export default function GuideStepList({
     setDragOverIndex(null);
   };
 
+  const handleInsertBlock = async (atIndex: number, blockType: BlockType) => {
+    await insertBlock(guideId, atIndex, blockType, '');
+    onChanged?.();
+  };
+
+  const dragHandlers = (idx: number) =>
+    readOnly
+      ? undefined
+      : {
+          onDragStart: (e: React.DragEvent) => {
+            setDragIndex(idx);
+            e.dataTransfer.effectAllowed = 'move';
+          },
+          onDragOver: (e: React.DragEvent) => {
+            e.preventDefault();
+            setDragOverIndex(idx);
+          },
+          onDragEnd: handleDragEnd,
+        };
+
   if (steps.length === 0) {
-    return <EmptyGuideState />;
+    return (
+      <div className="flex flex-col">
+        <EmptyGuideState />
+        {!readOnly && <InsertBlockMenu onInsert={(blockType) => handleInsertBlock(0, blockType)} />}
+      </div>
+    );
   }
 
   return (
     <div className="space-y-6">
+      {!readOnly && <InsertBlockMenu onInsert={(blockType) => handleInsertBlock(0, blockType)} />}
       {steps.map((step, idx) => (
         <div
           key={step.id}
@@ -96,33 +126,32 @@ export default function GuideStepList({
           {dragOverIndex === idx && dragIndex !== null && dragIndex !== idx && (
             <div className="h-1 bg-accent rounded-full mx-4 mb-2" />
           )}
-          <StepCard
-            step={step}
-            screenshot={screenshots.get(step.id)}
-            placeholderRatio={frameRatio}
-            frameRatio={frameRatio}
-            onDescriptionChange={onDescriptionChange}
-            onDelete={onDelete}
-            onOpenEditor={onOpenEditor}
-            readOnly={readOnly}
-            hasApiKey={hasApiKey}
-            onChanged={onChanged}
-            dragHandleProps={
-              readOnly
-                ? undefined
-                : {
-                    onDragStart: (e: React.DragEvent) => {
-                      setDragIndex(idx);
-                      e.dataTransfer.effectAllowed = 'move';
-                    },
-                    onDragOver: (e: React.DragEvent) => {
-                      e.preventDefault();
-                      setDragOverIndex(idx);
-                    },
-                    onDragEnd: handleDragEnd,
-                  }
-            }
-          />
+          {isBlock(step) ? (
+            <BlockCard
+              step={step}
+              onDescriptionChange={onDescriptionChange}
+              onDelete={onDelete}
+              onChanged={onChanged}
+              readOnly={readOnly}
+              dragHandleProps={dragHandlers(idx)}
+            />
+          ) : (
+            <StepCard
+              step={step}
+              number={numbers.get(step.id) ?? 0}
+              screenshot={screenshots.get(step.id)}
+              placeholderRatio={frameRatio}
+              frameRatio={frameRatio}
+              onDescriptionChange={onDescriptionChange}
+              onDelete={onDelete}
+              onOpenEditor={onOpenEditor}
+              readOnly={readOnly}
+              hasApiKey={hasApiKey}
+              onChanged={onChanged}
+              dragHandleProps={dragHandlers(idx)}
+            />
+          )}
+          {!readOnly && <InsertBlockMenu onInsert={(blockType) => handleInsertBlock(idx + 1, blockType)} />}
         </div>
       ))}
     </div>

--- a/src/ui/shared/BlockCard.tsx
+++ b/src/ui/shared/BlockCard.tsx
@@ -1,0 +1,148 @@
+import { Trash2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { i18n } from '#imports';
+import { CALLOUT_VARIANTS, calloutAccent, DEFAULT_CALLOUT_COLOR, tint, variantLabel } from '@/core/guides/blocks';
+import { updateCallout } from '@/core/guides/service';
+import type { CalloutVariant, Step } from '@/core/guides/types';
+import ConfirmDialog from '@/ui/shared/ConfirmDialog';
+
+interface DragHandleProps {
+  onDragStart: (e: React.DragEvent) => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDragEnd: () => void;
+}
+
+interface BlockCardProps {
+  step: Step;
+  onDescriptionChange: (stepId: string, description: string) => void;
+  onDelete: (stepId: string) => void;
+  onChanged?: () => void;
+  dragHandleProps?: DragHandleProps;
+  readOnly?: boolean;
+}
+
+export default function BlockCard({
+  step,
+  onDescriptionChange,
+  onDelete,
+  onChanged,
+  dragHandleProps,
+  readOnly,
+}: BlockCardProps) {
+  const [description, setDescription] = useState(step.description);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  useEffect(() => {
+    setDescription(step.description);
+  }, [step.description]);
+
+  const isHeading = step.blockType === 'heading';
+  const accent = calloutAccent(step);
+  const variant = step.calloutVariant ?? 'info';
+
+  const pickVariant = async (next: CalloutVariant) => {
+    await updateCallout(step.id, next, next === 'custom' ? (step.calloutColor ?? DEFAULT_CALLOUT_COLOR) : undefined);
+    onChanged?.();
+  };
+
+  const pickColor = async (color: string) => {
+    await updateCallout(step.id, 'custom', color);
+    onChanged?.();
+  };
+
+  const textClass = isHeading
+    ? 'text-[15px] font-bold leading-tight text-foreground'
+    : 'text-[13px] font-medium leading-snug text-foreground';
+
+  return (
+    <div
+      draggable={!!dragHandleProps}
+      onDragStart={dragHandleProps?.onDragStart}
+      onDragOver={(e) => {
+        e.preventDefault();
+        dragHandleProps?.onDragOver(e);
+      }}
+      onDragEnd={dragHandleProps?.onDragEnd}
+      className="mb-3"
+    >
+      <div
+        className={isHeading ? 'border-b border-foreground pb-1.5' : 'rounded-lg px-3 py-2.5 border-l-[3px]'}
+        style={isHeading ? undefined : { borderLeftColor: accent, background: tint(accent) }}
+      >
+        {readOnly ? (
+          <p className={`${textClass} whitespace-pre-wrap`}>{step.description}</p>
+        ) : (
+          <textarea
+            className={`${textClass} w-full resize-none outline-none border-0 bg-transparent p-0`}
+            value={description}
+            rows={1}
+            ref={(el) => {
+              if (el) {
+                el.style.height = '0';
+                el.style.height = `${el.scrollHeight}px`;
+              }
+            }}
+            onChange={(e) => {
+              setDescription(e.target.value);
+              e.target.style.height = '0';
+              e.target.style.height = `${e.target.scrollHeight}px`;
+            }}
+            onBlur={() => {
+              if (description !== step.description) onDescriptionChange(step.id, description);
+            }}
+            placeholder={isHeading ? i18n.t('blocks.headingPlaceholder') : i18n.t('blocks.calloutPlaceholder')}
+          />
+        )}
+      </div>
+      {!readOnly && (
+        <div className="flex items-center gap-1 mt-1">
+          {!isHeading &&
+            CALLOUT_VARIANTS.map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => pickVariant(option)}
+                title={variantLabel(option)}
+                aria-label={variantLabel(option)}
+                aria-pressed={variant === option}
+                className={`w-3.5 h-3.5 rounded-full border ${variant === option ? 'border-foreground' : 'border-border'}`}
+                style={{
+                  background:
+                    option === 'custom' && variant !== 'custom'
+                      ? 'linear-gradient(135deg,#DC2626,#4F46E5,#059669)'
+                      : calloutAccent({ ...step, calloutVariant: option }),
+                }}
+              />
+            ))}
+          {!isHeading && variant === 'custom' && (
+            <input
+              type="color"
+              value={accent}
+              onChange={(e) => pickColor(e.target.value)}
+              title={variantLabel('custom')}
+              className="w-5 h-4 bg-transparent border-0 p-0 cursor-pointer"
+            />
+          )}
+          <button
+            type="button"
+            onClick={() => setConfirmDelete(true)}
+            className="ml-auto p-1 rounded-md transition-colors text-border hover:text-destructive"
+            title={isHeading ? i18n.t('blocks.deleteHeading') : i18n.t('blocks.deleteCallout')}
+          >
+            <Trash2 size={13} />
+          </button>
+        </div>
+      )}
+      <ConfirmDialog
+        open={confirmDelete}
+        title={isHeading ? i18n.t('blocks.deleteHeading') : i18n.t('blocks.deleteCallout')}
+        destructive
+        onConfirm={() => {
+          setConfirmDelete(false);
+          onDelete(step.id);
+        }}
+        onCancel={() => setConfirmDelete(false)}
+      />
+    </div>
+  );
+}

--- a/src/ui/shared/InsertBlockMenu.tsx
+++ b/src/ui/shared/InsertBlockMenu.tsx
@@ -1,0 +1,71 @@
+import { Heading, Plus, StickyNote } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { i18n } from '#imports';
+import type { BlockType } from '@/core/guides/types';
+
+interface InsertBlockMenuProps {
+  onInsert: (blockType: BlockType) => void;
+}
+
+export default function InsertBlockMenu({ onInsert }: InsertBlockMenuProps) {
+  const [open, setOpen] = useState(false);
+  const rowRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (e: MouseEvent) => {
+      if (rowRef.current && !rowRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handlePointerDown);
+    return () => document.removeEventListener('mousedown', handlePointerDown);
+  }, [open]);
+
+  const choices = [
+    { type: 'heading' as const, icon: Heading, label: i18n.t('blocks.heading') },
+    { type: 'callout' as const, icon: StickyNote, label: i18n.t('blocks.callout') },
+  ];
+
+  return (
+    <div
+      ref={rowRef}
+      onKeyDown={(e) => {
+        if (e.key !== 'Escape' || !open) return;
+        setOpen(false);
+        triggerRef.current?.focus();
+      }}
+      className="group relative flex items-center justify-center gap-1 h-6 my-1"
+    >
+      <span
+        aria-hidden="true"
+        className={`absolute inset-x-0 top-1/2 border-t border-dashed border-border transition-opacity ${open ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100'}`}
+      />
+      <button
+        type="button"
+        ref={triggerRef}
+        onClick={() => setOpen((prev) => !prev)}
+        title={i18n.t('blocks.add')}
+        aria-label={i18n.t('blocks.add')}
+        aria-expanded={open}
+        className={`relative flex items-center justify-center w-5 h-5 rounded-full border border-border bg-card text-purple transition-opacity hover:text-accent focus-visible:opacity-100 group-hover:opacity-100 ${open ? 'opacity-100 text-accent' : 'opacity-0'}`}
+      >
+        <Plus size={13} />
+      </button>
+      {open &&
+        choices.map((choice) => (
+          <button
+            key={choice.type}
+            type="button"
+            onClick={() => {
+              setOpen(false);
+              onInsert(choice.type);
+            }}
+            className="relative flex items-center gap-1 rounded-full border border-border bg-card px-2 py-0.5 text-[11px] font-medium text-purple hover:text-accent hover:bg-secondary"
+          >
+            <choice.icon size={13} />
+            {choice.label}
+          </button>
+        ))}
+    </div>
+  );
+}

--- a/src/ui/shared/InsertBlockMenu.tsx
+++ b/src/ui/shared/InsertBlockMenu.tsx
@@ -36,10 +36,7 @@ export default function InsertBlockMenu({ onInsert }: InsertBlockMenuProps) {
       }}
       className="group relative flex items-center justify-center gap-1 h-6 my-1"
     >
-      <span
-        aria-hidden="true"
-        className={`absolute inset-x-0 top-1/2 border-t border-dashed border-border transition-opacity ${open ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100'}`}
-      />
+      <span aria-hidden="true" className="absolute inset-x-0 top-1/2 border-t border-dashed border-border" />
       <button
         type="button"
         ref={triggerRef}
@@ -47,7 +44,7 @@ export default function InsertBlockMenu({ onInsert }: InsertBlockMenuProps) {
         title={i18n.t('blocks.add')}
         aria-label={i18n.t('blocks.add')}
         aria-expanded={open}
-        className={`relative flex items-center justify-center w-5 h-5 rounded-full border border-border bg-card text-purple transition-opacity hover:text-accent focus-visible:opacity-100 group-hover:opacity-100 ${open ? 'opacity-100 text-accent' : 'opacity-0'}`}
+        className={`relative flex items-center justify-center w-5 h-5 rounded-full border border-border bg-card transition-colors hover:text-accent hover:border-accent ${open ? 'text-accent border-accent' : 'text-purple'}`}
       >
         <Plus size={13} />
       </button>

--- a/src/ui/sidepanel/GuideEditor.tsx
+++ b/src/ui/sidepanel/GuideEditor.tsx
@@ -1,27 +1,31 @@
 import { ArrowLeft, Check, Layers, Loader2, Maximize2, Pencil, Play, Sparkles } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { i18n } from '#imports';
+import { actionSteps, isBlock, stepNumbers } from '@/core/guides/blocks';
 import {
   createSnapshot,
   deleteStep,
   getGuide,
+  insertBlock,
   onGuidesChanged,
   reorderSteps,
   updateGuideDescription,
   updateGuideTitle,
   updateStepDescription,
 } from '@/core/guides/service';
-import type { Guide, Screenshot, Step } from '@/core/guides/types';
+import type { BlockType, Guide, Screenshot, Step } from '@/core/guides/types';
 import { createTab, focusWindow, getExtensionURL, localStorage, queryTabs, updateTab } from '@/lib/browser-api';
 import { logger } from '@/lib/logger';
 import { sendMessage } from '@/lib/messaging';
 import { getMostCommonDomain } from '@/lib/utils';
 import { Input } from '@/ui/components/ui/input';
 import { useAskAi } from '@/ui/shared/AskAi';
+import BlockCard from '@/ui/shared/BlockCard';
 import EmptyGuideState from '@/ui/shared/EmptyGuideState';
 import FaviconImg from '@/ui/shared/FaviconImg';
 import { guideDescriptionErrorMessage } from '@/ui/shared/guide-description-error';
 import { dominantRatio } from '@/ui/shared/ImagePlaceholder';
+import InsertBlockMenu from '@/ui/shared/InsertBlockMenu';
 import Toast from '@/ui/shared/Toast';
 import ExportMenu from './ExportMenu';
 import StepCard from './StepCard';
@@ -161,6 +165,14 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
     [guideId, loadGuide, applyGuide],
   );
 
+  const handleInsertBlock = useCallback(
+    async (atIndex: number, blockType: BlockType) => {
+      await insertBlock(guideId, atIndex, blockType, '');
+      await loadGuide();
+    },
+    [guideId, loadGuide],
+  );
+
   const openInFullView = useCallback((targetGuideId: string, options?: OpenInFullViewOptions) => {
     const params = new URLSearchParams({ guideId: targetGuideId });
     if (options?.stepId) params.set('stepId', options.stepId);
@@ -201,6 +213,39 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
   }
 
   const metaGenerating = title === i18n.t('fullview.untitledGuide') && data.steps.length > 0 && !description;
+  const actionCount = actionSteps(data.steps).length;
+  const numbers = stepNumbers(data.steps);
+
+  const dragHandlers = (idx: number) =>
+    editing
+      ? {
+          onDragStart: (e: React.DragEvent) => {
+            setDragIndex(idx);
+            e.dataTransfer.effectAllowed = 'move';
+          },
+          onDragOver: (e: React.DragEvent) => {
+            e.preventDefault();
+            setDragOverIndex(idx);
+          },
+          onDragEnd: () => {
+            if (dragIndex !== null && dragOverIndex !== null && dragIndex !== dragOverIndex) {
+              setData((prev) => {
+                if (!prev) return prev;
+                const newSteps = [...prev.steps];
+                const [moved] = newSteps.splice(dragIndex, 1);
+                newSteps.splice(dragOverIndex, 0, moved);
+                reorderSteps(
+                  guideId,
+                  newSteps.map((s) => s.id),
+                );
+                return { ...prev, steps: newSteps };
+              });
+            }
+            setDragIndex(null);
+            setDragOverIndex(null);
+          },
+        }
+      : undefined;
 
   return (
     <div className="min-h-screen bg-card flex flex-col">
@@ -305,9 +350,9 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
         <div className="text-[11px] flex items-center gap-2 text-muted-foreground" style={{ marginLeft: '34px' }}>
           <span className="flex items-center gap-1">
             <Layers size={11} />
-            {data.steps.length !== 1
-              ? i18n.t('fullview.stepCountPlural', [String(data.steps.length)])
-              : i18n.t('fullview.stepCount', [String(data.steps.length)])}
+            {actionCount !== 1
+              ? i18n.t('fullview.stepCountPlural', [String(actionCount)])
+              : i18n.t('fullview.stepCount', [String(actionCount)])}
           </span>
           {(() => {
             const d = getMostCommonDomain(data.steps);
@@ -324,58 +369,47 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
       </div>
       <div className="px-4 pt-1 pb-4 flex-1 flex flex-col">
         {data.steps.length === 0 ? (
-          <EmptyGuideState />
+          <>
+            <EmptyGuideState />
+            {editing && <InsertBlockMenu onInsert={(blockType) => handleInsertBlock(0, blockType)} />}
+          </>
         ) : (
-          data.steps.map((step, idx) => (
-            <div key={step.id}>
-              {dragOverIndex === idx && dragIndex !== null && dragIndex !== idx && (
-                <div className="h-1 bg-accent rounded-full mx-4 mb-1" />
-              )}
-              <StepCard
-                step={step}
-                screenshot={data.screenshots.get(step.id)}
-                placeholderRatio={dominantRatio(data.screenshots)}
-                frameRatio={dominantRatio(data.screenshots)}
-                onDescriptionChange={handleDescriptionChange}
-                onDelete={handleDeleteStep}
-                onOpenEditor={(stepId, tool) => openInFullView(guideId, { stepId, tool })}
-                readOnly={!editing}
-                hasApiKey={hasApiKey}
-                onChanged={loadGuide}
-                dragHandleProps={
-                  editing
-                    ? {
-                        onDragStart: (e: React.DragEvent) => {
-                          setDragIndex(idx);
-                          e.dataTransfer.effectAllowed = 'move';
-                        },
-                        onDragOver: (e: React.DragEvent) => {
-                          e.preventDefault();
-                          setDragOverIndex(idx);
-                        },
-                        onDragEnd: () => {
-                          if (dragIndex !== null && dragOverIndex !== null && dragIndex !== dragOverIndex) {
-                            setData((prev) => {
-                              if (!prev) return prev;
-                              const newSteps = [...prev.steps];
-                              const [moved] = newSteps.splice(dragIndex, 1);
-                              newSteps.splice(dragOverIndex, 0, moved);
-                              reorderSteps(
-                                guideId,
-                                newSteps.map((s) => s.id),
-                              );
-                              return { ...prev, steps: newSteps };
-                            });
-                          }
-                          setDragIndex(null);
-                          setDragOverIndex(null);
-                        },
-                      }
-                    : undefined
-                }
-              />
-            </div>
-          ))
+          <>
+            {editing && <InsertBlockMenu onInsert={(blockType) => handleInsertBlock(0, blockType)} />}
+            {data.steps.map((step, idx) => (
+              <div key={step.id}>
+                {dragOverIndex === idx && dragIndex !== null && dragIndex !== idx && (
+                  <div className="h-1 bg-accent rounded-full mx-4 mb-1" />
+                )}
+                {isBlock(step) ? (
+                  <BlockCard
+                    step={step}
+                    onDescriptionChange={handleDescriptionChange}
+                    onDelete={handleDeleteStep}
+                    onChanged={loadGuide}
+                    readOnly={!editing}
+                    dragHandleProps={dragHandlers(idx)}
+                  />
+                ) : (
+                  <StepCard
+                    step={step}
+                    number={numbers.get(step.id) ?? 0}
+                    screenshot={data.screenshots.get(step.id)}
+                    placeholderRatio={dominantRatio(data.screenshots)}
+                    frameRatio={dominantRatio(data.screenshots)}
+                    onDescriptionChange={handleDescriptionChange}
+                    onDelete={handleDeleteStep}
+                    onOpenEditor={(stepId, tool) => openInFullView(guideId, { stepId, tool })}
+                    readOnly={!editing}
+                    hasApiKey={hasApiKey}
+                    onChanged={loadGuide}
+                    dragHandleProps={dragHandlers(idx)}
+                  />
+                )}
+                {editing && <InsertBlockMenu onInsert={(blockType) => handleInsertBlock(idx + 1, blockType)} />}
+              </div>
+            ))}
+          </>
         )}
       </div>
     </div>

--- a/src/ui/sidepanel/GuideEditor.tsx
+++ b/src/ui/sidepanel/GuideEditor.tsx
@@ -299,7 +299,9 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
             >
               {editing ? <Check size={15} /> : <Pencil size={15} />}
             </button>
-            <ExportMenu guideId={guideId} guide={data.guide} steps={data.steps} screenshots={data.screenshots} />
+            {!editing && (
+              <ExportMenu guideId={guideId} guide={data.guide} steps={data.steps} screenshots={data.screenshots} />
+            )}
           </div>
         </div>
         <div className="mt-1 mb-1.5" style={{ marginLeft: '34px' }}>

--- a/src/ui/sidepanel/GuideMeView.tsx
+++ b/src/ui/sidepanel/GuideMeView.tsx
@@ -4,6 +4,7 @@ import { browser, i18n } from '#imports';
 import { stepRequiresManual } from '@/core/guideme/manual';
 import type { GuideMeSession } from '@/core/guideme/session';
 import { BLOCKED_KEY, SESSION_KEY } from '@/core/guideme/session';
+import { actionSteps } from '@/core/guides/blocks';
 import { getGuide } from '@/core/guides/service';
 import type { Guide, Screenshot, Step } from '@/core/guides/types';
 import { sendMessage } from '@/lib/messaging';
@@ -112,13 +113,14 @@ export default function GuideMeView({ guideId, onExit, onComplete }: GuideMeView
     });
   }, []);
 
-  const viewedStep = data?.steps[activeStepIndex] ?? null;
+  const steps = actionSteps(data?.steps ?? []);
+  const viewedStep = steps[activeStepIndex] ?? null;
   const viewedScreenshot = viewedStep ? data?.screenshots.get(viewedStep.id) : undefined;
 
   if (loading) return <p className="text-sm text-purple p-4">{i18n.t('common.loading')}</p>;
   if (!data) return <p className="text-sm text-purple p-4">{i18n.t('guideme.guideNotFound')}</p>;
 
-  const totalSteps = data.steps.length;
+  const totalSteps = steps.length;
   const viewedIsManual = viewedStep ? stepRequiresManual(viewedStep, viewedScreenshot) : false;
   const showRoadblock = !viewedIsManual && blockedStepIndex === activeStepIndex;
   const goTo = (stepIndex: number) => sendMessage('guideMeGoTo', { stepIndex }).catch(() => {});
@@ -141,7 +143,7 @@ export default function GuideMeView({ guideId, onExit, onComplete }: GuideMeView
       </div>
 
       <div className="px-4 pb-3 flex gap-1">
-        {data.steps.map((step, idx) => (
+        {steps.map((step, idx) => (
           <div
             key={step.id}
             className={`flex-1 h-[3px] rounded-[1.5px] ${
@@ -210,7 +212,7 @@ export default function GuideMeView({ guideId, onExit, onComplete }: GuideMeView
       </div>
 
       <div className="flex-1 px-4 pb-4 overflow-y-auto">
-        {data.steps.map((step, idx) => {
+        {steps.map((step, idx) => {
           const isDone = idx < activeStepIndex;
           const isActive = idx === activeStepIndex;
           return (

--- a/src/ui/sidepanel/StepCard.tsx
+++ b/src/ui/sidepanel/StepCard.tsx
@@ -18,6 +18,7 @@ interface DragHandleProps {
 
 interface StepCardProps {
   step: Step;
+  number: number;
   screenshot: Screenshot | undefined;
   onDescriptionChange: (stepId: string, description: string) => void;
   onDelete: (stepId: string) => void;
@@ -33,6 +34,7 @@ interface StepCardProps {
 
 export default function StepCard({
   step,
+  number,
   screenshot,
   onDescriptionChange,
   onDelete,
@@ -121,7 +123,7 @@ export default function StepCard({
       {screenshot ? (
         <ScreenshotView
           screenshot={screenshot}
-          alt={`Step ${step.index + 1} screenshot`}
+          alt={`Step ${number} screenshot`}
           className="!rounded-none !border-0"
           crop
           frameRatio={frameRatio}
@@ -141,7 +143,7 @@ export default function StepCard({
       <div className="px-3 pt-2 pb-2">
         <div className="flex items-center gap-2">
           <span className="flex items-center justify-center w-[22px] h-[22px] rounded-full text-[11px] font-bold shrink-0 bg-primary text-primary-foreground">
-            {step.index + 1}
+            {number}
           </span>
           {step.aiPending ? (
             <span className="flex items-center gap-1.5 text-[13px] font-medium leading-snug flex-1 text-muted-foreground">

--- a/src/ui/sidepanel/__tests__/step-card-upload.test.tsx
+++ b/src/ui/sidepanel/__tests__/step-card-upload.test.tsx
@@ -22,6 +22,7 @@ function renderCard(readOnly: boolean) {
   return render(
     <StepCard
       step={step}
+      number={1}
       screenshot={undefined}
       readOnly={readOnly}
       onDescriptionChange={vi.fn()}


### PR DESCRIPTION
A guide was a flat list of captured actions, so the only prose not welded to a screenshot sat at the top. There was no way to title a section partway down, or to write a note nobody performed.

Headings and callouts are now `Step` rows behind an optional `blockType`, so reorder, delete and version history keep working; no migration needed. Step numbers become a computed count of actions, so a block never consumes one. Both insert from a `+` between cards and render in HTML, Markdown, PDF, DOCX and as video interstitials over the preceding screenshot, blurred. Guide Me and AI titles skip them. Callout variants carry colour only, with a text alternative in HTML.

Still open: a guide opening with a block gets a flat backdrop instead of the next screenshot, and the interstitials have not been reviewed frame by frame.

`pnpm lint`, 524 tests, Chrome and Firefox builds clean.
