### PR TITLE
feat(editor): select and delete several steps at once

### DIFF
--- a/src/core/guides/__tests__/service.test.ts
+++ b/src/core/guides/__tests__/service.test.ts
@@ -30,6 +30,7 @@ import {
   addStepToGuide,
   createGuide,
   deleteStep,
+  deleteSteps,
   getGuide,
   getGuides,
   getStarredGuides,
@@ -172,6 +173,43 @@ describe('deleteStep', () => {
     const remaining = await db.steps.where('guideId').equals('g1').sortBy('index');
     expect(remaining[0].index).toBe(0);
     expect(remaining[1].index).toBe(1);
+  });
+});
+
+describe('deleteSteps', () => {
+  it('removes a non-contiguous selection including blocks and re-indexes once', async () => {
+    await seedGuide('g1', { stepIds: ['s1', 'b1', 's2', 's3', 'b2'] });
+    await db.steps.bulkAdd([
+      makeStep({ id: 's1', guideId: 'g1', index: 0, screenshotId: 'sc1' }),
+      makeStep({ id: 'b1', guideId: 'g1', index: 1, blockType: 'heading' }),
+      makeStep({ id: 's2', guideId: 'g1', index: 2, screenshotId: 'sc2' }),
+      makeStep({ id: 's3', guideId: 'g1', index: 3 }),
+      makeStep({ id: 'b2', guideId: 'g1', index: 4, blockType: 'callout' }),
+    ]);
+    await db.screenshots.bulkAdd([
+      makeScreenshot({ id: 'sc1', stepId: 's1' }),
+      makeScreenshot({ id: 'sc2', stepId: 's2' }),
+    ]);
+
+    await deleteSteps('g1', ['s1', 's2', 'b2']);
+
+    const guide = await db.guides.get('g1');
+    expect(guide!.stepIds).toEqual(['b1', 's3']);
+
+    const remaining = await db.steps.where('guideId').equals('g1').sortBy('index');
+    expect(remaining.map((s) => s.id)).toEqual(['b1', 's3']);
+    expect(remaining.map((s) => s.index)).toEqual([0, 1]);
+    expect(await db.screenshots.count()).toBe(0);
+  });
+
+  it('leaves the guide untouched when nothing is selected', async () => {
+    await seedGuide('g1', { stepIds: ['s1'] });
+    await db.steps.add(makeStep({ id: 's1', guideId: 'g1', index: 0 }));
+
+    await deleteSteps('g1', []);
+
+    expect(await db.steps.count()).toBe(1);
+    expect((await db.guides.get('g1'))!.stepIds).toEqual(['s1']);
   });
 });
 

--- a/src/core/guides/__tests__/snapshots.test.ts
+++ b/src/core/guides/__tests__/snapshots.test.ts
@@ -28,6 +28,7 @@ import {
   createSnapshot,
   deleteScreenshot,
   deleteStep,
+  deleteSteps,
   getGuide,
   getSnapshots,
   permanentlyDeleteGuide,
@@ -442,6 +443,23 @@ describe('append-only screenshots', () => {
     await deleteStep('g1', 's1');
 
     expect(await db.screenshots.get('sc1')).toBeDefined();
+  });
+
+  it('deleteSteps keeps the screenshot row of every deleted step', async () => {
+    await seedGuide('g1', { stepIds: ['s1', 's2'] });
+    await db.steps.bulkAdd([
+      makeStep({ id: 's1', guideId: 'g1', index: 0, screenshotId: 'sc1' }),
+      makeStep({ id: 's2', guideId: 'g1', index: 1, screenshotId: 'sc2' }),
+    ]);
+    await db.screenshots.bulkAdd([
+      makeScreenshot({ id: 'sc1', stepId: 's1' }),
+      makeScreenshot({ id: 'sc2', stepId: 's2' }),
+    ]);
+    await createSnapshot('g1');
+
+    await deleteSteps('g1', ['s1', 's2']);
+
+    expect(await db.screenshots.count()).toBe(2);
   });
 
   it('permanentlyDeleteGuide sweeps unreferenced rows and snapshots', async () => {

--- a/src/core/guides/service.ts
+++ b/src/core/guides/service.ts
@@ -225,24 +225,31 @@ export async function findExistingStepIds(stepIds: readonly string[]): Promise<s
   return found as string[];
 }
 
-export async function deleteStep(guideId: string, stepId: string): Promise<void> {
-  const snapshotCount = await db.snapshots.where('guideId').equals(guideId).count();
-  if (snapshotCount === 0) {
-    const step = await db.steps.get(stepId);
-    if (step?.screenshotId) await db.screenshots.delete(step.screenshotId);
-  }
-  await db.steps.delete(stepId);
-  const guide = await db.guides.get(guideId);
-  if (guide) {
-    const newStepIds = guide.stepIds.filter((id) => id !== stepId);
-    await db.guides.update(guideId, { stepIds: newStepIds, updatedAt: Date.now() });
-    const remaining = await db.steps.where('guideId').equals(guideId).sortBy('index');
-    for (let i = 0; i < remaining.length; i++) {
-      if (remaining[i].index !== i) {
-        await db.steps.update(remaining[i].id, { index: i });
-      }
+export async function deleteSteps(guideId: string, stepIds: readonly string[]): Promise<void> {
+  if (stepIds.length === 0) return;
+  const doomed = new Set(stepIds);
+  await db.transaction('rw', db.guides, db.steps, db.screenshots, db.snapshots, async () => {
+    const snapshotCount = await db.snapshots.where('guideId').equals(guideId).count();
+    if (snapshotCount === 0) {
+      const steps = await db.steps.bulkGet([...doomed]);
+      const screenshotIds = steps.map((step) => step?.screenshotId).filter((id): id is string => !!id);
+      if (screenshotIds.length > 0) await db.screenshots.bulkDelete(screenshotIds);
     }
-  }
+    await db.steps.bulkDelete([...doomed]);
+    const remaining = await db.steps.where('guideId').equals(guideId).sortBy('index');
+    await db.steps.bulkPut(remaining.map((step, index) => ({ ...step, index })));
+    const guide = await db.guides.get(guideId);
+    if (guide) {
+      await db.guides.update(guideId, {
+        stepIds: guide.stepIds.filter((id) => !doomed.has(id)),
+        updatedAt: Date.now(),
+      });
+    }
+  });
+}
+
+export async function deleteStep(guideId: string, stepId: string): Promise<void> {
+  await deleteSteps(guideId, [stepId]);
 }
 
 export async function getGuideDomain(guideId: string): Promise<string> {

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -177,6 +177,10 @@ editor:
   guideMe: Anleiten
   guideMeUnavailable: Keine abspielbaren Schritte in dieser Anleitung
   deleteThisStep: "Diesen Schritt löschen?"
+  selectStep: Schritt auswählen
+  selectedCount: "$1 ausgewählt"
+  deleteSelectedStep: "$1 ausgewählten Schritt löschen?"
+  deleteSelectedSteps: "$1 ausgewählte Schritte löschen?"
   copyScreenshot: Screenshot kopieren
   noScreenshot: Kein Screenshot
   edit: Bearbeiten

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -177,6 +177,10 @@ editor:
   guideMe: Guide Me
   guideMeUnavailable: No replayable steps in this guide
   deleteThisStep: "Delete this step?"
+  selectStep: Select step
+  selectedCount: "$1 selected"
+  deleteSelectedStep: "Delete $1 selected step?"
+  deleteSelectedSteps: "Delete $1 selected steps?"
   copyScreenshot: Copy screenshot
   noScreenshot: No screenshot
   edit: Edit

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -177,6 +177,10 @@ editor:
   guideMe: "¡Guíame!"
   guideMeUnavailable: Esta guía no tiene pasos que se puedan repetir
   deleteThisStep: "¿Eliminar este paso?"
+  selectStep: Seleccionar paso
+  selectedCount: "$1 seleccionados"
+  deleteSelectedStep: "¿Eliminar $1 paso seleccionado?"
+  deleteSelectedSteps: "¿Eliminar $1 pasos seleccionados?"
   copyScreenshot: Copiar captura
   noScreenshot: Sin captura
   edit: Editar

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -177,6 +177,10 @@ editor:
   guideMe: "Guidez-moi !"
   guideMeUnavailable: "Aucune étape rejouable dans ce guide"
   deleteThisStep: "Supprimer cette étape ?"
+  selectStep: "Sélectionner l'étape"
+  selectedCount: "$1 sélectionné(s)"
+  deleteSelectedStep: "Supprimer $1 étape sélectionnée ?"
+  deleteSelectedSteps: "Supprimer $1 étapes sélectionnées ?"
   copyScreenshot: "Copier la capture"
   noScreenshot: "Pas de capture"
   edit: Modifier

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -177,6 +177,10 @@ editor:
   guideMe: "Me guia!"
   guideMeUnavailable: Esse guia não tem passos pra repetir
   deleteThisStep: "Excluir esse passo?"
+  selectStep: Selecionar passo
+  selectedCount: "$1 selecionados"
+  deleteSelectedStep: "Excluir $1 passo selecionado?"
+  deleteSelectedSteps: "Excluir $1 passos selecionados?"
   copyScreenshot: Copiar captura
   noScreenshot: Sem captura
   edit: Editar

--- a/src/ui/fullview/components/GuideStepList.tsx
+++ b/src/ui/fullview/components/GuideStepList.tsx
@@ -1,10 +1,15 @@
+import { Trash2 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
+import { i18n } from '#imports';
 import { isBlock, stepNumbers } from '@/core/guides/blocks';
-import { insertBlock, reorderSteps } from '@/core/guides/service';
+import { createSnapshot, deleteSteps, insertBlock, reorderSteps } from '@/core/guides/service';
 import type { BlockType, Screenshot, Step } from '@/core/guides/types';
+import { logger } from '@/lib/logger';
 import { useFullview } from '@/stores/fullview';
+import { Button } from '@/ui/components/ui/button';
 import BlockCard from '@/ui/shared/BlockCard';
 import CaptureTabDialog from '@/ui/shared/CaptureTabDialog';
+import ConfirmDialog from '@/ui/shared/ConfirmDialog';
 import EmptyGuideState from '@/ui/shared/EmptyGuideState';
 import { dominantRatio } from '@/ui/shared/ImagePlaceholder';
 import InsertBlockMenu from '@/ui/shared/InsertBlockMenu';
@@ -37,14 +42,18 @@ export default function GuideStepList({
   hasApiKey,
   onInsertRecording,
 }: GuideStepListProps) {
-  const { scrollToStepId, setActiveStepId } = useFullview((s) => ({
+  const { scrollToStepId, setActiveStepId, bumpHistoryRefresh } = useFullview((s) => ({
     scrollToStepId: s.scrollToStepId,
     setActiveStepId: s.setActiveStepId,
+    bumpHistoryRefresh: s.bumpHistoryRefresh,
   }));
 
   const [recordAtIndex, setRecordAtIndex] = useState<number | null>(null);
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [confirmBulkDelete, setConfirmBulkDelete] = useState(false);
+  const anchorIndex = useRef<number | null>(null);
   const stepRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const frameRatio = dominantRatio(screenshots);
   const numbers = stepNumbers(steps);
@@ -71,6 +80,13 @@ export default function GuideStepList({
     return () => observer.disconnect();
   }, [steps, setActiveStepId]);
 
+  useEffect(() => {
+    if (readOnly) {
+      setSelected(new Set());
+      anchorIndex.current = null;
+    }
+  }, [readOnly]);
+
   const handleDragEnd = () => {
     if (dragIndex !== null && dragOverIndex !== null && dragIndex !== dragOverIndex) {
       const newSteps = [...steps];
@@ -88,6 +104,34 @@ export default function GuideStepList({
 
   const handleInsertBlock = async (atIndex: number, blockType: BlockType) => {
     await insertBlock(guideId, atIndex, blockType, '');
+    onChanged?.();
+  };
+
+  const toggleSelected = (index: number, extend: boolean) => {
+    const from = extend && anchorIndex.current !== null ? anchorIndex.current : index;
+    anchorIndex.current = index;
+    setSelected((prev) => {
+      const next = new Set(prev);
+      const adding = !prev.has(steps[index].id);
+      for (let i = Math.min(from, index); i <= Math.max(from, index); i++) {
+        if (adding) next.add(steps[i].id);
+        else next.delete(steps[i].id);
+      }
+      return next;
+    });
+  };
+
+  const handleBulkDelete = async () => {
+    setConfirmBulkDelete(false);
+    const ids = steps.filter((step) => selected.has(step.id)).map((step) => step.id);
+    try {
+      if (await createSnapshot(guideId)) bumpHistoryRefresh();
+    } catch (err) {
+      logger.error(' Snapshot before bulk delete failed', err);
+    }
+    await deleteSteps(guideId, ids);
+    setSelected(new Set());
+    anchorIndex.current = null;
     onChanged?.();
   };
 
@@ -153,31 +197,45 @@ export default function GuideStepList({
           {dragOverIndex === idx && dragIndex !== null && dragIndex !== idx && (
             <div className="h-1 bg-accent rounded-full mx-4 mb-2" />
           )}
-          {isBlock(step) ? (
-            <BlockCard
-              step={step}
-              onDescriptionChange={onDescriptionChange}
-              onDelete={onDelete}
-              onChanged={onChanged}
-              readOnly={readOnly}
-              dragHandleProps={dragHandlers(idx)}
-            />
-          ) : (
-            <StepCard
-              step={step}
-              number={numbers.get(step.id) ?? 0}
-              screenshot={screenshots.get(step.id)}
-              placeholderRatio={frameRatio}
-              frameRatio={frameRatio}
-              onDescriptionChange={onDescriptionChange}
-              onDelete={onDelete}
-              onOpenEditor={onOpenEditor}
-              readOnly={readOnly}
-              hasApiKey={hasApiKey}
-              onChanged={onChanged}
-              dragHandleProps={dragHandlers(idx)}
-            />
-          )}
+          <div className="flex items-start gap-2">
+            {!readOnly && (
+              <input
+                type="checkbox"
+                checked={selected.has(step.id)}
+                onChange={() => {}}
+                onClick={(e) => toggleSelected(idx, e.shiftKey)}
+                aria-label={i18n.t('editor.selectStep')}
+                className="mt-3 shrink-0 w-4 h-4 accent-accent"
+              />
+            )}
+            <div className="flex-1 min-w-0">
+              {isBlock(step) ? (
+                <BlockCard
+                  step={step}
+                  onDescriptionChange={onDescriptionChange}
+                  onDelete={onDelete}
+                  onChanged={onChanged}
+                  readOnly={readOnly}
+                  dragHandleProps={dragHandlers(idx)}
+                />
+              ) : (
+                <StepCard
+                  step={step}
+                  number={numbers.get(step.id) ?? 0}
+                  screenshot={screenshots.get(step.id)}
+                  placeholderRatio={frameRatio}
+                  frameRatio={frameRatio}
+                  onDescriptionChange={onDescriptionChange}
+                  onDelete={onDelete}
+                  onOpenEditor={onOpenEditor}
+                  readOnly={readOnly}
+                  hasApiKey={hasApiKey}
+                  onChanged={onChanged}
+                  dragHandleProps={dragHandlers(idx)}
+                />
+              )}
+            </div>
+          </div>
           {!readOnly && (
             <InsertBlockMenu
               onInsert={(blockType) => handleInsertBlock(idx + 1, blockType)}
@@ -187,6 +245,31 @@ export default function GuideStepList({
         </div>
       ))}
       {captureDialog}
+      {selected.size > 0 && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-40 flex items-center gap-3 rounded-full border border-border bg-card px-4 py-2 shadow-lg">
+          <span className="text-[12px] font-medium text-foreground">
+            {i18n.t('editor.selectedCount', [String(selected.size)])}
+          </span>
+          <Button variant="ghost" size="sm" onClick={() => setSelected(new Set())}>
+            {i18n.t('common.cancel')}
+          </Button>
+          <Button variant="destructive" size="sm" onClick={() => setConfirmBulkDelete(true)}>
+            <Trash2 size={13} />
+            {i18n.t('common.delete')}
+          </Button>
+        </div>
+      )}
+      <ConfirmDialog
+        open={confirmBulkDelete}
+        heading={
+          selected.size === 1
+            ? i18n.t('editor.deleteSelectedStep', ['1'])
+            : i18n.t('editor.deleteSelectedSteps', [String(selected.size)])
+        }
+        destructive
+        onConfirm={handleBulkDelete}
+        onCancel={() => setConfirmBulkDelete(false)}
+      />
     </div>
   );
 }

--- a/src/ui/global.css
+++ b/src/ui/global.css
@@ -43,6 +43,13 @@ body {
   font-family: "Poppins", sans-serif;
 }
 
+button:not(:disabled):not([aria-disabled="true"]),
+[role="button"]:not([aria-disabled="true"]),
+label:has(> input[type="checkbox"]),
+input[type="checkbox"]:not(:disabled) {
+  cursor: pointer;
+}
+
 @keyframes gradient-text {
   0% { background-position: 100% 50%; }
   100% { background-position: -100% 50%; }


### PR DESCRIPTION
Trimming a long recording meant deleting steps one at a time, and each delete rebuilt the whole index and left its own window for a partial write.

The fullview editor now puts a checkbox on every card while editing — steps and blocks alike — with shift-click for ranges and a floating bar to delete the selection. `deleteSteps` does it in one transaction: one screenshot sweep, one bulk delete, one reindex. Screenshots are still only hard-deleted when the guide has no snapshots, so version history keeps working, and a snapshot is taken first so a bulk removal is revertible. `deleteStep` delegates to it.

Buttons were also missing `cursor: pointer` — browsers default them to `default` and nothing overrode it. One rule in `global.css` covers all of them.

Selection is fullview-only; the side panel's list is untouched.

`lint`, 739 tests, Chrome and Firefox builds clean.
