### PR TITLE
fix(settings): validate the transcription key and route groq keys to groq

### DIFF
--- a/src/core/capture/ai/__tests__/validate.test.ts
+++ b/src/core/capture/ai/__tests__/validate.test.ts
@@ -59,6 +59,13 @@ describe('validateApiKey', () => {
     expect(init.headers.Authorization).toBe('Bearer gsk-key');
   });
 
+  it('gives up rather than spinning forever when a host never answers', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+    await validateApiKey('openai', 'sk-key');
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
   it('never sends a key to an unknown provider, and does not call it rejected', async () => {
     expect(await validateApiKey('mystery', 'secret')).toEqual({ valid: false, reason: 'network' });
     expect(fetchMock).not.toHaveBeenCalled();

--- a/src/core/capture/ai/__tests__/validate.test.ts
+++ b/src/core/capture/ai/__tests__/validate.test.ts
@@ -50,4 +50,17 @@ describe('validateApiKey', () => {
     expect(url).toBe('https://api.openai.com/v1/models');
     expect(init.headers.Authorization).toBe('Bearer sk-key');
   });
+
+  it('checks a groq key against groq, not openai', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+    expect(await validateApiKey('groq', 'gsk-key')).toEqual({ valid: true });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.groq.com/openai/v1/models');
+    expect(init.headers.Authorization).toBe('Bearer gsk-key');
+  });
+
+  it('never sends a key to an unknown provider, and does not call it rejected', async () => {
+    expect(await validateApiKey('mystery', 'secret')).toEqual({ valid: false, reason: 'network' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/core/capture/ai/validate.ts
+++ b/src/core/capture/ai/validate.ts
@@ -15,10 +15,18 @@ const ENDPOINTS: Record<string, { url: string; headers: (key: string) => Record<
       'anthropic-dangerous-direct-browser-access': 'true',
     }),
   },
+  groq: {
+    url: 'https://api.groq.com/openai/v1/models',
+    headers: (key) => ({ Authorization: `Bearer ${key}` }),
+  },
 };
 
 export async function validateApiKey(provider: string, apiKey: string): Promise<KeyValidation> {
-  const endpoint = ENDPOINTS[provider] ?? ENDPOINTS.openai;
+  const endpoint = ENDPOINTS[provider];
+  if (!endpoint) {
+    logger.error('No API key validation endpoint for provider', provider);
+    return { valid: false, reason: 'network' };
+  }
   try {
     const res = await fetch(endpoint.url, { headers: endpoint.headers(apiKey) });
     if (res.ok) return { valid: true };

--- a/src/core/capture/ai/validate.ts
+++ b/src/core/capture/ai/validate.ts
@@ -2,6 +2,8 @@ import { logger } from '@/lib/logger';
 
 export type KeyValidation = { valid: true } | { valid: false; reason: 'rejected' | 'network' };
 
+const REQUEST_TIMEOUT_MS = 10_000;
+
 const ENDPOINTS: Record<string, { url: string; headers: (key: string) => Record<string, string> }> = {
   openai: {
     url: 'https://api.openai.com/v1/models',
@@ -28,7 +30,10 @@ export async function validateApiKey(provider: string, apiKey: string): Promise<
     return { valid: false, reason: 'network' };
   }
   try {
-    const res = await fetch(endpoint.url, { headers: endpoint.headers(apiKey) });
+    const res = await fetch(endpoint.url, {
+      headers: endpoint.headers(apiKey),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
     if (res.ok) return { valid: true };
     if (res.status === 401 || res.status === 403) return { valid: false, reason: 'rejected' };
     return { valid: false, reason: 'network' };

--- a/src/ui/shared/SettingsView.tsx
+++ b/src/ui/shared/SettingsView.tsx
@@ -42,6 +42,52 @@ interface SettingsViewProps {
 const SAVE_DEBOUNCE_MS = 400;
 const SAVED_BADGE_MS = 1600;
 
+type KeyStatus = 'checking' | 'valid' | 'rejected' | 'unreachable' | null;
+
+function useKeyCheck() {
+  const [status, setStatus] = useState<KeyStatus>(null);
+  const validated = useRef('');
+
+  const check = useCallback(async (provider: string, apiKey: string) => {
+    const fingerprint = `${provider}:${apiKey}`;
+    if (validated.current === fingerprint) {
+      setStatus('valid');
+      return;
+    }
+    setStatus('checking');
+    const result = await sendMessage('validateApiKey', { provider, apiKey }).catch(() => null);
+    if (result?.valid) validated.current = fingerprint;
+    setStatus(result?.valid ? 'valid' : result?.reason === 'rejected' ? 'rejected' : 'unreachable');
+  }, []);
+
+  return { status, setStatus, check };
+}
+
+function KeyStatusNote({ status }: { status: KeyStatus }) {
+  if (status === 'checking') {
+    return <p className="mt-1 text-[11px] text-muted-foreground">{i18n.t('settings.validatingKey')}</p>;
+  }
+  if (status === 'valid') {
+    return (
+      <p className="mt-1 text-[11px] flex items-center gap-1" style={{ color: 'var(--color-success)' }}>
+        <Check size={11} />
+        {i18n.t('settings.keyValid')}
+      </p>
+    );
+  }
+  if (status === 'rejected') {
+    return (
+      <p className="mt-1 text-[11px] text-destructive" role="alert">
+        {i18n.t('settings.keyInvalid')}
+      </p>
+    );
+  }
+  if (status === 'unreachable') {
+    return <p className="mt-1 text-[11px] text-muted-foreground">{i18n.t('settings.keyUnreachable')}</p>;
+  }
+  return null;
+}
+
 const FOOTER_PRESETS = () => [
   defaultFooterLine(),
   i18n.t('settings.footerPresetConfidential'),
@@ -53,10 +99,10 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
   const [model, setModel] = useState(AI_PROVIDERS.openai.defaultModel);
   const [apiKey, setApiKey] = useState('');
   const [saved, setSaved] = useState(false);
-  const [keyStatus, setKeyStatus] = useState<'checking' | 'valid' | 'rejected' | 'unreachable' | null>(null);
+  const aiKeyCheck = useKeyCheck();
+  const voiceKeyCheck = useKeyCheck();
   const [customModel, setCustomModel] = useState(false);
   const [loaded, setLoaded] = useState(false);
-  const validatedKey = useRef('');
   const savedSnapshot = useRef<SettingsSnapshot | null>(null);
   const pending = useRef<SettingsSnapshot>({});
   const saveTimer = useRef<number | undefined>(undefined);
@@ -178,6 +224,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
 
   const handleProviderChange = (newProvider: AIProviderKey) => {
     setProvider(newProvider);
+    aiKeyCheck.setStatus(null);
     setCustomModel(false);
     setModel(AI_PROVIDERS[newProvider].defaultModel);
   };
@@ -190,18 +237,6 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
     }
     setCustomModel(false);
     setModel(value);
-  };
-
-  const handleCheckKey = async () => {
-    const fingerprint = `${provider}:${apiKey}`;
-    if (validatedKey.current === fingerprint) {
-      setKeyStatus('valid');
-      return;
-    }
-    setKeyStatus('checking');
-    const result = await sendMessage('validateApiKey', { provider, apiKey }).catch(() => null);
-    if (result?.valid) validatedKey.current = fingerprint;
-    setKeyStatus(result?.valid ? 'valid' : result?.reason === 'rejected' ? 'rejected' : 'unreachable');
   };
 
   const providerConfig = AI_PROVIDERS[provider];
@@ -302,7 +337,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
                 value={apiKey}
                 onChange={(e) => {
                   setApiKey(e.target.value);
-                  setKeyStatus(null);
+                  aiKeyCheck.setStatus(null);
                 }}
                 placeholder="sk-..."
                 className="h-8 text-[12px] rounded-lg border-border"
@@ -310,28 +345,14 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
               <Button
                 variant="outline"
                 size="sm"
-                disabled={!apiKey || keyStatus === 'checking'}
-                onClick={() => void handleCheckKey()}
+                disabled={!apiKey || aiKeyCheck.status === 'checking'}
+                onClick={() => void aiKeyCheck.check(provider, apiKey)}
                 className="h-8 shrink-0 rounded-lg bg-card text-[11px] font-semibold"
               >
                 {i18n.t('settings.checkKey')}
               </Button>
             </div>
-            {keyStatus === 'checking' && (
-              <p className="mt-1 text-[11px] text-muted-foreground">{i18n.t('settings.validatingKey')}</p>
-            )}
-            {keyStatus === 'valid' && (
-              <p className="mt-1 text-[11px] flex items-center gap-1" style={{ color: 'var(--color-success)' }}>
-                <Check size={11} />
-                {i18n.t('settings.keyValid')}
-              </p>
-            )}
-            {keyStatus === 'rejected' && (
-              <p className="mt-1 text-[11px] text-destructive">{i18n.t('settings.keyInvalid')}</p>
-            )}
-            {keyStatus === 'unreachable' && (
-              <p className="mt-1 text-[11px] text-muted-foreground">{i18n.t('settings.keyUnreachable')}</p>
-            )}
+            <KeyStatusNote status={aiKeyCheck.status} />
           </div>
 
           <div>
@@ -489,7 +510,10 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
             </label>
             <select
               value={voiceProvider}
-              onChange={(e) => setVoiceProvider(e.target.value as VoiceProvider)}
+              onChange={(e) => {
+                setVoiceProvider(e.target.value as VoiceProvider);
+                voiceKeyCheck.setStatus(null);
+              }}
               className="w-full border border-border rounded-lg px-3 py-2 text-[13px] text-foreground bg-card font-medium outline-none focus:border-ring focus:ring-2 focus:ring-ring/10"
             >
               <option value="openai">OpenAI</option>
@@ -499,12 +523,27 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
 
           <div>
             <label className="block text-[11px] font-semibold text-foreground mb-1">{i18n.t('settings.apiKey')}</label>
-            <Input
-              type="password"
-              value={voiceApiKey}
-              onChange={(e) => setVoiceApiKey(e.target.value)}
-              placeholder={voiceProvider === 'groq' ? 'gsk_...' : 'sk-...'}
-            />
+            <div className="flex items-center gap-1.5">
+              <Input
+                type="password"
+                value={voiceApiKey}
+                onChange={(e) => {
+                  setVoiceApiKey(e.target.value);
+                  voiceKeyCheck.setStatus(null);
+                }}
+                placeholder={voiceProvider === 'groq' ? 'gsk_...' : 'sk-...'}
+              />
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!voiceApiKey || voiceKeyCheck.status === 'checking'}
+                onClick={() => void voiceKeyCheck.check(voiceProvider, voiceApiKey)}
+                className="h-8 shrink-0 rounded-lg bg-card text-[11px] font-semibold"
+              >
+                {i18n.t('settings.checkKey')}
+              </Button>
+            </div>
+            <KeyStatusNote status={voiceKeyCheck.status} />
             {voiceKey.source === 'ai' && (
               <p className="mt-1.5 flex items-start gap-1.5 text-[10px] text-muted-foreground leading-relaxed">
                 <Sparkles size={11} className="shrink-0 mt-0.5 text-accent" />


### PR DESCRIPTION
The transcription key went straight to storage unchecked, so a bad key first
showed up as a recording that silently failed to narrate. It now has the same
Check key button as the AI key, and switching provider clears a stale verdict —
a key verified as OpenAI is not valid for Groq.

Validation only knew openai and anthropic and fell back to OpenAI for anything
else, so a Groq key was sent to api.openai.com: rejected when it was fine, or
worse, passed when the OpenAI key it shares works there. Unknown providers now
fail without a request rather than leaking the key to the wrong host.

Onboarding still writes voiceApiKey unchecked; it validates no key at all, so
that surface is untouched here.

pnpm lint, 791 tests, and both browser builds clean.
