### PR TITLE
fix(editor): reorder cards from a drag handle and guard unrecordable pages

### DIFF
--- a/src/core/capture/__tests__/recordable-tabs.test.ts
+++ b/src/core/capture/__tests__/recordable-tabs.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { isRecordableUrl } from '../recordable-tabs';
+
+describe('isRecordableUrl', () => {
+  it('accepts http and https pages', () => {
+    expect(isRecordableUrl('https://example.test/path')).toBe(true);
+    expect(isRecordableUrl('http://localhost:3000')).toBe(true);
+  });
+
+  it('rejects pages no content script can reach', () => {
+    for (const url of [
+      undefined,
+      '',
+      'chrome://settings',
+      'chrome-extension://abc/fullview.html',
+      'about:blank',
+      'file:///home/user/doc.pdf',
+      'view-source:https://example.test',
+      'edge://extensions',
+      'https://chrome.google.com/webstore/category/extensions',
+      'https://chromewebstore.google.com/detail/mimik/abc',
+    ]) {
+      expect(isRecordableUrl(url), url).toBe(false);
+    }
+  });
+});

--- a/src/core/capture/recordable-tabs.ts
+++ b/src/core/capture/recordable-tabs.ts
@@ -1,6 +1,6 @@
 import { queryTabs } from '@/lib/browser-api';
 
-const WEBSTORE_PREFIX = 'https://chrome.google.com/webstore';
+const WEBSTORE_PREFIXES = ['https://chrome.google.com/webstore', 'https://chromewebstore.google.com'];
 
 export interface RecordableTab {
   id: number;
@@ -10,7 +10,7 @@ export interface RecordableTab {
 }
 
 export function isRecordableUrl(url: string | undefined): boolean {
-  if (!url || url.startsWith(WEBSTORE_PREFIX)) return false;
+  if (!url || WEBSTORE_PREFIXES.some((prefix) => url.startsWith(prefix))) return false;
   return /^https?:/.test(url);
 }
 

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -29,6 +29,7 @@ sidepanel:
   startCapture: Aufnahme starten
   searchPlaceholder: Anleitungen durchsuchen...
   recentLabel: Zuletzt verwendet
+  notRecordable: Öffne eine Website, um aufzuzeichnen
 
 library:
   noGuidesTitle: Noch keine Anleitungen

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -29,6 +29,7 @@ sidepanel:
   startCapture: Start Capture
   searchPlaceholder: Search guides...
   recentLabel: Recent
+  notRecordable: Open a website to start capturing
 
 library:
   noGuidesTitle: No guides yet

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -29,6 +29,7 @@ sidepanel:
   startCapture: Empezar a capturar
   searchPlaceholder: Buscar guías...
   recentLabel: Recientes
+  notRecordable: Abre un sitio web para empezar a grabar
 
 library:
   noGuidesTitle: No hay guías todavía

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -29,6 +29,7 @@ sidepanel:
   startCapture: Lancer la capture
   searchPlaceholder: "Rechercher des guides..."
   recentLabel: "Récents"
+  notRecordable: "Ouvrez un site web pour lancer la capture"
 
 library:
   noGuidesTitle: Pas encore de guide

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -29,6 +29,7 @@ sidepanel:
   startCapture: Começar a capturar
   searchPlaceholder: Buscar guias...
   recentLabel: Recentes
+  notRecordable: Abra um site para começar a gravar
 
 library:
   noGuidesTitle: Nenhum guia ainda

--- a/src/ui/onboarding/App.tsx
+++ b/src/ui/onboarding/App.tsx
@@ -474,7 +474,7 @@ function VoiceStep({ onNext, onSkip, onBack, index, total }: StepProps) {
   );
 }
 
-function SmartBlurStep({ onNext, onSkip, onBack, index, total }: StepProps) {
+function SmartBlurStep({ onNext, onBack, index, total }: StepProps) {
   const [blurPresets, setBlurPresets] = useState<Record<PresetKey, boolean>>({
     email: true,
     phone: true,
@@ -550,12 +550,6 @@ function SmartBlurStep({ onNext, onSkip, onBack, index, total }: StepProps) {
             >
               {i18n.t('common.continue')}
             </button>
-            <button
-              onClick={onSkip}
-              className="ml-2 px-6 py-3 text-muted-foreground rounded-xl font-semibold text-sm hover:text-foreground transition-colors"
-            >
-              {i18n.t('common.skip')}
-            </button>
           </div>
 
           <div className="mt-6">
@@ -621,7 +615,7 @@ function SmartBlurStep({ onNext, onSkip, onBack, index, total }: StepProps) {
   );
 }
 
-function PinExtensionStep({ onNext, onSkip, onBack, index, total }: StepProps) {
+function PinExtensionStep({ onNext, onBack, index, total }: StepProps) {
   return (
     <div className="flex h-screen">
       <div className="flex-1 flex flex-col justify-center" style={{ padding: '80px 64px' }}>
@@ -676,12 +670,6 @@ function PinExtensionStep({ onNext, onSkip, onBack, index, total }: StepProps) {
               className="px-8 py-3 bg-accent text-white rounded-xl font-semibold text-sm hover:bg-accent/90 transition-colors"
             >
               {i18n.t('common.continue')}
-            </button>
-            <button
-              onClick={onSkip}
-              className="ml-2 px-6 py-3 text-muted-foreground rounded-xl font-semibold text-sm hover:text-foreground transition-colors"
-            >
-              {i18n.t('common.skip')}
             </button>
           </div>
 

--- a/src/ui/shared/BlockCard.tsx
+++ b/src/ui/shared/BlockCard.tsx
@@ -6,12 +6,7 @@ import { updateCallout } from '@/core/guides/service';
 import type { CalloutVariant, Step } from '@/core/guides/types';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/components/ui/tooltip';
 import ConfirmDialog from '@/ui/shared/ConfirmDialog';
-
-interface DragHandleProps {
-  onDragStart: (e: React.DragEvent) => void;
-  onDragOver: (e: React.DragEvent) => void;
-  onDragEnd: () => void;
-}
+import { DragGrip, type DragHandleProps, useCardDrag } from '@/ui/shared/card-drag';
 
 interface BlockCardProps {
   step: Step;
@@ -37,6 +32,7 @@ export default function BlockCard({
     setDescription(step.description);
   }, [step.description]);
 
+  const cardDrag = useCardDrag(dragHandleProps);
   const isHeading = step.blockType === 'heading';
   const accent = calloutAccent(step);
   const variant = step.calloutVariant ?? 'info';
@@ -57,8 +53,7 @@ export default function BlockCard({
 
   return (
     <div
-      draggable={!!dragHandleProps}
-      onDragStart={dragHandleProps?.onDragStart}
+      {...cardDrag}
       onDragOver={(e) => {
         e.preventDefault();
         dragHandleProps?.onDragOver(e);
@@ -97,6 +92,7 @@ export default function BlockCard({
       </div>
       {!readOnly && (
         <div className="flex items-center gap-1 mt-1">
+          {dragHandleProps && <DragGrip />}
           {!isHeading &&
             CALLOUT_VARIANTS.map((option) => (
               <Tooltip key={option}>

--- a/src/ui/shared/card-drag.tsx
+++ b/src/ui/shared/card-drag.tsx
@@ -1,0 +1,37 @@
+import { GripVertical } from 'lucide-react';
+import { useRef } from 'react';
+
+export interface DragHandleProps {
+  onDragStart: (e: React.DragEvent) => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDragEnd: () => void;
+}
+
+export function useCardDrag(dragHandleProps?: DragHandleProps) {
+  const pressedHandle = useRef(false);
+  return {
+    draggable: !!dragHandleProps,
+    onPointerDownCapture: (e: React.PointerEvent) => {
+      pressedHandle.current = !!(e.target as Element).closest('[data-drag-handle]');
+    },
+    onDragStart: (e: React.DragEvent) => {
+      if (!pressedHandle.current) {
+        e.preventDefault();
+        return;
+      }
+      dragHandleProps?.onDragStart(e);
+    },
+  };
+}
+
+export function DragGrip() {
+  return (
+    <span
+      data-drag-handle=""
+      aria-hidden="true"
+      className="shrink-0 p-1 -m-1 cursor-grab text-border hover:text-muted-foreground"
+    >
+      <GripVertical size={14} />
+    </span>
+  );
+}

--- a/src/ui/sidepanel/App.tsx
+++ b/src/ui/sidepanel/App.tsx
@@ -1,7 +1,8 @@
-import { Search, Settings, Video } from 'lucide-react';
+import { Globe, Search, Settings, Video } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { browser, i18n } from '#imports';
 import { CaptureState } from '@/core/capture/machine';
+import { isRecordableUrl } from '@/core/capture/recordable-tabs';
 import { startInsertRecording } from '@/core/capture/start-insert-recording';
 import type { GuideMeSession } from '@/core/guideme/session';
 import { SESSION_KEY } from '@/core/guideme/session';
@@ -91,6 +92,7 @@ export default function App() {
   const [_isRecording, setIsRecording] = useState(false);
   const [view, setView] = useState<View>({ name: 'library' });
   const [search, setSearch] = useState('');
+  const [activeUrl, setActiveUrl] = useState<string>();
   const [voice, setVoice] = useState<PanelVoiceUpdate>({ type: 'VOICE_UPDATE', phase: 'idle' });
   const [voiceStarted, setVoiceStarted] = useState(false);
 
@@ -148,6 +150,17 @@ export default function App() {
     return () => browser.storage.local.onChanged.removeListener(handler);
   }, []);
 
+  useEffect(() => {
+    const refresh = () => getActiveTab().then((tab) => setActiveUrl(tab?.url || tab?.pendingUrl || ''));
+    refresh();
+    browser.tabs.onActivated.addListener(refresh);
+    browser.tabs.onUpdated.addListener(refresh);
+    return () => {
+      browser.tabs.onActivated.removeListener(refresh);
+      browser.tabs.onUpdated.removeListener(refresh);
+    };
+  }, []);
+
   const handleStartRecording = useCallback(async () => {
     const permissionsPromise = requestHostPermissions();
     const granted = await permissionsPromise;
@@ -156,7 +169,11 @@ export default function App() {
       return;
     }
     const tab = await getActiveTab();
-    const url = tab?.url || '';
+    const url = tab?.url || tab?.pendingUrl || '';
+    if (!isRecordableUrl(url)) {
+      logger.warn('Active tab can no longer be recorded');
+      return;
+    }
 
     try {
       const res = await sendMessage('startRecording', { url });
@@ -276,14 +293,21 @@ export default function App() {
             <p className="text-xs mt-1 text-violet-dark">{i18n.t('sidepanel.heroSubtitle')}</p>
           </div>
 
-          <Button
-            onClick={handleStartRecording}
-            disabled={!isAlive}
-            className="w-full py-3 px-4 h-auto rounded-lg font-semibold text-sm hover:-translate-y-px shadow-lg"
-          >
-            <Video size={18} />
-            {i18n.t('sidepanel.startCapture')}
-          </Button>
+          {isRecordableUrl(activeUrl) ? (
+            <Button
+              onClick={handleStartRecording}
+              disabled={!isAlive}
+              className="w-full py-3 px-4 h-auto rounded-lg font-semibold text-sm hover:-translate-y-px shadow-lg"
+            >
+              <Video size={18} />
+              {i18n.t('sidepanel.startCapture')}
+            </Button>
+          ) : (
+            <p className="flex items-center justify-center gap-1.5 text-xs font-medium text-violet-dark">
+              <Globe size={14} className="shrink-0" />
+              {i18n.t('sidepanel.notRecordable')}
+            </p>
+          )}
         </div>
 
         {/* Body */}

--- a/src/ui/sidepanel/StepCard.tsx
+++ b/src/ui/sidepanel/StepCard.tsx
@@ -1,5 +1,5 @@
 import { Check, Copy, Loader2, Trash2 } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { i18n } from '#imports';
 import { replaceScreenshot } from '@/core/guides/service';
 import type { Screenshot, Step } from '@/core/guides/types';
@@ -8,14 +8,9 @@ import { logger } from '@/lib/logger';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/components/ui/tooltip';
 import { useAskAi } from '@/ui/shared/AskAi';
 import ConfirmDialog from '@/ui/shared/ConfirmDialog';
+import { DragGrip, type DragHandleProps, useCardDrag } from '@/ui/shared/card-drag';
 import ImagePlaceholder from '@/ui/shared/ImagePlaceholder';
 import ScreenshotView from '@/ui/shared/ScreenshotView';
-
-interface DragHandleProps {
-  onDragStart: (e: React.DragEvent) => void;
-  onDragOver: (e: React.DragEvent) => void;
-  onDragEnd: () => void;
-}
 
 interface StepCardProps {
   step: Step;
@@ -50,8 +45,8 @@ export default function StepCard({
   const [description, setDescription] = useState(step.description);
   const [dragOver, setDragOver] = useState(false);
   const [copied, setCopied] = useState(false);
-  const pressedOnScreenshot = useRef(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const cardDrag = useCardDrag(dragHandleProps);
 
   useEffect(() => {
     setDescription(step.description);
@@ -98,21 +93,9 @@ export default function StepCard({
     dragHandleProps?.onDragOver(e);
   };
 
-  const handleDragStart = (e: React.DragEvent) => {
-    if (pressedOnScreenshot.current) {
-      e.preventDefault();
-      return;
-    }
-    dragHandleProps?.onDragStart(e);
-  };
-
   return (
     <div
-      draggable={!!dragHandleProps}
-      onPointerDownCapture={(e) => {
-        pressedOnScreenshot.current = !!(e.target as HTMLElement).closest('[data-screenshot-frame]');
-      }}
-      onDragStart={handleDragStart}
+      {...cardDrag}
       onDragOver={handleDragOver}
       onDragLeave={() => setDragOver(false)}
       onDragEnd={() => {
@@ -143,6 +126,7 @@ export default function StepCard({
 
       <div className="px-3 pt-2 pb-2">
         <div className="flex items-center gap-2">
+          {dragHandleProps && <DragGrip />}
           <span className="flex items-center justify-center w-[22px] h-[22px] rounded-full text-[11px] font-bold shrink-0 bg-primary text-primary-foreground">
             {number}
           </span>

--- a/src/ui/sidepanel/__tests__/step-card-drag.test.tsx
+++ b/src/ui/sidepanel/__tests__/step-card-drag.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { Step } from '@/core/guides/types';
+import { TooltipProvider } from '@/ui/components/ui/tooltip';
+
+vi.mock('@/core/guides/service', () => ({ replaceScreenshot: vi.fn() }));
+vi.mock('@/core/screenshot/render', () => ({ imageDimensions: vi.fn(), renderScreenshot: vi.fn() }));
+
+import StepCard from '../StepCard';
+
+const step: Step = {
+  id: 's1',
+  guideId: 'g1',
+  index: 0,
+  description: 'Click the thing',
+  action: 'click',
+  url: 'https://a.test',
+  timestamp: 1,
+};
+
+function renderCard() {
+  const dragHandleProps = { onDragStart: vi.fn(), onDragOver: vi.fn(), onDragEnd: vi.fn() };
+  const { container } = render(
+    <TooltipProvider>
+      <StepCard
+        step={step}
+        number={1}
+        screenshot={undefined}
+        dragHandleProps={dragHandleProps}
+        onDescriptionChange={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    </TooltipProvider>,
+  );
+  const card = container.querySelector('[draggable="true"]') as HTMLElement;
+  return { dragHandleProps, card, container };
+}
+
+describe('StepCard reordering', () => {
+  it('does not start a drag when the press lands on the description', () => {
+    const { dragHandleProps, card, container } = renderCard();
+    fireEvent.pointerDown(container.querySelector('textarea') as HTMLElement);
+    fireEvent.dragStart(card);
+    expect(dragHandleProps.onDragStart).not.toHaveBeenCalled();
+  });
+
+  it('starts a drag when the press lands on the grip', () => {
+    const { dragHandleProps, card, container } = renderCard();
+    fireEvent.pointerDown(container.querySelector('[data-drag-handle]') as HTMLElement);
+    fireEvent.dragStart(card);
+    expect(dragHandleProps.onDragStart).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Dragging across a step's description selected nothing and started a card reorder: both `StepCard` and `BlockCard` set `draggable` on the card root with the textarea inside it; only the screenshot frame was exempt. Both now drag from a grip handle only — what `dragHandleProps` always implied — so selecting description text works, which the inline AI rewrite needs.

Two fixes ride along. The Pin and Smart blur onboarding steps had a Skip button wired to the same handler as Continue; removed, and Skip stays where it really skips a save. Start Capture was clickable on pages no content script can reach, leaving orphan empty guides — the panel now hides it and says what to do, reusing the `isRecordableUrl` guard the insert flow already had, extended to `chromewebstore.google.com`.

Keyboard reorder still isn't possible. `pnpm lint`, 740 tests, Chrome and Firefox builds clean.
