### PR TITLE
fix(export): apply screenshot edits in docx and label images correctly

### DIFF
--- a/src/core/export/__tests__/docx-export.test.ts
+++ b/src/core/export/__tests__/docx-export.test.ts
@@ -102,6 +102,13 @@ describe('exportGuideAsDOCX', () => {
     expect(Object.keys(files).some((name) => name.startsWith('word/media/'))).toBe(false);
   });
 
+  it('includes the guide description', async () => {
+    const guide = makeGuide({ description: 'A short SOP narrative.' });
+    const xml = await readDocumentXml(await exportGuideAsDOCX(guide, [makeStep()], new Map()));
+
+    expect(xml).toContain('A short SOP narrative.');
+  });
+
   it('embeds the rendered screenshot so annotations and redactions are applied', async () => {
     rendered.mockClear();
     const step = makeStep();

--- a/src/core/export/__tests__/docx-export.test.ts
+++ b/src/core/export/__tests__/docx-export.test.ts
@@ -1,8 +1,12 @@
 // @vitest-environment jsdom
 import { strFromU8, unzipSync } from 'fflate';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { exportGuideAsDOCX, fitDocxImageSize } from '@/core/export/docx-export';
 import type { Guide, Screenshot, Step } from '@/core/guides/types';
+
+const rendered = vi.hoisted(() => vi.fn(async () => new Blob(['rendered'], { type: 'image/png' })));
+
+vi.mock('@/core/screenshot/render', () => ({ renderScreenshot: rendered }));
 
 function makeGuide(overrides: Partial<Guide> = {}): Guide {
   return {
@@ -96,6 +100,46 @@ describe('exportGuideAsDOCX', () => {
     const files = await unzipDocx(blob);
 
     expect(Object.keys(files).some((name) => name.startsWith('word/media/'))).toBe(false);
+  });
+
+  it('embeds the rendered screenshot so annotations and redactions are applied', async () => {
+    rendered.mockClear();
+    const step = makeStep();
+    const screenshot = makeScreenshot(step.id, 'raw-pixels');
+    screenshot.edits = {
+      annotations: [{ id: 'r1', type: 'redact', x: 0, y: 0, w: 10, h: 10, style: 'solid' }],
+    };
+
+    const blob = await exportGuideAsDOCX(makeGuide(), [step], new Map([[step.id, screenshot]]));
+    const files = await unzipDocx(blob);
+    const media = Object.keys(files).filter((name) => name.startsWith('word/media/') && files[name].length > 0);
+
+    expect(rendered).toHaveBeenCalledWith(screenshot, expect.objectContaining({ format: 'image/png' }));
+    expect(media).toHaveLength(1);
+    expect(strFromU8(files[media[0]])).toBe('rendered');
+  });
+
+  it('sizes the image from the cropped viewport, not the original bitmap', async () => {
+    const step = makeStep();
+    const screenshot = makeScreenshot(step.id);
+    screenshot.edits = { viewport: { x: 0, y: 0, width: 400, height: 100 } };
+
+    const xml = await readDocumentXml(await exportGuideAsDOCX(makeGuide(), [step], new Map([[step.id, screenshot]])));
+
+    const extent = xml.match(/<wp:extent cx="(\d+)" cy="(\d+)"/);
+    expect(extent).not.toBeNull();
+    expect(Number(extent?.[1]) / Number(extent?.[2])).toBeCloseTo(4, 1);
+  });
+
+  it('embeds screenshots whose stored mime type is not natively supported by docx', async () => {
+    const step = makeStep();
+    const screenshot = makeScreenshot(step.id);
+    screenshot.mimeType = 'image/webp';
+
+    const blob = await exportGuideAsDOCX(makeGuide(), [step], new Map([[step.id, screenshot]]));
+    const files = await unzipDocx(blob);
+
+    expect(Object.keys(files).some((name) => name.startsWith('word/media/'))).toBe(true);
   });
 });
 

--- a/src/core/export/__tests__/markdown-export.test.ts
+++ b/src/core/export/__tests__/markdown-export.test.ts
@@ -139,6 +139,17 @@ describe('exportGuideAsMarkdown', () => {
     expect(md).toContain(b64);
   });
 
+  it('labels the data URL with the rendered mime type, not the stored one', async () => {
+    const step = makeStep();
+    const ss = makeScreenshot(step.id, 'pixel-data');
+    ss.mimeType = 'image/jpeg';
+
+    const md = await exportGuideAsMarkdown(makeGuide(), [step], new Map([[step.id, ss]]));
+
+    expect(md).toContain('](data:image/png;base64,');
+    expect(md).not.toContain('data:image/jpeg');
+  });
+
   it('renders a heading block as an H2 without a step number', async () => {
     const guide = makeGuide();
     const steps = [makeStep({ id: 'block-1', blockType: 'heading', description: 'Section title', url: '' })];

--- a/src/core/export/docx-export.ts
+++ b/src/core/export/docx-export.ts
@@ -25,9 +25,9 @@ import { type ExportOptions, IMAGE_SCALE_FACTORS, loadExportOptions } from '@/co
 import { blobToArrayBuffer, extractDomain, formatDate } from '@/core/export/utils';
 import { actionSteps, calloutAccent, isBlock, stepNumbers, tint } from '@/core/guides/blocks';
 import type { Guide, Screenshot, Step } from '@/core/guides/types';
+import { resolveViewport } from '@/core/screenshot/geometry';
+import { renderScreenshot } from '@/core/screenshot/render';
 import { logger } from '@/lib/logger';
-
-type SupportedDocxImageType = 'bmp' | 'gif' | 'jpg' | 'png';
 
 const DOCX_MAX_IMAGE_WIDTH = 520;
 const DOCX_MAX_IMAGE_HEIGHT = 640; // px @ 96dpi, fits one page after margins
@@ -219,47 +219,24 @@ function buildCover(guide: Guide, steps: Step[], domain: string | null, brand: B
   return [head, rule, meta];
 }
 
-function getDocxImageType(mimeType: string): SupportedDocxImageType | null {
-  switch (mimeType) {
-    case 'image/png':
-      return 'png';
-    case 'image/jpeg':
-    case 'image/jpg':
-      return 'jpg';
-    case 'image/gif':
-      return 'gif';
-    case 'image/bmp':
-      return 'bmp';
-    default:
-      return null;
-  }
-}
-
 async function buildImageParagraph(
   screenshot: Screenshot,
   stepIndex: number,
   scale: number,
 ): Promise<Paragraph | null> {
-  const imageType = getDocxImageType(screenshot.mimeType);
-  if (!imageType) {
-    logger.warn('DOCX: unsupported screenshot mime type', screenshot.mimeType, 'for step', stepIndex);
-    return null;
-  }
-
   try {
-    const arrayBuffer = await blobToArrayBuffer(screenshot.blob);
-    const fitted = fitDocxImageSize(screenshot.width, screenshot.height, DOCX_STEP_INDENT / 2);
+    const arrayBuffer = await blobToArrayBuffer(await renderScreenshot(screenshot, { format: 'image/png' }));
+    const viewport = resolveViewport(screenshot);
+    const fitted = fitDocxImageSize(viewport.width, viewport.height, DOCX_STEP_INDENT / 2);
     const width = Math.max(1, Math.round(fitted.width * scale));
     const height = Math.max(1, Math.round(fitted.height * scale));
 
     return new Paragraph({
       alignment: AlignmentType.LEFT,
-      children: [
-        new ImageRun({ type: imageType, data: new Uint8Array(arrayBuffer), transformation: { width, height } }),
-      ],
+      children: [new ImageRun({ type: 'png', data: new Uint8Array(arrayBuffer), transformation: { width, height } })],
     });
   } catch (err) {
-    logger.warn('DOCX: failed to load screenshot for step', stepIndex, err);
+    logger.warn('DOCX: failed to render screenshot for step', stepIndex, err);
     return null;
   }
 }

--- a/src/core/export/docx-export.ts
+++ b/src/core/export/docx-export.ts
@@ -154,6 +154,16 @@ function buildCover(guide: Guide, steps: Step[], domain: string | null, brand: B
                   new TextRun({ text: guide.title, bold: true, color: INK, size: 60, font: DOCX_FONT_FAMILY }),
                 ],
               }),
+              ...(guide.description
+                ? [
+                    new Paragraph({
+                      spacing: { before: 220 },
+                      children: [
+                        new TextRun({ text: guide.description, color: MUTED, size: 22, font: DOCX_FONT_FAMILY }),
+                      ],
+                    }),
+                  ]
+                : []),
             ],
             CONTENT_MM - 40,
           ),

--- a/src/core/export/html-export.ts
+++ b/src/core/export/html-export.ts
@@ -59,9 +59,10 @@ export async function exportGuideAsHTML(
     const screenshot = opts.screenshots ? screenshots.get(step.id) : undefined;
     let imgHtml = '';
     if (screenshot) {
-      const b64 = await blobToBase64(await renderScreenshot(screenshot));
+      const rendered = await renderScreenshot(screenshot);
+      const b64 = await blobToBase64(rendered);
       const altText = screenshot.edits?.alt || i18n.t('export.stepLabel', [String(number)]);
-      imgHtml = `<img src="data:${screenshot.mimeType};base64,${b64}" alt="${escapeHtml(altText)}" style="display:block;width:${imgWidthPct}%;margin-top:14px;border:1px solid #CBD5E1;" />`;
+      imgHtml = `<img src="data:${rendered.type};base64,${b64}" alt="${escapeHtml(altText)}" style="display:block;width:${imgWidthPct}%;margin-top:14px;border:1px solid #CBD5E1;" />`;
     }
 
     const stepNumber = String(number).padStart(2, '0');

--- a/src/core/export/markdown-export.ts
+++ b/src/core/export/markdown-export.ts
@@ -39,9 +39,10 @@ export async function exportGuideAsMarkdown(
 
     const screenshot = screenshots.get(step.id);
     if (screenshot) {
-      const b64 = await blobToBase64(await renderScreenshot(screenshot));
+      const rendered = await renderScreenshot(screenshot);
+      const b64 = await blobToBase64(rendered);
       const altText = screenshot.edits?.alt || i18n.t('export.stepLabel', [num]);
-      lines.push(`![${altText}](data:${screenshot.mimeType};base64,${b64})`, '');
+      lines.push(`![${altText}](data:${rendered.type};base64,${b64})`, '');
     }
   }
 


### PR DESCRIPTION
DOCX embedded the raw captured blob instead of the rendered screenshot, so annotations, crop and the click-target outline never appeared — and redactions leaked: a region blacked out in the editor shipped unredacted in the file. Every other exporter goes through `renderScreenshot`, which is the only place `edits.annotations` are applied. It also sized images from the original bitmap, distorting cropped shots, and silently dropped any screenshot whose stored mime type was not png/jpg/gif/bmp.

DOCX also omitted the guide description that HTML, PDF and Markdown all render. Separately, HTML and Markdown labelled their data URLs with the stored mime type while embedding webp bytes — browsers sniff, stricter Markdown consumers do not.

Five regression tests added. The DOCX suite never set `edits`, which is how this shipped.

`lint`, 736 tests, Chrome and Firefox builds clean.
