### PR TITLE
feat(capture): record more steps into an existing guide

### DIFF
--- a/src/core/capture/machine.ts
+++ b/src/core/capture/machine.ts
@@ -8,7 +8,7 @@ export const CaptureState = {
 export type CaptureStateValue = (typeof CaptureState)[keyof typeof CaptureState];
 
 type CaptureEvent =
-  | { type: 'START_RECORDING'; url?: string }
+  | { type: 'START_RECORDING'; url?: string; insertTargetGuideId?: string; insertAtIndex?: number }
   | { type: 'STOP_RECORDING' }
   | { type: 'USER_ACTION' }
   | { type: 'URL_CHANGED'; url: string };
@@ -17,6 +17,8 @@ interface CaptureContext {
   currentGuideId: string | null;
   stepCount: number;
   currentUrl: string;
+  insertTargetGuideId: string | null;
+  insertAtIndex: number | null;
 }
 
 export const captureMachine = createMachine({
@@ -30,6 +32,8 @@ export const captureMachine = createMachine({
     currentGuideId: null,
     stepCount: 0,
     currentUrl: '',
+    insertTargetGuideId: null,
+    insertAtIndex: null,
   },
   states: {
     [CaptureState.IDLE]: {
@@ -40,6 +44,8 @@ export const captureMachine = createMachine({
             currentGuideId: () => crypto.randomUUID(),
             stepCount: 0,
             currentUrl: ({ event }) => event.url ?? '',
+            insertTargetGuideId: ({ event }) => event.insertTargetGuideId ?? null,
+            insertAtIndex: ({ event }) => event.insertAtIndex ?? null,
           }),
         },
       },
@@ -52,6 +58,8 @@ export const captureMachine = createMachine({
             currentGuideId: null,
             stepCount: 0,
             currentUrl: '',
+            insertTargetGuideId: null,
+            insertAtIndex: null,
           }),
         },
         USER_ACTION: {

--- a/src/core/capture/recordable-tabs.ts
+++ b/src/core/capture/recordable-tabs.ts
@@ -1,0 +1,27 @@
+import { queryTabs } from '@/lib/browser-api';
+
+const WEBSTORE_PREFIX = 'https://chrome.google.com/webstore';
+
+export interface RecordableTab {
+  id: number;
+  title: string;
+  url: string;
+  favIconUrl?: string;
+}
+
+export function isRecordableUrl(url: string | undefined): boolean {
+  if (!url || url.startsWith(WEBSTORE_PREFIX)) return false;
+  return /^https?:/.test(url);
+}
+
+export async function getRecordableTabs(): Promise<RecordableTab[]> {
+  const tabs = await queryTabs({ currentWindow: true });
+  return tabs
+    .filter((tab) => tab.id !== undefined && isRecordableUrl(tab.url || tab.pendingUrl))
+    .map((tab) => ({
+      id: tab.id as number,
+      title: tab.title || ((tab.url || tab.pendingUrl) as string),
+      url: (tab.url || tab.pendingUrl) as string,
+      favIconUrl: tab.favIconUrl,
+    }));
+}

--- a/src/core/capture/start-insert-recording.ts
+++ b/src/core/capture/start-insert-recording.ts
@@ -1,0 +1,36 @@
+import { focusWindow, getTab, requestHostPermissions, updateTab } from '@/lib/browser-api';
+import { logger } from '@/lib/logger';
+import { sendMessage } from '@/lib/messaging';
+import { isRecordableUrl } from './recordable-tabs';
+
+export async function startInsertRecording(
+  guideId: string,
+  insertAtIndex: number,
+  tabId: number,
+): Promise<string | null> {
+  if (!(await requestHostPermissions())) {
+    logger.warn('Host permissions not granted, cannot start recording');
+    return null;
+  }
+
+  const tab = await getTab(tabId).catch(() => null);
+  if (!isRecordableUrl(tab?.url || tab?.pendingUrl)) {
+    logger.warn('Selected tab can no longer be recorded');
+    return null;
+  }
+
+  await updateTab(tabId, { active: true });
+  if (tab?.windowId) await focusWindow(tab.windowId);
+
+  try {
+    const res = await sendMessage('startRecording', {
+      url: tab?.url || '',
+      insertTargetGuideId: guideId,
+      insertAtIndex,
+    });
+    return res.guideId ?? null;
+  } catch (err) {
+    logger.error(' START_RECORDING error', err);
+    return null;
+  }
+}

--- a/src/core/guides/__tests__/merge-guide-into.test.ts
+++ b/src/core/guides/__tests__/merge-guide-into.test.ts
@@ -1,0 +1,133 @@
+import 'fake-indexeddb/auto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.hoisted(() => {
+  globalThis.BroadcastChannel = class BroadcastChannel {
+    name: string;
+    constructor(name: string) {
+      this.name = name;
+    }
+    postMessage() {}
+    addEventListener() {}
+    removeEventListener() {}
+    close() {}
+    onmessage = null;
+    onmessageerror = null;
+    dispatchEvent() {
+      return true;
+    }
+  } as unknown as typeof BroadcastChannel;
+});
+
+import { db } from '../db';
+import { mergeGuideInto } from '../service';
+import type { Guide, Step } from '../types';
+
+function makeStep(id: string, index: number, guideId = 'g1'): Step {
+  return {
+    id,
+    guideId,
+    index,
+    description: id,
+    action: 'click',
+    url: 'https://example.com',
+    timestamp: 1,
+  };
+}
+
+async function seedGuide(guideId: string, ids: string[]) {
+  const guide: Guide = {
+    id: guideId,
+    title: guideId,
+    createdAt: 1,
+    updatedAt: 1,
+    stepIds: ids,
+    starred: false,
+    deletedAt: null,
+  };
+  await db.guides.put(guide);
+  await db.steps.bulkPut(ids.map((id, index) => makeStep(id, index, guideId)));
+}
+
+async function orderedIds(guideId = 'g1') {
+  const steps = await db.steps.where('guideId').equals(guideId).sortBy('index');
+  return steps.map((step) => step.id);
+}
+
+afterEach(async () => {
+  await db.steps.clear();
+  await db.guides.clear();
+});
+
+describe('mergeGuideInto', () => {
+  it('inserts the recorded steps at the anchor in capture order', async () => {
+    await seedGuide('g1', ['a', 'b', 'c']);
+    await seedGuide('tmp', ['x', 'y', 'z']);
+
+    const moved = await mergeGuideInto('tmp', 'g1', 1);
+
+    expect(moved).toBe(3);
+    expect(await orderedIds('g1')).toEqual(['a', 'x', 'y', 'z', 'b', 'c']);
+  });
+
+  it('reassigns moved steps to the target guide and renumbers contiguously', async () => {
+    await seedGuide('g1', ['a', 'b']);
+    await seedGuide('tmp', ['x']);
+
+    await mergeGuideInto('tmp', 'g1', 1);
+
+    const steps = await db.steps.where('guideId').equals('g1').sortBy('index');
+    expect(steps.map((step) => step.index)).toEqual([0, 1, 2]);
+    expect(steps.every((step) => step.guideId === 'g1')).toBe(true);
+  });
+
+  it('keeps target.stepIds in the merged order', async () => {
+    await seedGuide('g1', ['a', 'b']);
+    await seedGuide('tmp', ['x']);
+
+    await mergeGuideInto('tmp', 'g1', 2);
+
+    const guide = await db.guides.get('g1');
+    expect(guide?.stepIds).toEqual(['a', 'b', 'x']);
+  });
+
+  it('deletes the staging guide once merged', async () => {
+    await seedGuide('g1', ['a']);
+    await seedGuide('tmp', ['x']);
+
+    await mergeGuideInto('tmp', 'g1', 0);
+
+    expect(await db.guides.get('tmp')).toBeUndefined();
+    expect(await orderedIds('tmp')).toEqual([]);
+  });
+
+  it('carries each moved step screenshot across', async () => {
+    await seedGuide('g1', ['a']);
+    await seedGuide('tmp', ['x']);
+    await db.steps.update('x', { screenshotId: 'shot-1' });
+
+    await mergeGuideInto('tmp', 'g1', 1);
+
+    expect((await db.steps.get('x'))?.screenshotId).toBe('shot-1');
+  });
+
+  it('drops an empty staging guide and leaves the target untouched', async () => {
+    await seedGuide('g1', ['a', 'b']);
+    await seedGuide('tmp', []);
+
+    const moved = await mergeGuideInto('tmp', 'g1', 1);
+
+    expect(moved).toBe(0);
+    expect(await orderedIds('g1')).toEqual(['a', 'b']);
+    expect(await db.guides.get('tmp')).toBeUndefined();
+  });
+
+  it('appends when the anchor is past the end of the target', async () => {
+    await seedGuide('g1', ['a']);
+    await seedGuide('tmp', ['x', 'y']);
+
+    await mergeGuideInto('tmp', 'g1', 99);
+
+    expect(await orderedIds('g1')).toEqual(['a', 'x', 'y']);
+  });
+});

--- a/src/core/guides/service.ts
+++ b/src/core/guides/service.ts
@@ -18,7 +18,7 @@ function notifyGuidesChanged(event: GuideChangeEvent) {
   guidesChannel.postMessage(event);
 }
 
-export async function createGuide(guideId: string): Promise<Guide> {
+export async function createGuide(guideId: string, staging = false): Promise<Guide> {
   const guide: Guide = {
     id: guideId,
     title: i18n.t('fullview.untitledGuide'),
@@ -27,6 +27,7 @@ export async function createGuide(guideId: string): Promise<Guide> {
     stepIds: [],
     starred: false,
     deletedAt: null,
+    ...(staging ? { staging: true } : {}),
   };
   await db.guides.add(guide);
   return guide;
@@ -48,7 +49,7 @@ export async function getGuides(): Promise<Guide[]> {
   return db.guides
     .orderBy('updatedAt')
     .reverse()
-    .filter((g) => g.deletedAt == null)
+    .filter((g) => g.deletedAt == null && !g.staging)
     .toArray();
 }
 
@@ -56,7 +57,7 @@ export async function getStarredGuides(): Promise<Guide[]> {
   return db.guides
     .orderBy('updatedAt')
     .reverse()
-    .filter((g) => g.starred === true && g.deletedAt == null)
+    .filter((g) => g.starred === true && g.deletedAt == null && !g.staging)
     .toArray();
 }
 
@@ -137,6 +138,29 @@ export async function reorderSteps(guideId: string, orderedStepIds: string[]): P
 
 export async function createStep(step: Step): Promise<void> {
   await db.steps.add(step);
+}
+
+export async function mergeGuideInto(sourceGuideId: string, targetGuideId: string, atIndex: number): Promise<number> {
+  const moved = await db.transaction('rw', db.steps, db.guides, async () => {
+    const incoming = await db.steps.where('guideId').equals(sourceGuideId).sortBy('index');
+    const target = await db.steps.where('guideId').equals(targetGuideId).sortBy('index');
+    if (incoming.length > 0) {
+      target.splice(
+        Math.max(0, Math.min(atIndex, target.length)),
+        0,
+        ...incoming.map((step) => ({ ...step, guideId: targetGuideId })),
+      );
+      await db.steps.bulkPut(target.map((step, index) => ({ ...step, index })));
+      await db.guides.update(targetGuideId, {
+        stepIds: target.map((step) => step.id),
+        updatedAt: Date.now(),
+      });
+    }
+    await db.guides.delete(sourceGuideId);
+    return incoming.length;
+  });
+  if (moved > 0) notifyGuidesChanged({ type: 'mutated' });
+  return moved;
 }
 
 export async function insertBlock(

--- a/src/core/guides/types.ts
+++ b/src/core/guides/types.ts
@@ -9,6 +9,7 @@ export interface Guide {
   stepIds: string[];
   starred: boolean;
   deletedAt: number | null;
+  staging?: boolean;
 }
 
 export type BlockType = 'heading' | 'callout';

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -4,7 +4,13 @@ import { validateApiKey } from '@/core/capture/ai/validate';
 import { stepRequiresManual } from '@/core/guideme/manual';
 import { advanceSession, cancelSession, completeSession, getSession, startSession } from '@/core/guideme/session';
 import { actionSteps } from '@/core/guides/blocks';
-import { createGuide, getScreenshotsForSteps, getStepsForGuide } from '@/core/guides/service';
+import {
+  createGuide,
+  createSnapshot,
+  getScreenshotsForSteps,
+  getStepsForGuide,
+  mergeGuideInto,
+} from '@/core/guides/service';
 import type { Step } from '@/core/guides/types';
 import { getActiveTab, localStorage, sendMessageToTab, setSidePanelBehavior, updateTab } from '@/lib/browser-api';
 import { logger } from '@/lib/logger';
@@ -86,10 +92,15 @@ export default defineBackground(() => {
   onMessage('startRecording', async ({ data }) => {
     await waitUntilReady();
     const actor = getActor();
-    actor.send({ type: 'START_RECORDING', url: data.url });
+    actor.send({
+      type: 'START_RECORDING',
+      url: data.url,
+      insertTargetGuideId: data.insertTargetGuideId,
+      insertAtIndex: data.insertAtIndex,
+    });
     const guideId = actor.getSnapshot().context.currentGuideId!;
 
-    await createGuide(guideId);
+    await createGuide(guideId, data.insertTargetGuideId !== undefined);
 
     const activeTab = await getActiveTab();
     if (activeTab?.id) await showNotificationOnTab(activeTab.id);
@@ -101,13 +112,19 @@ export default defineBackground(() => {
   onMessage('stopRecording', async () => {
     await waitUntilReady();
     const actor = getActor();
-    const guideId = actor.getSnapshot().context.currentGuideId;
+    const { currentGuideId: guideId, insertTargetGuideId, insertAtIndex } = actor.getSnapshot().context;
     await broadcastStopCapture();
     actor.send({ type: 'STOP_RECORDING' });
 
+    if (guideId && insertTargetGuideId !== null && insertAtIndex !== null) {
+      await createSnapshot(insertTargetGuideId);
+      await mergeGuideInto(guideId, insertTargetGuideId, insertAtIndex);
+      return { success: true, guideId: insertTargetGuideId, inserted: true };
+    }
+
     if (guideId) generateGuideMetaOnStop(guideId).catch(() => {});
 
-    return { success: true, guideId: guideId ?? undefined };
+    return { success: true, guideId: guideId ?? undefined, inserted: false };
   });
 
   onMessage('enterBlurMode', async () => {

--- a/src/entrypoints/background/step-pipeline.ts
+++ b/src/entrypoints/background/step-pipeline.ts
@@ -3,7 +3,13 @@ import type { DOMContext } from '@/core/capture/dom/context';
 import { CaptureState } from '@/core/capture/machine';
 import { buildFallbackDescription } from '@/core/capture/step-description';
 import { db } from '@/core/guides/db';
-import { addStepToGuide, clearStepAiPending, createStep, saveScreenshot } from '@/core/guides/service';
+import {
+  addStepToGuide,
+  clearStepAiPending,
+  createStep,
+  saveScreenshot,
+  updateStepDescription,
+} from '@/core/guides/service';
 import type { ElementMeta, Screenshot, Step } from '@/core/guides/types';
 import { DEFAULT_TARGET_COLOR } from '@/core/screenshot/types';
 import { captureVisibleTab, localStorage } from '@/lib/browser-api';

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -11,6 +11,8 @@ export interface GetStateResponse {
 
 export interface StartRecordingData {
   url: string;
+  insertTargetGuideId?: string;
+  insertAtIndex?: number;
 }
 
 export interface StartRecordingResponse {
@@ -20,6 +22,7 @@ export interface StartRecordingResponse {
 export interface StopRecordingResponse {
   success: boolean;
   guideId?: string;
+  inserted?: boolean;
 }
 
 export interface CaptureStepData {

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -189,6 +189,13 @@ editor:
   descriptionErrorSaveFailed: Die Beschreibung wurde erstellt, konnte aber nicht gespeichert werden. Versuche es erneut.
   writingStepDescription: "Beschreibung wird geschrieben…"
 
+capture:
+  recordSteps: Schritte aufzeichnen
+  moreStepsTitle: Weitere Schritte aufnehmen
+  moreStepsBody: "Neue Schritte werden hier eingefügt. Wähle den Tab zum Aufzeichnen."
+  startCapture: Aufnahme starten
+  noRecordableTabs: In diesem Fenster ist kein aufzeichenbarer Tab offen.
+
 blocks:
   add: "Block hinzufügen"
   heading: "Überschrift"

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -189,6 +189,13 @@ editor:
   rewriteErrorFailed: Could not rewrite the selection. Try again.
   rewriteErrorStale: The text changed. Select it again.
 
+capture:
+  recordSteps: Record steps
+  moreStepsTitle: Capture more steps
+  moreStepsBody: New steps are inserted here. Pick the tab to record in.
+  startCapture: Start capture
+  noRecordableTabs: No recordable tabs are open in this window.
+
 blocks:
   add: Add block
   heading: Heading

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -189,6 +189,13 @@ editor:
   rewriteErrorFailed: "No se pudo reescribir la selecci\xF3n. Int\xE9ntalo de nuevo."
   rewriteErrorStale: "El texto cambi\xF3. Vuelve a seleccionarlo."
 
+capture:
+  recordSteps: Grabar pasos
+  moreStepsTitle: Capturar más pasos
+  moreStepsBody: "Los nuevos pasos se insertan aquí. Elige la pestaña que quieres grabar."
+  startCapture: Iniciar captura
+  noRecordableTabs: No hay pestañas grabables abiertas en esta ventana.
+
 blocks:
   add: "Añadir bloque"
   heading: Encabezado

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -189,6 +189,13 @@ editor:
   rewriteErrorFailed: "Impossible de r\xE9\xE9crire la s\xE9lection. R\xE9essayez."
   rewriteErrorStale: "Le texte a chang\xE9. S\xE9lectionnez-le \xE0 nouveau."
 
+capture:
+  recordSteps: "Enregistrer des étapes"
+  moreStepsTitle: "Capturer d'autres étapes"
+  moreStepsBody: "Les nouvelles étapes sont insérées ici. Choisissez l'onglet à enregistrer."
+  startCapture: "Démarrer la capture"
+  noRecordableTabs: "Aucun onglet enregistrable n'est ouvert dans cette fenêtre."
+
 blocks:
   add: Ajouter un bloc
   heading: Titre

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -189,6 +189,13 @@ editor:
   rewriteErrorFailed: "N\xE3o foi poss\xEDvel reescrever a sele\xE7\xE3o. Tente novamente."
   rewriteErrorStale: O texto mudou. Selecione-o novamente.
 
+capture:
+  recordSteps: Gravar etapas
+  moreStepsTitle: Capturar mais etapas
+  moreStepsBody: "As novas etapas entram aqui. Escolha a aba que quer gravar."
+  startCapture: Iniciar captura
+  noRecordableTabs: Nenhuma aba gravável está aberta nesta janela.
+
 blocks:
   add: Adicionar bloco
   heading: "Título"

--- a/src/ui/fullview/GuideContent.tsx
+++ b/src/ui/fullview/GuideContent.tsx
@@ -2,6 +2,7 @@ import { History, Loader2, Play, Sparkles } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { TypeAnimation } from 'react-type-animation';
 import { i18n } from '#imports';
+import { startInsertRecording } from '@/core/capture/start-insert-recording';
 import { actionSteps } from '@/core/guides/blocks';
 import {
   deleteStep,
@@ -469,6 +470,10 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
             readOnly={!editing || preview !== null}
             hasApiKey={hasApiKey}
             onChanged={loadGuide}
+            onInsertRecording={(targetGuideId, insertAtIndex, tabId) => {
+              openSidebar();
+              void startInsertRecording(targetGuideId, insertAtIndex, tabId);
+            }}
           />
         </div>
 

--- a/src/ui/fullview/components/GuideStepList.tsx
+++ b/src/ui/fullview/components/GuideStepList.tsx
@@ -4,6 +4,7 @@ import { insertBlock, reorderSteps } from '@/core/guides/service';
 import type { BlockType, Screenshot, Step } from '@/core/guides/types';
 import { useFullview } from '@/stores/fullview';
 import BlockCard from '@/ui/shared/BlockCard';
+import CaptureTabDialog from '@/ui/shared/CaptureTabDialog';
 import EmptyGuideState from '@/ui/shared/EmptyGuideState';
 import { dominantRatio } from '@/ui/shared/ImagePlaceholder';
 import InsertBlockMenu from '@/ui/shared/InsertBlockMenu';
@@ -20,6 +21,7 @@ interface GuideStepListProps {
   readOnly?: boolean;
   onChanged?: () => void;
   hasApiKey?: boolean;
+  onInsertRecording?: (guideId: string, insertAtIndex: number, tabId: number) => void;
 }
 
 export default function GuideStepList({
@@ -33,12 +35,14 @@ export default function GuideStepList({
   readOnly,
   onChanged,
   hasApiKey,
+  onInsertRecording,
 }: GuideStepListProps) {
   const { scrollToStepId, setActiveStepId } = useFullview((s) => ({
     scrollToStepId: s.scrollToStepId,
     setActiveStepId: s.setActiveStepId,
   }));
 
+  const [recordAtIndex, setRecordAtIndex] = useState<number | null>(null);
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
   const stepRefs = useRef<Map<string, HTMLDivElement>>(new Map());
@@ -102,18 +106,41 @@ export default function GuideStepList({
           onDragEnd: handleDragEnd,
         };
 
+  const captureDialog = (
+    <CaptureTabDialog
+      open={recordAtIndex !== null}
+      onCancel={() => setRecordAtIndex(null)}
+      onStart={(tabId) => {
+        const atIndex = recordAtIndex;
+        setRecordAtIndex(null);
+        if (atIndex !== null) onInsertRecording?.(guideId, atIndex, tabId);
+      }}
+    />
+  );
+
   if (steps.length === 0) {
     return (
       <div className="flex flex-col">
         <EmptyGuideState />
-        {!readOnly && <InsertBlockMenu onInsert={(blockType) => handleInsertBlock(0, blockType)} />}
+        {!readOnly && (
+          <InsertBlockMenu
+            onInsert={(blockType) => handleInsertBlock(0, blockType)}
+            onRecord={onInsertRecording && (() => setRecordAtIndex(0))}
+          />
+        )}
+        {captureDialog}
       </div>
     );
   }
 
   return (
     <div className="space-y-6">
-      {!readOnly && <InsertBlockMenu onInsert={(blockType) => handleInsertBlock(0, blockType)} />}
+      {!readOnly && (
+        <InsertBlockMenu
+          onInsert={(blockType) => handleInsertBlock(0, blockType)}
+          onRecord={onInsertRecording && (() => setRecordAtIndex(0))}
+        />
+      )}
       {steps.map((step, idx) => (
         <div
           key={step.id}
@@ -151,9 +178,15 @@ export default function GuideStepList({
               dragHandleProps={dragHandlers(idx)}
             />
           )}
-          {!readOnly && <InsertBlockMenu onInsert={(blockType) => handleInsertBlock(idx + 1, blockType)} />}
+          {!readOnly && (
+            <InsertBlockMenu
+              onInsert={(blockType) => handleInsertBlock(idx + 1, blockType)}
+              onRecord={onInsertRecording && (() => setRecordAtIndex(idx + 1))}
+            />
+          )}
         </div>
       ))}
+      {captureDialog}
     </div>
   );
 }

--- a/src/ui/shared/CaptureTabDialog.tsx
+++ b/src/ui/shared/CaptureTabDialog.tsx
@@ -1,0 +1,73 @@
+import { Globe } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { i18n } from '#imports';
+import { getRecordableTabs, type RecordableTab } from '@/core/capture/recordable-tabs';
+import { Button } from '@/ui/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/ui/components/ui/dialog';
+
+interface CaptureTabDialogProps {
+  open: boolean;
+  onCancel: () => void;
+  onStart: (tabId: number) => void;
+}
+
+export default function CaptureTabDialog({ open, onCancel, onStart }: CaptureTabDialogProps) {
+  const [tabs, setTabs] = useState<RecordableTab[]>([]);
+  const [selected, setSelected] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setSelected(null);
+    getRecordableTabs().then(setTabs);
+  }, [open]);
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onCancel()}>
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader>
+          <DialogTitle>{i18n.t('capture.moreStepsTitle')}</DialogTitle>
+          <DialogDescription>{i18n.t('capture.moreStepsBody')}</DialogDescription>
+        </DialogHeader>
+        <div className="max-h-[240px] overflow-y-auto flex flex-col gap-1.5">
+          {tabs.length === 0 ? (
+            <p className="text-[13px] text-muted-foreground py-2">{i18n.t('capture.noRecordableTabs')}</p>
+          ) : (
+            tabs.map((tab) => (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => setSelected(tab.id)}
+                aria-pressed={selected === tab.id}
+                className={`flex items-center gap-2 rounded-lg border px-2.5 py-2 text-left transition-colors ${
+                  selected === tab.id ? 'border-accent bg-secondary' : 'border-border hover:bg-secondary'
+                }`}
+              >
+                {tab.favIconUrl ? (
+                  <img src={tab.favIconUrl} alt="" width={16} height={16} className="shrink-0 rounded" />
+                ) : (
+                  <Globe size={16} className="shrink-0 text-muted-foreground" />
+                )}
+                <span className="text-[13px] text-foreground truncate">{tab.title}</span>
+              </button>
+            ))
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" size="sm" onClick={onCancel}>
+            {i18n.t('common.cancel')}
+          </Button>
+          <Button size="sm" disabled={selected === null} onClick={() => selected !== null && onStart(selected)}>
+            {i18n.t('capture.startCapture')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/ui/shared/InsertBlockMenu.tsx
+++ b/src/ui/shared/InsertBlockMenu.tsx
@@ -1,13 +1,14 @@
-import { Heading, Plus, StickyNote } from 'lucide-react';
+import { Circle, Heading, Plus, StickyNote } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { i18n } from '#imports';
 import type { BlockType } from '@/core/guides/types';
 
 interface InsertBlockMenuProps {
   onInsert: (blockType: BlockType) => void;
+  onRecord?: () => void;
 }
 
-export default function InsertBlockMenu({ onInsert }: InsertBlockMenuProps) {
+export default function InsertBlockMenu({ onInsert, onRecord }: InsertBlockMenuProps) {
   const [open, setOpen] = useState(false);
   const rowRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -63,6 +64,19 @@ export default function InsertBlockMenu({ onInsert }: InsertBlockMenuProps) {
             {choice.label}
           </button>
         ))}
+      {open && onRecord && (
+        <button
+          type="button"
+          onClick={() => {
+            setOpen(false);
+            onRecord();
+          }}
+          className="relative flex items-center gap-1 rounded-full border border-border bg-card px-2 py-0.5 text-[11px] font-medium text-purple hover:text-accent hover:bg-secondary"
+        >
+          <Circle size={13} />
+          {i18n.t('capture.recordSteps')}
+        </button>
+      )}
     </div>
   );
 }

--- a/src/ui/sidepanel/App.tsx
+++ b/src/ui/sidepanel/App.tsx
@@ -2,6 +2,7 @@ import { Search, Settings, Video } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { browser, i18n } from '#imports';
 import { CaptureState } from '@/core/capture/machine';
+import { startInsertRecording } from '@/core/capture/start-insert-recording';
 import type { GuideMeSession } from '@/core/guideme/session';
 import { SESSION_KEY } from '@/core/guideme/session';
 import {
@@ -95,6 +96,10 @@ export default function App() {
       onStateUpdate: (update) => {
         if (update.state === CaptureState.RECORDING) {
           setIsRecording(true);
+          const guideId = update.currentGuideId;
+          if (guideId) {
+            setView((prev) => (prev.name === 'recording' ? prev : { name: 'recording', guideId }));
+          }
         } else {
           setIsRecording(false);
         }
@@ -145,12 +150,20 @@ export default function App() {
     }
   }, []);
 
+  const handleInsertRecording = useCallback(async (guideId: string, insertAtIndex: number, tabId: number) => {
+    const started = await startInsertRecording(guideId, insertAtIndex, tabId);
+    if (started) {
+      setIsRecording(true);
+      setView({ name: 'recording', guideId: started });
+    }
+  }, []);
+
   const handleStopRecording = useCallback(async () => {
     try {
       const res = await sendMessage('stopRecording', undefined);
       if (res.success) {
         setIsRecording(false);
-        setView({ name: 'library' });
+        setView(res.inserted && res.guideId ? { name: 'editor', guideId: res.guideId } : { name: 'library' });
         if (res.guideId) {
           const url = getExtensionURL(`/fullview.html?guideId=${res.guideId}`);
           const tabs = await queryTabs({ url: getExtensionURL('/fullview.html') });
@@ -203,6 +216,7 @@ export default function App() {
         guideId={view.guideId}
         onBack={() => setView({ name: 'library' })}
         onGuideMe={(id) => setView({ name: 'guideme', guideId: id })}
+        onInsertRecording={handleInsertRecording}
       />
     );
   }

--- a/src/ui/sidepanel/GuideEditor.tsx
+++ b/src/ui/sidepanel/GuideEditor.tsx
@@ -21,6 +21,7 @@ import { getMostCommonDomain } from '@/lib/utils';
 import { Input } from '@/ui/components/ui/input';
 import { useAskAi } from '@/ui/shared/AskAi';
 import BlockCard from '@/ui/shared/BlockCard';
+import CaptureTabDialog from '@/ui/shared/CaptureTabDialog';
 import EmptyGuideState from '@/ui/shared/EmptyGuideState';
 import FaviconImg from '@/ui/shared/FaviconImg';
 import { guideDescriptionErrorMessage } from '@/ui/shared/guide-description-error';
@@ -34,6 +35,7 @@ interface GuideEditorProps {
   guideId: string;
   onBack: () => void;
   onGuideMe?: (guideId: string) => void;
+  onInsertRecording?: (guideId: string, insertAtIndex: number, tabId: number) => void;
 }
 
 interface OpenInFullViewOptions {
@@ -52,7 +54,8 @@ function flushFocusedField() {
   if (el instanceof HTMLTextAreaElement || el instanceof HTMLInputElement) el.blur();
 }
 
-export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorProps) {
+export default function GuideEditor({ guideId, onBack, onGuideMe, onInsertRecording }: GuideEditorProps) {
+  const [recordAtIndex, setRecordAtIndex] = useState<number | null>(null);
   const [data, setData] = useState<GuideData | null>(null);
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
@@ -373,11 +376,21 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
         {data.steps.length === 0 ? (
           <>
             <EmptyGuideState />
-            {editing && <InsertBlockMenu onInsert={(blockType) => handleInsertBlock(0, blockType)} />}
+            {editing && (
+              <InsertBlockMenu
+                onInsert={(blockType) => handleInsertBlock(0, blockType)}
+                onRecord={onInsertRecording && (() => setRecordAtIndex(0))}
+              />
+            )}
           </>
         ) : (
           <>
-            {editing && <InsertBlockMenu onInsert={(blockType) => handleInsertBlock(0, blockType)} />}
+            {editing && (
+              <InsertBlockMenu
+                onInsert={(blockType) => handleInsertBlock(0, blockType)}
+                onRecord={onInsertRecording && (() => setRecordAtIndex(0))}
+              />
+            )}
             {data.steps.map((step, idx) => (
               <div key={step.id}>
                 {dragOverIndex === idx && dragIndex !== null && dragIndex !== idx && (
@@ -408,12 +421,26 @@ export default function GuideEditor({ guideId, onBack, onGuideMe }: GuideEditorP
                     dragHandleProps={dragHandlers(idx)}
                   />
                 )}
-                {editing && <InsertBlockMenu onInsert={(blockType) => handleInsertBlock(idx + 1, blockType)} />}
+                {editing && (
+                  <InsertBlockMenu
+                    onInsert={(blockType) => handleInsertBlock(idx + 1, blockType)}
+                    onRecord={onInsertRecording && (() => setRecordAtIndex(idx + 1))}
+                  />
+                )}
               </div>
             ))}
           </>
         )}
       </div>
+      <CaptureTabDialog
+        open={recordAtIndex !== null}
+        onCancel={() => setRecordAtIndex(null)}
+        onStart={(tabId) => {
+          const atIndex = recordAtIndex;
+          setRecordAtIndex(null);
+          if (atIndex !== null) onInsertRecording?.(guideId, atIndex, tabId);
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Capture was append-only, so a step missed in the middle of a finished guide meant re-recording the whole thing.

The `+` between steps now also offers Record steps: pick one of the http/https tabs in the current window, and Mimik records into a hidden staging guide, so the live panel counts from 1 and the target is untouched. Finishing merges those steps in at that position, renumbers the rest and returns you to the guide, with its title and description intact. Undo is a snapshot in Version History.

Also fixes a live bug: the step pipeline called `updateStepDescription` without importing it, throwing on every keystroke of an input capture.

Still open: the X button during recording commits rather than discards, despite its label, and a crash mid-recording orphans the staging guide.

`pnpm lint`, 531 tests, Chrome and Firefox builds clean.
