### PR TITLE
feat(video): rework the video export composition and preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@ai-sdk/openai": "^3.0.49",
     "@fontsource/poppins": "^5.2.7",
     "@tailwindcss/vite": "^4.2.2",
+    "@vidstack/react": "^1.15.6",
     "@webext-core/messaging": "^2.3.0",
     "@wxt-dev/module-react": "^1.2.2",
     "@xstate/react": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1))
+      '@vidstack/react':
+        specifier: ^1.15.6
+        version: 1.15.6(@types/react@19.2.14)(react@19.2.4)
       '@webext-core/messaging':
         specifier: ^2.3.0
         version: 2.3.0
@@ -1607,6 +1610,13 @@ packages:
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
+  '@vidstack/react@1.15.6':
+    resolution: {integrity: sha512-hO7cLld5yfxCdDnDCYqh5aS7JxmHfsmX43PmKBJWzDTwK40P3hh5qAdDQzl3qDtEJLYjuo3Sv+kr6tt/VRtJzQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2701,6 +2711,10 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  media-captions@1.0.4:
+    resolution: {integrity: sha512-cyDNmuZvvO4H27rcBq2Eudxo9IZRDCOX/I7VEyqbxsEiD2Ei7UYUhG/Sc5fvMZjmathgz3fEK7iAKqvpY+Ux1w==}
+    engines: {node: '>=16'}
 
   mediabunny@1.52.3:
     resolution: {integrity: sha512-rMGwH5fykDCSA55LG9aWkE433wwHrycq3J5mRf+djBnHBZzmJGvIwg6Qfcfr4rRkzkmrdmewxQozLkOM1H1C6Q==}
@@ -5039,6 +5053,13 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
+  '@vidstack/react@1.15.6(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@types/react': 19.2.14
+      media-captions: 1.0.4
+      react: 19.2.4
+
   '@vitejs/plugin-react@6.0.1(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
@@ -6096,6 +6117,8 @@ snapshots:
   marky@1.3.0: {}
 
   mdn-data@2.27.1: {}
+
+  media-captions@1.0.4: {}
 
   mediabunny@1.52.3:
     dependencies:

--- a/src/core/capture/__tests__/element-meta.test.ts
+++ b/src/core/capture/__tests__/element-meta.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { extractElementMeta } from '@/core/capture/dom/element-meta';
+
+function withRect(el: HTMLElement, rect: { x: number; y: number; width: number; height: number }) {
+  el.getBoundingClientRect = () => ({ ...rect, top: rect.y, left: rect.x, right: 0, bottom: 0, toJSON: () => ({}) });
+  return el;
+}
+
+function menuItem(): HTMLElement {
+  const el = document.createElement('button');
+  el.textContent = 'Copy link';
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('extractElementMeta', () => {
+  it('measures the element when nothing was frozen at event time', () => {
+    const el = withRect(menuItem(), { x: 12, y: 34, width: 100, height: 20 });
+    expect(extractElementMeta(el).rect).toEqual({ x: 12, y: 34, width: 100, height: 20 });
+  });
+
+  it('prefers the live measurement while the element is still laid out', () => {
+    const el = withRect(menuItem(), { x: 12, y: 34, width: 100, height: 20 });
+    const stale = { x: 999, y: 999, width: 5, height: 5 };
+    expect(extractElementMeta(el, stale).rect).toEqual({ x: 12, y: 34, width: 100, height: 20 });
+  });
+
+  it('falls back to the click-time rect once the element leaves the layout', () => {
+    const el = withRect(menuItem(), { x: 12, y: 34, width: 100, height: 20 });
+    const atClick = { x: 12, y: 34, width: 100, height: 20 };
+    withRect(el, { x: 0, y: 0, width: 0, height: 0 });
+    el.remove();
+    expect(extractElementMeta(el, atClick).rect).toEqual(atClick);
+  });
+
+  it('still reports a degenerate rect when there is nothing better to offer', () => {
+    const el = withRect(menuItem(), { x: 0, y: 0, width: 0, height: 0 });
+    expect(extractElementMeta(el).rect).toEqual({ x: 0, y: 0, width: 0, height: 0 });
+  });
+
+  it('keeps reading the label off a detached element, which needs no layout', () => {
+    const el = withRect(menuItem(), { x: 0, y: 0, width: 0, height: 0 });
+    el.setAttribute('aria-label', 'Copy link');
+    el.remove();
+    const meta = extractElementMeta(el, { x: 12, y: 34, width: 100, height: 20 });
+    expect(meta.ariaLabel).toBe('Copy link');
+    expect(meta.rect).toEqual({ x: 12, y: 34, width: 100, height: 20 });
+  });
+});

--- a/src/core/capture/dom/element-meta.ts
+++ b/src/core/capture/dom/element-meta.ts
@@ -22,8 +22,21 @@ function getCleanText(el: HTMLElement): string | null {
   }
 }
 
-export function extractElementMeta(el: HTMLElement): ElementMeta {
-  const rect = el.getBoundingClientRect();
+export interface FrozenRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export function freezeRect(el: Element): FrozenRect {
+  const { x, y, width, height } = el.getBoundingClientRect();
+  return { x, y, width, height };
+}
+
+export function extractElementMeta(el: HTMLElement, atEvent?: FrozenRect): ElementMeta {
+  const live = freezeRect(el);
+  const rect = live.width > 0 || live.height > 0 ? live : (atEvent ?? live);
   let cssSelector: string;
   try {
     cssSelector = getCssSelector(el);
@@ -42,7 +55,7 @@ export function extractElementMeta(el: HTMLElement): ElementMeta {
     href: el instanceof HTMLAnchorElement ? el.href : null,
     inputType: el instanceof HTMLInputElement ? el.type : null,
     dataTestId: el.getAttribute('data-testid') || el.getAttribute('data-test-id') || el.getAttribute('data-qa') || null,
-    rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+    rect,
     devicePixelRatio: window.devicePixelRatio,
   };
 }

--- a/src/core/capture/events/handlers.ts
+++ b/src/core/capture/events/handlers.ts
@@ -4,7 +4,7 @@ import { localStorage } from '@/lib/browser-api';
 import { HoverRing } from '@/lib/hover-ring';
 import { sendMessage } from '@/lib/messaging';
 import { extractDOMContext } from '../dom/context';
-import { extractElementMeta } from '../dom/element-meta';
+import { extractElementMeta, freezeRect } from '../dom/element-meta';
 import {
   findFocusableAncestor,
   isMimikElement,
@@ -93,14 +93,17 @@ class CaptureController {
     }
   }
 
-  private async captureAction(action: string, target: HTMLElement, point?: { x: number; y: number }) {
-    const elementMeta = extractElementMeta(target);
-    await sendMessage('captureStep', {
-      guideId: this.guideId,
-      action,
-      elementMeta: point ? { ...elementMeta, clickPoint: point } : elementMeta,
-      domContext: extractDOMContext(target, action),
-    });
+  private capture(action: string, target: HTMLElement, point?: { x: number; y: number }) {
+    const atEvent = freezeRect(target);
+    return async () => {
+      const elementMeta = extractElementMeta(target, atEvent);
+      await sendMessage('captureStep', {
+        guideId: this.guideId,
+        action,
+        elementMeta: point ? { ...elementMeta, clickPoint: point } : elementMeta,
+        domContext: extractDOMContext(target, action),
+      });
+    };
   }
 
   private enqueue(task: () => Promise<unknown>) {
@@ -154,9 +157,10 @@ class CaptureController {
     lastClickTime = now;
 
     if (isTextField(target)) {
+      const atEvent = freezeRect(target);
       this.enqueue(async () => {
         if (this.input.active && this.input.target !== target) await this.input.finalize();
-        if (!this.input.active) await this.input.start(target);
+        if (!this.input.active) await this.input.start(target, atEvent);
       });
       return;
     }
@@ -164,7 +168,7 @@ class CaptureController {
     if (isNavigatingClick(target)) {
       me.preventDefault();
       me.stopImmediatePropagation();
-      this.enqueue(() => this.captureAction('click', target, { x: me.clientX, y: me.clientY }));
+      this.enqueue(this.capture('click', target, { x: me.clientX, y: me.clientY }));
       const anchor = target.closest('a[href]') as HTMLAnchorElement;
       if (anchor) {
         const href = anchor.href;
@@ -177,7 +181,7 @@ class CaptureController {
       return;
     }
 
-    this.enqueue(() => this.captureAction('click', target, { x: me.clientX, y: me.clientY }));
+    this.enqueue(this.capture('click', target, { x: me.clientX, y: me.clientY }));
   }
 
   private onAuxClick(e: Event) {
@@ -185,9 +189,7 @@ class CaptureController {
     if (!raw || !(raw instanceof Element)) return;
     const target = findFocusableAncestor(raw);
     if (isMimikElement(target)) return;
-    this.enqueue(() =>
-      this.captureAction('auxclick', target, { x: (e as MouseEvent).clientX, y: (e as MouseEvent).clientY }),
-    );
+    this.enqueue(this.capture('auxclick', target, { x: (e as MouseEvent).clientX, y: (e as MouseEvent).clientY }));
   }
 
   private onKeydown(e: Event) {
@@ -201,7 +203,7 @@ class CaptureController {
     }
 
     if (isTextField(target)) return;
-    this.enqueue(() => this.captureAction(`keydown:${ke.key}`, target));
+    this.enqueue(this.capture(`keydown:${ke.key}`, target));
   }
 
   private onInput(e: Event) {
@@ -218,7 +220,7 @@ class CaptureController {
       return;
 
     if (target instanceof HTMLSelectElement) {
-      this.enqueue(() => this.captureAction('input', target));
+      this.enqueue(this.capture('input', target));
       return;
     }
 
@@ -248,7 +250,7 @@ class CaptureController {
         ? ((e as ClipboardEvent).target as HTMLElement)
         : document.activeElement;
     if (!target || !(target instanceof HTMLElement) || isMimikElement(target)) return;
-    this.enqueue(() => this.captureAction(e.type, target));
+    this.enqueue(this.capture(e.type, target));
   }
 
   private onPointerDown(e: Event) {
@@ -272,7 +274,7 @@ class CaptureController {
 
     if (dx >= DRAG_MIN_PX || dy >= DRAG_MIN_PX) {
       const target = findFocusableAncestor(this.dragStartElement);
-      if (!isMimikElement(target)) this.enqueue(() => this.captureAction('drag', target));
+      if (!isMimikElement(target)) this.enqueue(this.capture('drag', target));
     }
 
     this.dragStartX = this.dragStartY = null;
@@ -281,7 +283,7 @@ class CaptureController {
 
   private onDragEnd(e: Event) {
     if (!e.target || !(e.target instanceof Element) || isMimikElement(e.target)) return;
-    this.enqueue(() => this.captureAction('drag', findFocusableAncestor(e.target as Element)));
+    this.enqueue(this.capture('drag', findFocusableAncestor(e.target as Element)));
   }
 
   stop() {

--- a/src/core/capture/events/input-session.ts
+++ b/src/core/capture/events/input-session.ts
@@ -1,7 +1,7 @@
 import { logger } from '@/lib/logger';
 import { sendMessage } from '@/lib/messaging';
 import { extractDOMContext } from '../dom/context';
-import { extractElementMeta } from '../dom/element-meta';
+import { extractElementMeta, type FrozenRect, freezeRect } from '../dom/element-meta';
 import { getFieldLabel, getFieldValue } from '../dom/element-utils';
 
 export class InputSession {
@@ -9,6 +9,7 @@ export class InputSession {
   target: HTMLElement | null = null;
 
   private guideId: string;
+  private atEvent: FrozenRect | undefined;
 
   constructor(guideId: string) {
     this.guideId = guideId;
@@ -18,11 +19,12 @@ export class InputSession {
     return this.stepId !== null;
   }
 
-  async start(target: HTMLElement) {
+  async start(target: HTMLElement, atEvent?: FrozenRect) {
+    this.atEvent = atEvent;
     const res = await sendMessage('captureStep', {
       guideId: this.guideId,
       action: 'input',
-      elementMeta: extractElementMeta(target),
+      elementMeta: extractElementMeta(target, atEvent),
       domContext: extractDOMContext(target, 'input'),
     });
     if ('stepId' in res) {
@@ -33,6 +35,7 @@ export class InputSession {
 
   update(target: HTMLElement) {
     if (!this.stepId) return;
+    this.atEvent = freezeRect(target);
     const val = getFieldValue(target);
     const desc = val ? `Type "${val}" in ${getFieldLabel(target)}` : `Clear ${getFieldLabel(target)}`;
     sendMessage('updateInputStep', { stepId: this.stepId, description: desc, inputValue: val || undefined }).catch(
@@ -44,11 +47,13 @@ export class InputSession {
     if (!this.target || !this.stepId) return;
     const target = this.target;
     const stepId = this.stepId;
+    const atEvent = this.atEvent;
     this.stepId = null;
     this.target = null;
+    this.atEvent = undefined;
     await sendMessage('finalizeInputStep', {
       stepId,
-      elementMeta: extractElementMeta(target),
+      elementMeta: extractElementMeta(target, atEvent),
       domContext: extractDOMContext(target, 'input'),
     });
   }

--- a/src/core/export/__tests__/options.test.ts
+++ b/src/core/export/__tests__/options.test.ts
@@ -27,7 +27,19 @@ describe('normaliseExportOptions', () => {
       screenshots: DEFAULT_EXPORT_OPTIONS.screenshots,
       stepUrls: DEFAULT_EXPORT_OPTIONS.stepUrls,
       imageScale: 'small',
+      stepDescriptions: DEFAULT_EXPORT_OPTIONS.stepDescriptions,
+      resolution: DEFAULT_EXPORT_OPTIONS.resolution,
     });
+  });
+
+  it('rejects an unknown resolution so the encoder never gets bogus dimensions', () => {
+    expect(normaliseExportOptions({ resolution: '4k' }).resolution).toBe(DEFAULT_EXPORT_OPTIONS.resolution);
+    expect(normaliseExportOptions({ resolution: '1080p' }).resolution).toBe('1080p');
+  });
+
+  it('keeps step captions on unless they are explicitly turned off', () => {
+    expect(normaliseExportOptions({ stepDescriptions: 'no' }).stepDescriptions).toBe(true);
+    expect(normaliseExportOptions({ stepDescriptions: false }).stepDescriptions).toBe(false);
   });
 
   it('rejects an unknown image scale so no exporter can derive a NaN width', () => {

--- a/src/core/export/__tests__/video-export.test.ts
+++ b/src/core/export/__tests__/video-export.test.ts
@@ -1,21 +1,32 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
 import {
+  cursorProgress,
+  cursorScale,
   easeInOut,
   FPS,
   findIdealZoomLevel,
+  landingFrame,
   letterbox,
+  normalizedTargetCenter,
   overlapFrames,
+  reserveTooltip,
+  ringProgress,
   STEP_SECONDS,
+  sharpZoomCeiling,
   stepFrames,
+  stepKind,
   toFrames,
+  tooltipBand,
   tooltipPlacement,
+  tooltipProgress,
   totalStepFrames,
+  videoChapters,
   wrapLines,
   zoomCrop,
   zoomProgress,
 } from '@/core/export/video-export';
-import { FRAME_HEIGHT, FRAME_WIDTH } from '@/core/export/video-support';
+import { FRAME_HEIGHT, FRAME_WIDTH, RESOLUTION_SPECS } from '@/core/export/video-support';
 
 const measure = (line: string) => line.length * 10;
 
@@ -113,19 +124,19 @@ describe('easeInOut', () => {
 
 describe('findIdealZoomLevel', () => {
   const zoom = (rect: { x: number; y: number; width: number; height: number }) =>
-    findIdealZoomLevel(rect, 1000, 800, FRAME_WIDTH, FRAME_HEIGHT);
+    findIdealZoomLevel(rect, 3000, 2400, FRAME_WIDTH, FRAME_HEIGHT);
 
   it('refuses to zoom when the target already fills the frame', () => {
-    expect(zoom({ x: 0, y: 0, width: 1000, height: 800 })).toBe(1);
+    expect(zoom({ x: 0, y: 0, width: 3000, height: 2400 })).toBe(1);
   });
 
   it('caps at the composition ceiling for a target hugging the bottom-right', () => {
-    expect(zoom({ x: 800, y: 640, width: 20, height: 16 })).toBe(3.5);
+    expect(zoom({ x: 2400, y: 1920, width: 60, height: 48 })).toBe(3.5);
   });
 
   it('zooms further on a small target than on a large one', () => {
-    const small = zoom({ x: 480, y: 380, width: 40, height: 40 });
-    const large = zoom({ x: 300, y: 240, width: 400, height: 320 });
+    const small = zoom({ x: 1440, y: 1140, width: 120, height: 120 });
+    const large = zoom({ x: 900, y: 720, width: 1200, height: 960 });
     expect(small).toBeGreaterThan(large);
     expect(large).toBeGreaterThanOrEqual(1);
     expect(small).toBeLessThanOrEqual(3.5);
@@ -134,14 +145,342 @@ describe('findIdealZoomLevel', () => {
   it('never leaves the one-to-ceiling band', () => {
     for (const rect of [
       { x: 0, y: 0, width: 1, height: 1 },
-      { x: 999, y: 799, width: 1, height: 1 },
-      { x: 0, y: 0, width: 5000, height: 5000 },
-      { x: 1000, y: 800, width: 10, height: 10 },
+      { x: 2999, y: 2399, width: 1, height: 1 },
+      { x: 0, y: 0, width: 15000, height: 15000 },
+      { x: 3000, y: 2400, width: 30, height: 30 },
     ]) {
       const level = zoom(rect);
       expect(level).toBeGreaterThanOrEqual(1);
       expect(level).toBeLessThanOrEqual(3.5);
     }
+  });
+
+  it('will not magnify a small capture past the upscale allowance', () => {
+    const pinpoint = { x: 640, y: 360, width: 8, height: 8 };
+    expect(findIdealZoomLevel(pinpoint, 1280, 720, FRAME_WIDTH, FRAME_HEIGHT)).toBe(1.5);
+    expect(findIdealZoomLevel(pinpoint, 2560, 1440, FRAME_WIDTH, FRAME_HEIGHT)).toBe(3);
+  });
+});
+
+describe('sharpZoomCeiling', () => {
+  it('allows a fixed upscale beyond one-to-one', () => {
+    expect(sharpZoomCeiling(1280)).toBe(1.5);
+    expect(sharpZoomCeiling(2560)).toBe(3);
+  });
+
+  it('never drops below one, however small the capture', () => {
+    expect(sharpZoomCeiling(320)).toBe(1);
+    expect(sharpZoomCeiling(1)).toBe(1);
+  });
+
+  it('still respects the composition ceiling on a huge capture', () => {
+    expect(sharpZoomCeiling(6000)).toBe(3.5);
+    expect(sharpZoomCeiling(20000)).toBe(3.5);
+  });
+
+  it('falls back to the composition ceiling for a degenerate size', () => {
+    expect(sharpZoomCeiling(0)).toBe(3.5);
+    expect(sharpZoomCeiling(Number.NaN)).toBe(3.5);
+  });
+});
+
+describe('reveal beats', () => {
+  const land = landingFrame();
+
+  it('lands the camera on frame 67', () => {
+    expect(land).toBe(67);
+  });
+
+  it('shows nothing but the page while the camera is still moving', () => {
+    for (let frame = 0; frame <= land; frame++) {
+      expect(ringProgress(frame)).toBe(0);
+      expect(tooltipProgress(frame)).toBe(0);
+    }
+  });
+
+  it('pops the ring after the camera lands, then settles', () => {
+    expect(ringProgress(land + 4)).toBe(0);
+    expect(ringProgress(land + 7)).toBeGreaterThan(0);
+    expect(ringProgress(land + 11)).toBe(1);
+  });
+
+  it('brings the tooltip in only once the ring is fully on', () => {
+    const ringDone = Array.from({ length: stepFrames() }, (_, f) => f).find((f) => ringProgress(f) === 1) as number;
+    const tipStart = Array.from({ length: stepFrames() }, (_, f) => f).find((f) => tooltipProgress(f) > 0) as number;
+    expect(tipStart).toBeGreaterThanOrEqual(ringDone);
+  });
+
+  it('holds ring and tooltip on for the rest of the step', () => {
+    for (let frame = 90; frame < stepFrames(); frame++) {
+      expect(ringProgress(frame)).toBe(1);
+      expect(tooltipProgress(frame)).toBe(1);
+    }
+  });
+
+  it('rises monotonically', () => {
+    let ring = -1;
+    let tip = -1;
+    let cursor = -1;
+    for (let frame = 0; frame <= stepFrames(); frame++) {
+      expect(ringProgress(frame)).toBeGreaterThanOrEqual(ring);
+      expect(tooltipProgress(frame)).toBeGreaterThanOrEqual(tip);
+      expect(cursorProgress(frame)).toBeGreaterThanOrEqual(cursor);
+      ring = ringProgress(frame);
+      tip = tooltipProgress(frame);
+      cursor = cursorProgress(frame);
+    }
+  });
+});
+
+describe('cursorProgress', () => {
+  it('waits before setting off', () => {
+    expect(cursorProgress(0)).toBe(0);
+    expect(cursorProgress(11)).toBe(0);
+  });
+
+  it('arrives exactly as the camera lands', () => {
+    expect(cursorProgress(landingFrame())).toBe(1);
+    expect(cursorProgress(landingFrame() - 1)).toBeLessThan(1);
+  });
+
+  it('is halfway across at the midpoint of its travel', () => {
+    expect(cursorProgress(39)).toBeCloseTo(0.5, 2);
+  });
+
+  it('stays parked on the target through the close hold', () => {
+    for (let frame = landingFrame(); frame < stepFrames(); frame++) {
+      expect(cursorProgress(frame)).toBe(1);
+    }
+  });
+});
+
+describe('reserveTooltip', () => {
+  const image = { width: 3000, height: 2000 };
+  const band = tooltipBand({ height: 66 });
+  const reserve = (target: { x: number; y: number; width: number; height: number }) =>
+    reserveTooltip(target, band, image, FRAME_HEIGHT);
+
+  it('counts the gap and the frame padding into the reserved band', () => {
+    expect(band).toBe(66 + 14 + 20);
+  });
+
+  it('grows downwards for a target in the upper half', () => {
+    const target = { x: 1400, y: 300, width: 120, height: 40 };
+    const reserved = reserve(target);
+    expect(reserved.y).toBe(target.y);
+    expect(reserved.height).toBeGreaterThan(target.height);
+  });
+
+  it('grows upwards for a target in the lower half', () => {
+    const target = { x: 1400, y: 1600, width: 120, height: 40 };
+    const reserved = reserve(target);
+    expect(reserved.y).toBeLessThan(target.y);
+    expect(reserved.y + reserved.height).toBeCloseTo(target.y + target.height, 6);
+  });
+
+  it('leaves the horizontal extent alone', () => {
+    const reserved = reserve({ x: 1400, y: 300, width: 120, height: 40 });
+    expect(reserved.x).toBe(1400);
+    expect(reserved.width).toBe(120);
+  });
+
+  it('pulls the camera back so the tooltip has somewhere to sit', () => {
+    const target = { x: 1400, y: 300, width: 120, height: 40 };
+    const zoomOf = (r: typeof target) => findIdealZoomLevel(r, image.width, image.height, FRAME_WIDTH, FRAME_HEIGHT);
+    expect(zoomOf(reserve(target))).toBeLessThan(zoomOf(target));
+  });
+
+  it('never reserves outside the image', () => {
+    for (const target of [
+      { x: 0, y: 0, width: 90, height: 60 },
+      { x: 2910, y: 1940, width: 90, height: 60 },
+      { x: 1400, y: 990, width: 120, height: 20 },
+    ]) {
+      const reserved = reserve(target);
+      expect(reserved.y).toBeGreaterThanOrEqual(0);
+      expect(reserved.y + reserved.height).toBeLessThanOrEqual(image.height);
+      expect(reserved.height).toBeGreaterThanOrEqual(target.height);
+    }
+  });
+
+  it('returns the bare target when there is nothing to reserve', () => {
+    const target = { x: 1400, y: 300, width: 120, height: 40 };
+    expect(reserveTooltip(target, 0, image, FRAME_HEIGHT)).toEqual(target);
+    expect(reserveTooltip(target, band, image, 0)).toEqual(target);
+  });
+});
+
+describe('resolution specs', () => {
+  it('offers a codec level that actually covers each frame size', () => {
+    expect(RESOLUTION_SPECS['720p']).toMatchObject({ width: 1280, height: 720, avc: 'avc1.64001f' });
+    expect(RESOLUTION_SPECS['1080p']).toMatchObject({ width: 1920, height: 1080, avc: 'avc1.640028' });
+  });
+
+  it('keeps every frame size on the sixteen-by-nine composition', () => {
+    for (const spec of Object.values(RESOLUTION_SPECS)) {
+      expect(spec.width / spec.height).toBeCloseTo(FRAME_WIDTH / FRAME_HEIGHT, 6);
+    }
+  });
+
+  it('demands more source pixels before zooming at the larger frame size', () => {
+    expect(sharpZoomCeiling(3024, RESOLUTION_SPECS['1080p'].width)).toBeLessThan(
+      sharpZoomCeiling(3024, RESOLUTION_SPECS['720p'].width),
+    );
+  });
+});
+
+describe('videoChapters', () => {
+  const steps = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({ id: `s${i}`, description: `Do thing ${i}`, action: 'click' })) as never[];
+  const stride = (157 - 10) / 30;
+
+  it('has nothing to mark for a guide with no frames', () => {
+    expect(videoChapters([], true)).toEqual([]);
+  });
+
+  it('starts the first step at zero when there is no cover', () => {
+    expect(videoChapters(steps(3), false)[0].start).toBe(0);
+  });
+
+  it('pushes every step past the cover when there is one', () => {
+    const marks = videoChapters(steps(3), true);
+    expect(marks[0].start).toBe(3);
+    expect(marks[1].start).toBeCloseTo(3 + stride, 6);
+  });
+
+  it('spaces steps by one stride, not one full step', () => {
+    const marks = videoChapters(steps(4), false);
+    for (let i = 1; i < marks.length; i++) {
+      expect(marks[i].start - marks[i - 1].start).toBeCloseTo(stride, 6);
+    }
+  });
+
+  it('runs the last chapter to the true end of the footage', () => {
+    const marks = videoChapters(steps(6), true);
+    expect(marks[5].end).toBeCloseTo(3 + totalStepFrames(6) / FPS, 6);
+    expect(marks[5].end).toBeGreaterThan(marks[5].start);
+  });
+
+  it('leaves no gap or overlap between consecutive chapters', () => {
+    const marks = videoChapters(steps(5), true);
+    for (let i = 1; i < marks.length; i++) {
+      expect(marks[i].start).toBeCloseTo(marks[i - 1].end, 6);
+    }
+  });
+
+  it('carries the step description as the chapter title', () => {
+    expect(videoChapters(steps(2), false)[1].title).toBe('Do thing 1');
+  });
+
+  it('falls back to a numbered label when a step has no description', () => {
+    const bare = [{ id: 'a', description: '   ', action: 'click' }] as never[];
+    expect(videoChapters(bare, false)[0].title).toBe('export.stepLabel[1]');
+  });
+
+  it('carries the action kind through to each chapter', () => {
+    const mixed = [
+      { id: 'a', description: 'Click save', action: 'click' },
+      { id: 'b', description: 'Type a name', action: 'input' },
+      { id: 'c', description: 'Press Enter', action: 'keydown:Enter' },
+      { id: 'd', description: 'Open the page', action: 'navigate' },
+    ] as never[];
+    expect(videoChapters(mixed, false).map((c) => c.kind)).toEqual(['click', 'type', 'key', 'navigate']);
+  });
+});
+
+describe('stepKind', () => {
+  const step = (over: Record<string, unknown>) => over as unknown as Parameters<typeof stepKind>[0];
+
+  it('reads typing apart from clicking', () => {
+    expect(stepKind(step({ action: 'input' }))).toBe('type');
+    expect(stepKind(step({ action: 'click' }))).toBe('click');
+  });
+
+  it('recognises any key press', () => {
+    expect(stepKind(step({ action: 'keydown:Enter' }))).toBe('key');
+    expect(stepKind(step({ action: 'keydown:Tab' }))).toBe('key');
+  });
+
+  it('marks navigation, which has no target to point at', () => {
+    expect(stepKind(step({ action: 'navigate' }))).toBe('navigate');
+  });
+
+  it('treats an authored block as a note rather than an action', () => {
+    expect(stepKind(step({ blockType: 'callout', action: '' }))).toBe('note');
+    expect(stepKind(step({ blockType: 'heading', action: '' }))).toBe('note');
+  });
+
+  it('folds the remaining pointer actions in with clicks', () => {
+    for (const action of ['auxclick', 'copy', 'paste', 'cut', 'drag', '']) {
+      expect(stepKind(step({ action }))).toBe('click');
+    }
+  });
+});
+
+describe('cursorScale', () => {
+  const capture = 1700;
+  const wide = FRAME_WIDTH / 3024;
+  const close = FRAME_WIDTH / (3024 / 2.4);
+
+  it('shrinks the pointer on the wide shot and grows it as the camera closes in', () => {
+    expect(cursorScale(capture, wide)).toBeLessThan(cursorScale(capture, close));
+  });
+
+  it('keeps the pointer legible at the widest framing', () => {
+    expect(cursorScale(capture, wide)).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it('never lets the pointer swell past the ceiling', () => {
+    expect(cursorScale(capture, 12)).toBe(2.6);
+    expect(cursorScale(9000, close)).toBe(2.6);
+  });
+
+  it('tracks the camera proportionally between the two limits', () => {
+    const mid = cursorScale(capture, 0.7);
+    expect(mid).toBeCloseTo((capture * 0.026 * 0.7) / 23, 6);
+    expect(mid).toBeGreaterThan(0.9);
+    expect(mid).toBeLessThan(2.6);
+  });
+
+  it('falls back to the floor for a degenerate camera', () => {
+    expect(cursorScale(0, close)).toBe(0.9);
+    expect(cursorScale(capture, 0)).toBe(0.9);
+  });
+});
+
+describe('normalizedTargetCenter', () => {
+  const shot = (over: Record<string, unknown> = {}) =>
+    ({
+      id: 's',
+      stepId: 'p',
+      guideId: 'g',
+      blob: new Blob(),
+      mimeType: 'image/webp',
+      width: 2000,
+      height: 1000,
+      pixelRatio: 2,
+      bounds: { x: 100, y: 200, width: 50, height: 20 },
+      createdAt: 0,
+      ...over,
+    }) as unknown as Parameters<typeof normalizedTargetCenter>[0];
+
+  it('reports the target centre as a fraction of the full capture', () => {
+    expect(normalizedTargetCenter(shot())).toEqual({ x: 0.125, y: 0.42 });
+  });
+
+  it('measures against a deliberate crop when the step has one', () => {
+    const at = normalizedTargetCenter(shot({ edits: { viewport: { x: 200, y: 400, width: 200, height: 100 } } }));
+    expect(at).toEqual({ x: 0.25, y: 0.2 });
+  });
+
+  it('has no origin to offer when the step has no target', () => {
+    expect(normalizedTargetCenter(shot({ bounds: undefined }))).toBeNull();
+  });
+
+  it('stays inside the frame for a target sitting outside the crop', () => {
+    const at = normalizedTargetCenter(shot({ edits: { viewport: { x: 1000, y: 600, width: 400, height: 200 } } }));
+    expect(at?.x).toBe(0);
+    expect(at?.y).toBe(0);
   });
 });
 

--- a/src/core/export/options.ts
+++ b/src/core/export/options.ts
@@ -8,11 +8,17 @@ export const IMAGE_SCALE_FACTORS: Record<ImageScale, number> = {
   large: 1,
 };
 
+export type VideoResolution = '720p' | '1080p';
+
+export const VIDEO_RESOLUTIONS: VideoResolution[] = ['720p', '1080p'];
+
 export interface ExportOptions {
   cover: boolean;
   screenshots: boolean;
   stepUrls: boolean;
   imageScale: ImageScale;
+  stepDescriptions: boolean;
+  resolution: VideoResolution;
 }
 
 export const DEFAULT_EXPORT_OPTIONS: ExportOptions = {
@@ -20,6 +26,8 @@ export const DEFAULT_EXPORT_OPTIONS: ExportOptions = {
   screenshots: true,
   stepUrls: true,
   imageScale: 'medium',
+  stepDescriptions: true,
+  resolution: '720p',
 };
 
 const bool = (value: unknown, fallback: boolean) => (typeof value === 'boolean' ? value : fallback);
@@ -33,6 +41,10 @@ export function normaliseExportOptions(value: unknown): ExportOptions {
     stepUrls: bool(raw.stepUrls, DEFAULT_EXPORT_OPTIONS.stepUrls),
     imageScale:
       raw.imageScale && raw.imageScale in IMAGE_SCALE_FACTORS ? raw.imageScale : DEFAULT_EXPORT_OPTIONS.imageScale,
+    stepDescriptions: bool(raw.stepDescriptions, DEFAULT_EXPORT_OPTIONS.stepDescriptions),
+    resolution: VIDEO_RESOLUTIONS.includes(raw.resolution as VideoResolution)
+      ? (raw.resolution as VideoResolution)
+      : DEFAULT_EXPORT_OPTIONS.resolution,
   };
 }
 

--- a/src/core/export/video-export.ts
+++ b/src/core/export/video-export.ts
@@ -9,6 +9,7 @@ import {
   FRAME_HEIGHT,
   FRAME_WIDTH,
   pickContainer,
+  RESOLUTION_SPECS,
   STEP_SECONDS,
   STEP_ZOOM_TRANSITION_SEC,
   STEP_ZOOMED_OUT_SEC,
@@ -16,8 +17,8 @@ import {
 import { actionSteps, calloutAccent, isBlock } from '@/core/guides/blocks';
 import type { BlockType, Guide, Screenshot, Step } from '@/core/guides/types';
 import type { Ctx } from '@/core/screenshot/draw';
-import { drawRoundedRect } from '@/core/screenshot/draw';
-import { clamp, resolveTarget, resolveViewport } from '@/core/screenshot/geometry';
+import { drawRoundedRect, TARGET_RADIUS, TARGET_STROKE } from '@/core/screenshot/draw';
+import { clamp, resolveFrameViewport, resolveTarget } from '@/core/screenshot/geometry';
 import { renderScreenshot } from '@/core/screenshot/render';
 
 const TRANSITION_DURATION_SEC = 0.33;
@@ -27,6 +28,8 @@ const KEY_FRAME_INTERVAL_SEC = 2;
 const ZOOM_MIN = 1;
 const ZOOM_MAX = 3.5;
 const ZOOM_PAD_RATIO = 0.15;
+const MAX_UPSCALE = 1.5;
+const RESERVE_PASSES = 3;
 
 const BACKDROP = '#1E1B4B';
 const MUTED = '#9CA3AF';
@@ -42,6 +45,22 @@ const TOOLTIP_GAP = 14;
 const TOOLTIP_MAX_LINES = 3;
 const TOOLTIP_MAX_WIDTH_RATIO = 0.45;
 const FRAME_PADDING = 20;
+
+const RING_DELAY_SEC = 0.12;
+const RING_POP_SEC = 0.22;
+const RING_OVERSHOOT = 0.16;
+const RING_PAD = 7;
+const TOOLTIP_DELAY_SEC = 0.37;
+const TOOLTIP_FADE_SEC = 0.28;
+const TOOLTIP_RISE = 8;
+
+const CURSOR_START_SEC = 0.35;
+const CURSOR_HEIGHT = 23;
+const CURSOR_PAGE_RATIO = 0.026;
+const CURSOR_MIN_SCALE = 0.9;
+const CURSOR_MAX_SCALE = 2.6;
+const CURSOR_PRESS_SEC = 0.16;
+const CURSOR_PRESS_SCALE = 0.86;
 
 const COVER_MARGIN = 96;
 const COVER_CELL_WIDTH = 300;
@@ -89,6 +108,34 @@ export function zoomProgress(frame: number, fps = FPS): number {
   return (frame - held) / moving;
 }
 
+export function landingFrame(fps = FPS): number {
+  return toFrames(STEP_ZOOMED_OUT_SEC + STEP_ZOOM_TRANSITION_SEC, fps);
+}
+
+function fadeAt(frame: number, startSec: number, spanSec: number, fps: number): number {
+  const start = landingFrame(fps) + toFrames(startSec, fps);
+  const span = toFrames(spanSec, fps);
+  if (frame < start) return 0;
+  if (span <= 0 || frame >= start + span) return 1;
+  return (frame - start) / span;
+}
+
+export function ringProgress(frame: number, fps = FPS): number {
+  return fadeAt(frame, RING_DELAY_SEC, RING_POP_SEC, fps);
+}
+
+export function tooltipProgress(frame: number, fps = FPS): number {
+  return fadeAt(frame, TOOLTIP_DELAY_SEC, TOOLTIP_FADE_SEC, fps);
+}
+
+export function cursorProgress(frame: number, fps = FPS): number {
+  const start = toFrames(CURSOR_START_SEC, fps);
+  const land = landingFrame(fps);
+  if (frame <= start) return 0;
+  if (frame >= land) return 1;
+  return (frame - start) / (land - start);
+}
+
 export function easeInOut(t: number): number {
   const x = clamp(t, 0, 1);
   return x < 0.5 ? 4 * x ** 3 : 1 - (-2 * x + 2) ** 3 / 2;
@@ -118,7 +165,12 @@ export function findIdealZoomLevel(
   const needWidth = Math.min(target.width / imgWidth + 2 * ZOOM_PAD_RATIO, 1 - nx) * viewWidth;
   const needHeight = Math.min(target.height / imgHeight + 2 * ZOOM_PAD_RATIO, 1 - ny) * viewHeight;
   const zoom = Math.min(viewWidth / needWidth, viewHeight / needHeight);
-  return Number.isFinite(zoom) ? clamp(zoom, ZOOM_MIN, ZOOM_MAX) : ZOOM_MIN;
+  return Number.isFinite(zoom) ? clamp(zoom, ZOOM_MIN, sharpZoomCeiling(imgWidth, viewWidth)) : ZOOM_MIN;
+}
+
+export function sharpZoomCeiling(imgWidth: number, viewWidth = FRAME_WIDTH): number {
+  if (!(imgWidth > 0) || !(viewWidth > 0)) return ZOOM_MAX;
+  return clamp((imgWidth * MAX_UPSCALE) / viewWidth, ZOOM_MIN, ZOOM_MAX);
 }
 
 export function zoomCrop(
@@ -192,6 +244,34 @@ export function wrapLines(
   return lines;
 }
 
+export function tooltipBand(box: { height: number }): number {
+  return box.height + TOOLTIP_GAP + FRAME_PADDING;
+}
+
+export function reserveTooltip(
+  target: Rect,
+  band: number,
+  image: Size,
+  fitHeight: number,
+  viewWidth = FRAME_WIDTH,
+  viewHeight = FRAME_HEIGHT,
+): Rect {
+  if (band <= 0 || fitHeight <= 0) return target;
+
+  const below = target.y + target.height / 2 < image.height / 2;
+  let rect = target;
+
+  for (let pass = 0; pass < RESERVE_PASSES; pass++) {
+    const zoom = findIdealZoomLevel(rect, image.width, image.height, viewWidth, viewHeight);
+    const reserve = (band * image.height) / (zoom * fitHeight);
+    const top = clamp(below ? target.y : target.y - reserve, 0, image.height);
+    const bottom = clamp((below ? target.y + reserve : target.y) + target.height, top, image.height);
+    rect = { x: target.x, y: top, width: target.width, height: bottom - top };
+  }
+
+  return rect;
+}
+
 export function tooltipPlacement(
   target: Rect,
   tooltip: { width: number; height: number },
@@ -214,25 +294,42 @@ function logoBitmap(logo: NonNullable<Branding['logo']>): Promise<ImageBitmap> {
   return createImageBitmap(new Blob([bytes as BlobPart]));
 }
 
-function drawTooltip(ctx: Ctx, text: string, target: Rect) {
+interface TooltipBox {
+  lines: string[];
+  width: number;
+  height: number;
+}
+
+function measureTooltip(ctx: Ctx, text: string): TooltipBox | null {
   ctx.font = `500 ${TOOLTIP_FONT_SIZE}px Poppins, sans-serif`;
   const lines = wrapLines(text, FRAME_WIDTH * TOOLTIP_MAX_WIDTH_RATIO, (line) => ctx.measureText(line).width);
-  if (lines.length === 0) return;
+  if (lines.length === 0) return null;
 
   const textWidth = Math.max(...lines.map((line) => ctx.measureText(line).width));
-  const width = textWidth + TOOLTIP_PADDING_X * 2;
-  const height = lines.length * TOOLTIP_LINE_HEIGHT + TOOLTIP_PADDING_Y * 2;
-  const at = tooltipPlacement(target, { width, height });
+  return {
+    lines,
+    width: textWidth + TOOLTIP_PADDING_X * 2,
+    height: lines.length * TOOLTIP_LINE_HEIGHT + TOOLTIP_PADDING_Y * 2,
+  };
+}
+
+function drawTooltip(ctx: Ctx, box: TooltipBox, target: Rect) {
+  const at = tooltipPlacement(target, box);
 
   ctx.fillStyle = TOOLTIP_BG;
-  drawRoundedRect(ctx, at.x, at.y, width, height, TOOLTIP_RADIUS);
+  drawRoundedRect(ctx, at.x, at.y, box.width, box.height, TOOLTIP_RADIUS);
   ctx.fill();
 
   ctx.fillStyle = ON_DARK;
   ctx.textBaseline = 'top';
-  lines.forEach((line, i) => {
+  box.lines.forEach((line, i) => {
     ctx.fillText(line, at.x + TOOLTIP_PADDING_X, at.y + TOOLTIP_PADDING_Y + i * TOOLTIP_LINE_HEIGHT);
   });
+}
+
+interface Point {
+  x: number;
+  y: number;
 }
 
 interface ScreenshotLayer {
@@ -240,6 +337,8 @@ interface ScreenshotLayer {
   bitmap: ImageBitmap;
   fit: ReturnType<typeof letterbox>;
   target: Rect | null;
+  ring: { color: string; dashed: boolean } | null;
+  from: Point | null;
   description: string;
 }
 
@@ -279,7 +378,10 @@ async function blurBackdrop(screenshot: Screenshot): Promise<Pick<BlockLayer, 'b
   const ctx = canvas.getContext('2d');
   if (!ctx) throw new Error('Canvas 2D context unavailable');
 
-  const rendered = await renderScreenshot(screenshot, RENDER_OPTIONS);
+  const rendered = await renderScreenshot(screenshot, {
+    ...RENDER_OPTIONS,
+    viewport: resolveFrameViewport(screenshot),
+  });
   const source = await createImageBitmap(rendered);
   const blurred = supportsCanvasFilter();
   const at = coverFit(source, blurred ? BLOCK_OVERSCAN : 1);
@@ -302,10 +404,21 @@ async function loadBlockLayer(step: Step, behind: Screenshot | undefined): Promi
   };
 }
 
-async function loadScreenshotLayer(step: Step, screenshot: Screenshot): Promise<ScreenshotLayer> {
-  const rendered = await renderScreenshot(screenshot, RENDER_OPTIONS);
+export function normalizedTargetCenter(screenshot: Screenshot): Point | null {
+  const target = resolveTarget(screenshot);
+  if (!target) return null;
+  const viewport = resolveFrameViewport(screenshot);
+  if (!(viewport.width > 0) || !(viewport.height > 0)) return null;
+  return {
+    x: clamp((target.x + target.width / 2 - viewport.x) / viewport.width, 0, 1),
+    y: clamp((target.y + target.height / 2 - viewport.y) / viewport.height, 0, 1),
+  };
+}
+
+async function loadScreenshotLayer(step: Step, screenshot: Screenshot, from: Point | null): Promise<ScreenshotLayer> {
+  const viewport = resolveFrameViewport(screenshot);
+  const rendered = await renderScreenshot(screenshot, { ...RENDER_OPTIONS, viewport, target: false });
   const bitmap = await createImageBitmap(rendered);
-  const viewport = resolveViewport(screenshot);
   const target = resolveTarget(screenshot);
   const sx = bitmap.width / viewport.width;
   const sy = bitmap.height / viewport.height;
@@ -322,6 +435,8 @@ async function loadScreenshotLayer(step: Step, screenshot: Screenshot): Promise<
           height: target.height * sy,
         }
       : null,
+    ring: target ? { color: target.color, dashed: target.border === 'dashed' } : null,
+    from: from ? { x: from.x * bitmap.width, y: from.y * bitmap.height } : null,
     description: step.description,
   };
 }
@@ -378,32 +493,98 @@ function drawBlockFrame(ctx: Ctx, layer: BlockLayer) {
   ctx.restore();
 }
 
-function drawStepFrame(ctx: Ctx, layer: StepLayer, frame: number) {
+function drawRing(ctx: Ctx, at: Rect, ring: NonNullable<ScreenshotLayer['ring']>, progress: number) {
+  const pad = RING_PAD * (1 + RING_OVERSHOOT * (1 - progress) ** 2);
+  ctx.save();
+  ctx.globalAlpha *= progress;
+  ctx.strokeStyle = ring.color;
+  ctx.lineWidth = TARGET_STROKE;
+  if (ring.dashed) ctx.setLineDash([8, 5]);
+  drawRoundedRect(ctx, at.x - pad, at.y - pad, at.width + pad * 2, at.height + pad * 2, TARGET_RADIUS);
+  ctx.stroke();
+  ctx.restore();
+}
+
+export function cursorScale(imageHeight: number, cameraScale: number): number {
+  if (!(imageHeight > 0) || !(cameraScale > 0)) return CURSOR_MIN_SCALE;
+  const onPage = (imageHeight * CURSOR_PAGE_RATIO) / CURSOR_HEIGHT;
+  return clamp(onPage * cameraScale, CURSOR_MIN_SCALE, CURSOR_MAX_SCALE);
+}
+
+function drawCursor(ctx: Ctx, x: number, y: number, scale: number) {
+  ctx.save();
+  ctx.translate(x, y);
+  ctx.scale(scale, scale);
+  ctx.beginPath();
+  ctx.moveTo(0, 0);
+  ctx.lineTo(0, 20);
+  ctx.lineTo(5.2, 15.2);
+  ctx.lineTo(8.6, 23);
+  ctx.lineTo(12.2, 21.4);
+  ctx.lineTo(8.8, 13.8);
+  ctx.lineTo(15.6, 13.2);
+  ctx.closePath();
+  ctx.fillStyle = ON_DARK;
+  ctx.strokeStyle = BACKDROP;
+  ctx.lineWidth = 1.6;
+  ctx.lineJoin = 'round';
+  ctx.fill();
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawStepFrame(ctx: Ctx, layer: StepLayer, frame: number, device: Size) {
   if (layer.kind === 'block') {
     drawBlockFrame(ctx, layer);
     return;
   }
 
-  const crop = zoomCrop(layer.bitmap, layer.target, easeInOut(zoomProgress(frame)));
   const { fit } = layer;
+  const box = layer.description ? measureTooltip(ctx, layer.description) : null;
+  const framed =
+    box && layer.target
+      ? reserveTooltip(layer.target, tooltipBand(box), layer.bitmap, fit.height, device.width, device.height)
+      : layer.target;
+
+  const crop = zoomCrop(layer.bitmap, framed, easeInOut(zoomProgress(frame)), device.width, device.height);
   ctx.drawImage(layer.bitmap, crop.x, crop.y, crop.width, crop.height, fit.x, fit.y, fit.width, fit.height);
 
-  if (!layer.description) return;
-
   const scale = fit.width / crop.width;
+  const project = (x: number, y: number) => ({ x: fit.x + (x - crop.x) * scale, y: fit.y + (y - crop.y) * scale });
+
   const anchor: Rect = layer.target
     ? {
-        x: fit.x + (layer.target.x - crop.x) * scale,
-        y: fit.y + (layer.target.y - crop.y) * scale,
+        ...project(layer.target.x, layer.target.y),
         width: layer.target.width * scale,
         height: layer.target.height * scale,
       }
     : { x: FRAME_WIDTH / 2, y: FRAME_HEIGHT, width: 0, height: 0 };
 
-  drawTooltip(ctx, layer.description, anchor);
+  const ringIn = ringProgress(frame);
+  if (layer.target && layer.ring && ringIn > 0) drawRing(ctx, anchor, layer.ring, ringIn);
+
+  const tipIn = tooltipProgress(frame);
+  if (box && tipIn > 0) {
+    ctx.save();
+    ctx.globalAlpha *= tipIn;
+    ctx.translate(0, (1 - tipIn) * -TOOLTIP_RISE);
+    drawTooltip(ctx, box, anchor);
+    ctx.restore();
+  }
+
+  if (layer.target && layer.from) {
+    const travel = easeInOut(cursorProgress(frame));
+    const tip = project(
+      layer.from.x + (layer.target.x + layer.target.width * 0.42 - layer.from.x) * travel,
+      layer.from.y + (layer.target.y + layer.target.height * 0.55 - layer.from.y) * travel,
+    );
+    const pressed = ringIn > 0 && frame < landingFrame() + toFrames(RING_DELAY_SEC + CURSOR_PRESS_SEC);
+    const size = cursorScale(layer.bitmap.height, scale) * (pressed ? CURSOR_PRESS_SCALE : 1);
+    drawCursor(ctx, tip.x, tip.y, size);
+  }
 }
 
-async function drawCoverFrame(ctx: Ctx, guide: Guide, steps: Step[], brand: Branding) {
+async function drawCardFrame(ctx: Ctx, guide: Guide, steps: Step[], brand: Branding, label: string) {
   ctx.fillStyle = BACKDROP;
   ctx.fillRect(0, 0, FRAME_WIDTH, FRAME_HEIGHT);
   ctx.textBaseline = 'top';
@@ -411,7 +592,7 @@ async function drawCoverFrame(ctx: Ctx, guide: Guide, steps: Step[], brand: Bran
   let y = 150;
   ctx.fillStyle = MUTED;
   ctx.font = '700 14px Poppins, sans-serif';
-  ctx.fillText(i18n.t('export.guideLabel').toUpperCase(), COVER_MARGIN, y);
+  ctx.fillText(label.toUpperCase(), COVER_MARGIN, y);
   y += 34;
 
   ctx.fillStyle = ON_DARK;
@@ -463,16 +644,51 @@ async function drawCoverFrame(ctx: Ctx, guide: Guide, steps: Step[], brand: Bran
   }
 }
 
-export type VideoOptions = Pick<ExportOptions, 'cover'>;
+export type VideoOptions = Pick<ExportOptions, 'cover' | 'stepDescriptions' | 'resolution'>;
 
 export interface VideoExportControls {
   onProgress?: (done: number, total: number) => void;
   signal?: AbortSignal;
 }
 
+export type StepKind = 'click' | 'type' | 'key' | 'navigate' | 'note';
+
+export interface VideoChapter {
+  stepId: string;
+  title: string;
+  kind: StepKind;
+  start: number;
+  end: number;
+}
+
+export function stepKind(step: Step): StepKind {
+  if (isBlock(step)) return 'note';
+  const action = step.action ?? '';
+  if (action.startsWith('keydown:')) return 'key';
+  if (action === 'input') return 'type';
+  if (action === 'navigate') return 'navigate';
+  return 'click';
+}
+
 export interface VideoExportResult {
   blob: Blob;
   extension: string;
+  chapters: VideoChapter[];
+}
+
+export function videoChapters(frames: Step[], cover: boolean, fps = FPS): VideoChapter[] {
+  if (frames.length === 0) return [];
+  const offset = cover ? COVER_SECONDS : 0;
+  const stride = (stepFrames(fps) - overlapFrames(fps)) / fps;
+  const last = offset + totalStepFrames(frames.length, fps) / fps;
+
+  return frames.map((step, index) => ({
+    stepId: step.id,
+    title: step.description?.trim() || i18n.t('export.stepLabel', [String(index + 1)]),
+    kind: stepKind(step),
+    start: offset + index * stride,
+    end: index === frames.length - 1 ? last : offset + (index + 1) * stride,
+  }));
 }
 
 export async function exportGuideAsVideo(
@@ -489,20 +705,26 @@ export async function exportGuideAsVideo(
     'mediabunny'
   );
 
-  const container = await pickContainer();
-  if (!container) throw new Error('This browser cannot encode video');
-  const mp4 = container === 'mp4';
-
   const [brand, options] = await Promise.all([
     loadBranding(),
     exportOptions ? Promise.resolve(exportOptions) : loadExportOptions(),
   ]);
 
+  const requested = RESOLUTION_SPECS[options.resolution] ? options.resolution : '720p';
+  const preferred = await pickContainer(requested);
+  const resolution = preferred ? requested : '720p';
+  const container = preferred ?? (await pickContainer('720p'));
+  if (!container) throw new Error('This browser cannot encode video');
+  const mp4 = container === 'mp4';
+  const spec = RESOLUTION_SPECS[resolution];
+
   const canvas = document.createElement('canvas');
-  canvas.width = FRAME_WIDTH;
-  canvas.height = FRAME_HEIGHT;
+  canvas.width = spec.width;
+  canvas.height = spec.height;
   const ctx = canvas.getContext('2d');
   if (!ctx) throw new Error('Canvas 2D context unavailable');
+  ctx.scale(spec.width / FRAME_WIDTH, spec.height / FRAME_HEIGHT);
+  const device = { width: spec.width, height: spec.height };
 
   const output = new Output({
     format: mp4 ? new Mp4OutputFormat() : new WebMOutputFormat(),
@@ -520,7 +742,7 @@ export async function exportGuideAsVideo(
   const overlap = overlapFrames();
   const stride = span - overlap;
   const stepTotal = totalStepFrames(frames.length);
-  const total = stepTotal + (options.cover ? 1 : 0);
+  const total = stepTotal + (options.cover ? 2 : 0);
   const loaded = new Map<number, StepLayer>();
   const { onProgress, signal } = controls;
   let done = 0;
@@ -533,13 +755,22 @@ export async function exportGuideAsVideo(
     return undefined;
   };
 
+  const cursorOriginFor = (index: number) => {
+    for (let i = index - 1; i >= 0; i--) {
+      const behind = screenshots.get(frames[i].id);
+      if (behind) return normalizedTargetCenter(behind);
+    }
+    return null;
+  };
+
   const layerAt = async (index: number) => {
     const cached = loaded.get(index);
     if (cached) return cached;
     const step = frames[index];
     const layer = isBlock(step)
       ? await loadBlockLayer(step, backdropFor(index))
-      : await loadScreenshotLayer(step, screenshots.get(step.id) as Screenshot);
+      : await loadScreenshotLayer(step, screenshots.get(step.id) as Screenshot, cursorOriginFor(index));
+    if (layer.kind === 'screenshot' && !options.stepDescriptions) layer.description = '';
     loaded.set(index, layer);
     return layer;
   };
@@ -560,9 +791,11 @@ export async function exportGuideAsVideo(
   try {
     const offset = options.cover ? COVER_SECONDS : 0;
 
+    const cards = actionSteps(frames);
+
     if (options.cover) {
       abortIfRequested();
-      await drawCoverFrame(ctx, guide, actionSteps(frames), brand);
+      await drawCardFrame(ctx, guide, cards, brand, i18n.t('export.guideLabel'));
       await source.add(0, COVER_SECONDS);
       done += 1;
       onProgress?.(done, total);
@@ -584,15 +817,23 @@ export async function exportGuideAsVideo(
       ctx.fillRect(0, 0, FRAME_WIDTH, FRAME_HEIGHT);
 
       if (previous) {
-        drawStepFrame(ctx, previous, local + stride);
+        drawStepFrame(ctx, previous, local + stride, device);
         ctx.globalAlpha = (local + 1) / overlap;
-        drawStepFrame(ctx, current, local);
+        drawStepFrame(ctx, current, local, device);
         ctx.globalAlpha = 1;
       } else {
-        drawStepFrame(ctx, current, local);
+        drawStepFrame(ctx, current, local, device);
       }
 
       await source.add(offset + frame / FPS, 1 / FPS);
+      done += 1;
+      onProgress?.(done, total);
+    }
+
+    if (options.cover) {
+      abortIfRequested();
+      await drawCardFrame(ctx, guide, cards, brand, i18n.t('export.endLabel'));
+      await source.add(offset + stepTotal / FPS, COVER_SECONDS);
       done += 1;
       onProgress?.(done, total);
     }
@@ -612,5 +853,6 @@ export async function exportGuideAsVideo(
   return {
     blob: new Blob([buffer], { type: mp4 ? 'video/mp4' : 'video/webm' }),
     extension: mp4 ? 'mp4' : 'webm',
+    chapters: videoChapters(frames, Boolean(options.cover)),
   };
 }

--- a/src/core/export/video-support.ts
+++ b/src/core/export/video-support.ts
@@ -1,3 +1,5 @@
+import type { VideoResolution } from '@/core/export/options';
+
 export const FRAME_WIDTH = 1280;
 export const FRAME_HEIGHT = 720;
 
@@ -7,35 +9,46 @@ export const STEP_ZOOM_TRANSITION_SEC = 0.73;
 export const STEP_ZOOMED_IN_SEC = 3;
 export const STEP_SECONDS = STEP_ZOOMED_OUT_SEC + STEP_ZOOM_TRANSITION_SEC + STEP_ZOOMED_IN_SEC;
 
-export const AVC_CODEC = 'avc1.64001f';
-export const VP9_CODEC = 'vp09.00.31.08';
+export interface ResolutionSpec {
+  width: number;
+  height: number;
+  avc: string;
+  vp9: string;
+}
+
+export const RESOLUTION_SPECS: Record<VideoResolution, ResolutionSpec> = {
+  '720p': { width: 1280, height: 720, avc: 'avc1.64001f', vp9: 'vp09.00.31.08' },
+  '1080p': { width: 1920, height: 1080, avc: 'avc1.640028', vp9: 'vp09.00.40.08' },
+};
+
+export const AVC_CODEC = RESOLUTION_SPECS['720p'].avc;
+export const VP9_CODEC = RESOLUTION_SPECS['720p'].vp9;
 
 export type VideoContainer = 'mp4' | 'webm';
 
-async function encodes(codec: string): Promise<boolean> {
+async function encodes(codec: string, width: number, height: number): Promise<boolean> {
   try {
-    const { supported } = await VideoEncoder.isConfigSupported({
-      codec,
-      width: FRAME_WIDTH,
-      height: FRAME_HEIGHT,
-    });
+    const { supported } = await VideoEncoder.isConfigSupported({ codec, width, height });
     return Boolean(supported);
   } catch {
     return false;
   }
 }
 
-async function probe(): Promise<VideoContainer | null> {
+async function probe(spec: ResolutionSpec): Promise<VideoContainer | null> {
   if (typeof VideoEncoder === 'undefined') return null;
-  if (await encodes(AVC_CODEC)) return 'mp4';
-  return (await encodes(VP9_CODEC)) ? 'webm' : null;
+  if (await encodes(spec.avc, spec.width, spec.height)) return 'mp4';
+  return (await encodes(spec.vp9, spec.width, spec.height)) ? 'webm' : null;
 }
 
-let pending: Promise<VideoContainer | null> | undefined;
+const pending = new Map<VideoResolution, Promise<VideoContainer | null>>();
 
-export function pickContainer(): Promise<VideoContainer | null> {
-  pending ??= probe();
-  return pending;
+export function pickContainer(resolution: VideoResolution = '720p'): Promise<VideoContainer | null> {
+  const cached = pending.get(resolution);
+  if (cached) return cached;
+  const next = probe(RESOLUTION_SPECS[resolution]);
+  pending.set(resolution, next);
+  return next;
 }
 
 export async function canExportVideo(): Promise<boolean> {

--- a/src/core/screenshot/__tests__/geometry.test.ts
+++ b/src/core/screenshot/__tests__/geometry.test.ts
@@ -7,6 +7,7 @@ import {
   moveAnnotation,
   panBy,
   resizeAnnotation,
+  resolveTarget,
   resolveViewport,
   zoomBy,
 } from '@/core/screenshot/geometry';
@@ -58,6 +59,38 @@ describe('resolveViewport', () => {
     const v = resolveViewport(s);
     expect(v.width).toBeLessThanOrEqual(1000);
     expect(v.height).toBeLessThanOrEqual(800);
+  });
+
+  it('shows the whole page rather than the top-left corner when the element vanished before measuring', () => {
+    const s = makeScreenshot({ bounds: { x: 0, y: 0, width: 0, height: 0 }, pixelRatio: 2 });
+    expect(resolveViewport(s)).toEqual({ x: 0, y: 0, width: 1000, height: 800 });
+  });
+});
+
+describe('resolveTarget', () => {
+  it('derives the target from bounds at the captured pixel ratio', () => {
+    const s = makeScreenshot({ bounds: { x: 50, y: 60, width: 100, height: 20 }, pixelRatio: 2 });
+    expect(resolveTarget(s)).toMatchObject({ x: 100, y: 120, width: 200, height: 40 });
+  });
+
+  it('prefers an explicit target from the editor', () => {
+    const s = makeScreenshot({
+      bounds: { x: 50, y: 60, width: 100, height: 20 },
+      edits: { target: { x: 1, y: 2, width: 3, height: 4, border: 'dashed', color: '#fff' } },
+    });
+    expect(resolveTarget(s)).toMatchObject({ x: 1, y: 2, width: 3, height: 4 });
+  });
+
+  it('respects a target the user deliberately removed', () => {
+    expect(
+      resolveTarget(makeScreenshot({ bounds: { x: 5, y: 5, width: 9, height: 9 }, edits: { target: null } })),
+    ).toBe(null);
+  });
+
+  it('reports no target rather than one pinned to the origin when the element vanished before measuring', () => {
+    const zeroed = { x: 0, y: 0, width: 0, height: 0, border: 'dashed' as const, color: '#4F46E5' };
+    expect(resolveTarget(makeScreenshot({ edits: { target: zeroed } }))).toBe(null);
+    expect(resolveTarget(makeScreenshot({ bounds: { x: 0, y: 0, width: 0, height: 0 }, pixelRatio: 2 }))).toBe(null);
   });
 });
 

--- a/src/core/screenshot/geometry.ts
+++ b/src/core/screenshot/geometry.ts
@@ -8,6 +8,14 @@ export function clamp(val: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, val));
 }
 
+function hasArea<T extends { width: number; height: number }>(rect: T | null | undefined): rect is T {
+  return !!rect && rect.width > 0 && rect.height > 0;
+}
+
+export function resolveFrameViewport(screenshot: Screenshot): ScreenshotBounds {
+  return screenshot.edits?.viewport ?? { x: 0, y: 0, width: screenshot.width, height: screenshot.height };
+}
+
 export function resolveViewport(screenshot: Screenshot): ScreenshotBounds {
   const imgW = screenshot.width;
   const imgH = screenshot.height;
@@ -15,7 +23,7 @@ export function resolveViewport(screenshot: Screenshot): ScreenshotBounds {
   if (explicit) return explicit;
 
   const bounds = screenshot.bounds;
-  if (!bounds) return { x: 0, y: 0, width: imgW, height: imgH };
+  if (!hasArea(bounds)) return { x: 0, y: 0, width: imgW, height: imgH };
 
   const dpr = screenshot.pixelRatio || 1;
   const bx = bounds.x * dpr;
@@ -198,10 +206,10 @@ export type TargetSource = Pick<Screenshot, 'edits' | 'bounds' | 'pixelRatio'>;
 
 export function resolveTarget(screenshot: TargetSource): ClickTarget | null {
   const explicit = screenshot.edits?.target;
-  if (explicit !== undefined) return explicit;
+  if (explicit !== undefined) return hasArea(explicit) ? explicit : null;
 
   const bounds = screenshot.bounds;
-  if (!bounds) return null;
+  if (!hasArea(bounds)) return null;
 
   const dpr = screenshot.pixelRatio || 1;
   return {

--- a/src/core/screenshot/render.ts
+++ b/src/core/screenshot/render.ts
@@ -1,10 +1,12 @@
-import type { Screenshot } from '@/core/guides/types';
+import type { Screenshot, ScreenshotBounds } from '@/core/guides/types';
 import { drawAnnotation } from './draw';
 import { resolveTarget, resolveViewport } from './geometry';
 
 interface RenderOptions {
   format?: 'image/webp' | 'image/jpeg' | 'image/png';
   quality?: number;
+  viewport?: ScreenshotBounds;
+  target?: boolean;
 }
 
 export async function imageDimensions(file: Blob): Promise<{ width: number; height: number }> {
@@ -16,7 +18,7 @@ export async function imageDimensions(file: Blob): Promise<{ width: number; heig
 
 export async function renderScreenshot(screenshot: Screenshot, opts: RenderOptions = {}): Promise<Blob> {
   const { format = 'image/webp', quality = 0.85 } = opts;
-  const viewport = resolveViewport(screenshot);
+  const viewport = opts.viewport ?? resolveViewport(screenshot);
   const bitmap = await createImageBitmap(screenshot.blob);
 
   const canvas = new OffscreenCanvas(Math.round(viewport.width), Math.round(viewport.height));
@@ -26,7 +28,7 @@ export async function renderScreenshot(screenshot: Screenshot, opts: RenderOptio
 
   ctx.translate(-viewport.x, -viewport.y);
 
-  const target = resolveTarget(screenshot);
+  const target = opts.target === false ? null : resolveTarget(screenshot);
   if (target) {
     drawAnnotation(
       ctx,

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -287,6 +287,11 @@ blurPanel:
   resetAll: Alles zurücksetzen
 
 exportPreview:
+  stepDescriptions: "Schritttexte"
+  stepDescriptionsHint: "Den Schritttext in jedes Videobild einzeichnen"
+  resolution: "Videoqualität"
+  res_720p: "720p"
+  res_1080p: "1080p"
   title: "Export-Vorschau"
   cover: "Deckblatt"
   coverHint: "Ein eigenes erstes Blatt mit Titel und Details"
@@ -307,12 +312,19 @@ exportPreview:
   modeVideo: "Video"
   encodingVideo: "Videovorschau wird erstellt"
   videoFailed: "Die Videovorschau konnte nicht erstellt werden"
+videoPlayer:
+  stepCount: "$1 Schritte"
+  previousStep: "Vorheriger Schritt"
+  nextStep: "Nächster Schritt"
+  speed: "Wiedergabegeschwindigkeit"
+
 exportMenu:
   docx: "DOCX"
   html: HTML
   markdown: Markdown
   pdf: PDF
   video: Video
+  cancelProgress: "Abbrechen · $1 %"
 
 onboarding:
   welcomeBadge: Willkommen
@@ -380,6 +392,7 @@ steps:
 
 export:
   guideLabel: "ANLEITUNG"
+  endLabel: "ANLEITUNG ABGESCHLOSSEN"
   stepsRange: "Schritte $1–$2 von $3"
   stepOf: "Schritt $1 von $2"
   madeWith: "Made with Mimik"

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -356,6 +356,11 @@ annotationEditor:
   done: Done
 
 exportPreview:
+  stepDescriptions: "Step captions"
+  stepDescriptionsHint: "Draw the step text onto each video frame"
+  resolution: "Video quality"
+  res_720p: "720p"
+  res_1080p: "1080p"
   title: "Export preview"
   cover: "Cover page"
   coverHint: "A separate first sheet with the title and details"
@@ -376,12 +381,19 @@ exportPreview:
   modeVideo: "Video"
   encodingVideo: "Encoding video preview"
   videoFailed: "The video preview could not be created"
+videoPlayer:
+  stepCount: "$1 steps"
+  previousStep: "Previous step"
+  nextStep: "Next step"
+  speed: "Playback speed"
+
 exportMenu:
   docx: DOCX
   html: HTML
   markdown: Markdown
   pdf: PDF
   video: Video
+  cancelProgress: "Cancel · $1%"
 
 onboarding:
   welcomeBadge: Welcome
@@ -449,6 +461,7 @@ steps:
 
 export:
   guideLabel: "GUIDE"
+  endLabel: "GUIDE COMPLETE"
   stepsRange: "Steps $1–$2 of $3"
   stepOf: "Step $1 of $2"
   madeWith: "Made with Mimik"

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -356,6 +356,11 @@ annotationEditor:
   done: Listo
 
 exportPreview:
+  stepDescriptions: "Textos de paso"
+  stepDescriptionsHint: "Dibujar el texto del paso en cada fotograma"
+  resolution: "Calidad de vídeo"
+  res_720p: "720p"
+  res_1080p: "1080p"
   title: "Vista previa de exportación"
   cover: "Portada"
   coverHint: "Una primera hoja con el título y los detalles"
@@ -376,12 +381,19 @@ exportPreview:
   modeVideo: "Vídeo"
   encodingVideo: "Codificando la vista previa del vídeo"
   videoFailed: "No se pudo crear la vista previa del vídeo"
+videoPlayer:
+  stepCount: "$1 pasos"
+  previousStep: "Paso anterior"
+  nextStep: "Paso siguiente"
+  speed: "Velocidad de reproducción"
+
 exportMenu:
   docx: DOCX
   html: HTML
   markdown: Markdown
   pdf: PDF
   video: Vídeo
+  cancelProgress: "Cancelar · $1 %"
 
 onboarding:
   welcomeBadge: Bienvenido
@@ -449,6 +461,7 @@ steps:
 
 export:
   guideLabel: "GUÍA"
+  endLabel: "GUÍA COMPLETADA"
   stepsRange: "Pasos $1–$2 de $3"
   stepOf: "Paso $1 de $2"
   madeWith: "Made with Mimik"

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -356,6 +356,11 @@ annotationEditor:
   done: "Terminé"
 
 exportPreview:
+  stepDescriptions: "Textes d'étape"
+  stepDescriptionsHint: "Incruster le texte de l'étape sur chaque image"
+  resolution: "Qualité vidéo"
+  res_720p: "720p"
+  res_1080p: "1080p"
   title: "Aperçu de l’export"
   cover: "Page de couverture"
   coverHint: "Une première page avec le titre et les détails"
@@ -376,12 +381,19 @@ exportPreview:
   modeVideo: "Vidéo"
   encodingVideo: "Encodage de l’aperçu vidéo"
   videoFailed: "Impossible de créer l’aperçu vidéo"
+videoPlayer:
+  stepCount: "$1 étapes"
+  previousStep: "Étape précédente"
+  nextStep: "Étape suivante"
+  speed: "Vitesse de lecture"
+
 exportMenu:
   docx: DOCX
   html: HTML
   markdown: Markdown
   pdf: PDF
   video: Vidéo
+  cancelProgress: "Annuler · $1 %"
 
 onboarding:
   welcomeBadge: Bienvenue
@@ -449,6 +461,7 @@ steps:
 
 export:
   guideLabel: "GUIDE"
+  endLabel: "GUIDE TERMINÉ"
   stepsRange: "Étapes $1–$2 sur $3"
   stepOf: "Étape $1 sur $2"
   madeWith: "Made with Mimik"

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -356,6 +356,11 @@ annotationEditor:
   done: Pronto
 
 exportPreview:
+  stepDescriptions: "Textos da etapa"
+  stepDescriptionsHint: "Desenhar o texto da etapa em cada quadro"
+  resolution: "Qualidade do vídeo"
+  res_720p: "720p"
+  res_1080p: "1080p"
   title: "Prévia da exportação"
   cover: "Capa"
   coverHint: "Uma primeira folha com título e detalhes"
@@ -376,12 +381,19 @@ exportPreview:
   modeVideo: "Vídeo"
   encodingVideo: "Codificando a prévia do vídeo"
   videoFailed: "Não foi possível criar a prévia do vídeo"
+videoPlayer:
+  stepCount: "$1 etapas"
+  previousStep: "Etapa anterior"
+  nextStep: "Próxima etapa"
+  speed: "Velocidade de reprodução"
+
 exportMenu:
   docx: DOCX
   html: HTML
   markdown: Markdown
   pdf: PDF
   video: Vídeo
+  cancelProgress: "Cancelar · $1%"
 
 onboarding:
   welcomeBadge: Bem-vindo
@@ -449,6 +461,7 @@ steps:
 
 export:
   guideLabel: "GUIA"
+  endLabel: "GUIA CONCLUÍDO"
   stepsRange: "Etapas $1–$2 de $3"
   stepOf: "Etapa $1 de $2"
   madeWith: "Made with Mimik"

--- a/src/ui/fullview/ExportPreviewModal.tsx
+++ b/src/ui/fullview/ExportPreviewModal.tsx
@@ -1,5 +1,5 @@
 import { FileCode, FileDown, FileText, Loader2, Video } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import { i18n } from '#imports';
 import { downloadBlob, downloadText, safeFilename } from '@/core/export/download';
 import { exportGuideAsHTML } from '@/core/export/html-export';
@@ -9,13 +9,17 @@ import {
   type ImageScale,
   loadExportOptions,
   saveExportOptions,
+  VIDEO_RESOLUTIONS,
 } from '@/core/export/options';
 import { exportGuideAsPDF } from '@/core/export/pdf-export';
 import { paginatePreview, withPreviewStyles } from '@/core/export/preview';
+import type { VideoChapter } from '@/core/export/video-export';
 import { canExportVideo, STEP_SECONDS } from '@/core/export/video-support';
 import type { Guide, Screenshot, Step } from '@/core/guides/types';
 import { Button } from '@/ui/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/ui/components/ui/dialog';
+
+const VideoStepPlayer = lazy(() => import('@/ui/fullview/VideoStepPlayer'));
 
 const VIDEO_AUTOPLAY_STEP_LIMIT = 25;
 const IMAGE_SCALES: ImageScale[] = ['small', 'medium', 'large'];
@@ -39,6 +43,9 @@ export default function ExportPreviewModal({ open, onOpenChange, guide, steps, s
   const [videoSupported, setVideoSupported] = useState(false);
   const [mode, setMode] = useState<PreviewMode>('document');
   const [videoUrl, setVideoUrl] = useState<string | null>(null);
+  const [videoChapters, setVideoChapters] = useState<VideoChapter[]>([]);
+  const [downloadProgress, setDownloadProgress] = useState(0);
+  const downloadAbort = useRef<AbortController | null>(null);
   const [videoError, setVideoError] = useState<string | null>(null);
   const [videoProgress, setVideoProgress] = useState(0);
   const [videoRequested, setVideoRequested] = useState(false);
@@ -58,7 +65,7 @@ export default function ExportPreviewModal({ open, onOpenChange, guide, steps, s
   }, []);
 
   const videoPending = steps.length > VIDEO_AUTOPLAY_STEP_LIMIT && !videoRequested;
-  const cover = options.cover;
+  const { cover, stepDescriptions, resolution } = options;
 
   useEffect(() => {
     if (!open) setVideoRequested(false);
@@ -89,11 +96,11 @@ export default function ExportPreviewModal({ open, onOpenChange, guide, steps, s
     const timer = setTimeout(async () => {
       try {
         const { exportGuideAsVideo } = await import('@/core/export/video-export');
-        const { blob } = await exportGuideAsVideo(
+        const { blob, chapters } = await exportGuideAsVideo(
           guide,
           steps,
           screenshots,
-          { cover },
+          { cover, stepDescriptions, resolution },
           {
             signal: controller.signal,
             onProgress: (encoded, frames) => {
@@ -103,6 +110,7 @@ export default function ExportPreviewModal({ open, onOpenChange, guide, steps, s
         );
         if (controller.signal.aborted) return;
         url = URL.createObjectURL(blob);
+        setVideoChapters(chapters);
         setVideoUrl(url);
       } catch (error) {
         if (controller.signal.aborted || (error instanceof DOMException && error.name === 'AbortError')) return;
@@ -115,7 +123,7 @@ export default function ExportPreviewModal({ open, onOpenChange, guide, steps, s
       if (url) URL.revokeObjectURL(url);
       setVideoUrl(null);
     };
-  }, [open, mode, guide, steps, screenshots, cover, videoPending]);
+  }, [open, mode, guide, steps, screenshots, cover, stepDescriptions, resolution, videoPending]);
 
   const update = (patch: Partial<ExportOptions>) => {
     const next = { ...options, ...patch };
@@ -135,15 +143,24 @@ export default function ExportPreviewModal({ open, onOpenChange, guide, steps, s
         const { exportGuideAsDOCX } = await import('@/core/export/docx-export');
         downloadBlob(await exportGuideAsDOCX(guide, steps, screenshots, options), safeFilename(guide.title, 'docx'));
       } else if (format === 'video') {
+        const controller = new AbortController();
+        downloadAbort.current = controller;
+        setDownloadProgress(0);
         const { exportGuideAsVideo } = await import('@/core/export/video-export');
-        const { blob, extension } = await exportGuideAsVideo(guide, steps, screenshots, options);
+        const { blob, extension } = await exportGuideAsVideo(guide, steps, screenshots, options, {
+          signal: controller.signal,
+          onProgress: (encoded, frames) => setDownloadProgress(frames > 0 ? encoded / frames : 0),
+        });
         downloadBlob(blob, safeFilename(guide.title, extension));
       } else {
         const { exportGuideAsMarkdown } = await import('@/core/export/markdown-export');
         const md = await exportGuideAsMarkdown(guide, steps, screenshots);
         downloadText(md, safeFilename(guide.title, 'md'), 'text/markdown');
       }
+    } catch (error) {
+      if (!(error instanceof DOMException && error.name === 'AbortError')) throw error;
     } finally {
+      downloadAbort.current = null;
       setExporting(null);
     }
   }
@@ -152,6 +169,11 @@ export default function ExportPreviewModal({ open, onOpenChange, guide, steps, s
     { key: 'cover', label: i18n.t('exportPreview.cover'), hint: i18n.t('exportPreview.coverHint') },
     { key: 'screenshots', label: i18n.t('exportPreview.screenshots'), hint: i18n.t('exportPreview.screenshotsHint') },
     { key: 'stepUrls', label: i18n.t('exportPreview.stepUrls'), hint: i18n.t('exportPreview.stepUrlsHint') },
+    {
+      key: 'stepDescriptions',
+      label: i18n.t('exportPreview.stepDescriptions'),
+      hint: i18n.t('exportPreview.stepDescriptionsHint'),
+    },
   ];
 
   const modes: Array<{ key: PreviewMode; icon: typeof FileText; label: string }> = [
@@ -223,20 +245,49 @@ export default function ExportPreviewModal({ open, onOpenChange, guide, steps, s
               </div>
             </div>
 
+            {videoSupported && (
+              <div className="pt-3 border-t border-border">
+                <div className="text-[12px] font-semibold text-foreground mb-2">
+                  {i18n.t('exportPreview.resolution')}
+                </div>
+                <div className="flex gap-1.5">
+                  {VIDEO_RESOLUTIONS.map((value) => (
+                    <button
+                      key={value}
+                      type="button"
+                      onClick={() => update({ resolution: value })}
+                      className={`flex-1 px-2 py-1.5 rounded-lg border text-[11px] transition-colors ${
+                        options.resolution === value
+                          ? 'border-accent text-accent'
+                          : 'border-border text-muted-foreground hover:border-accent hover:text-foreground'
+                      }`}
+                    >
+                      {i18n.t(`exportPreview.res_${value}`)}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
             <div className="pt-3 border-t border-border space-y-1.5">
-              {formats.map(({ key, icon: Icon, label }) => (
-                <Button
-                  key={key}
-                  size="sm"
-                  variant="ghost"
-                  disabled={exporting !== null}
-                  onClick={() => handleExport(key)}
-                  className="w-full justify-start gap-2 border border-border hover:border-accent"
-                >
-                  {exporting === key ? <Loader2 size={14} className="animate-spin" /> : <Icon size={14} />}
-                  {i18n.t('exportPreview.download', [label])}
-                </Button>
-              ))}
+              {formats.map(({ key, icon: Icon, label }) => {
+                const cancellable = exporting === key && key === 'video';
+                return (
+                  <Button
+                    key={key}
+                    size="sm"
+                    variant="ghost"
+                    disabled={exporting !== null && !cancellable}
+                    onClick={() => (cancellable ? downloadAbort.current?.abort() : handleExport(key))}
+                    className="w-full justify-start gap-2 border border-border hover:border-accent"
+                  >
+                    {exporting === key ? <Loader2 size={14} className="animate-spin" /> : <Icon size={14} />}
+                    {cancellable
+                      ? i18n.t('exportMenu.cancelProgress', [String(Math.round(downloadProgress * 100))])
+                      : i18n.t('exportPreview.download', [label])}
+                  </Button>
+                );
+              })}
             </div>
           </div>
 
@@ -307,15 +358,9 @@ export default function ExportPreviewModal({ open, onOpenChange, guide, steps, s
                       <div className="mt-1 text-[11px] text-muted-foreground leading-snug">{videoError}</div>
                     </div>
                   ) : videoUrl ? (
-                    <video
-                      key={videoUrl}
-                      src={videoUrl}
-                      controls
-                      autoPlay
-                      muted
-                      loop
-                      className="w-full h-full object-contain"
-                    />
+                    <Suspense fallback={null}>
+                      <VideoStepPlayer key={videoUrl} src={videoUrl} chapters={videoChapters} />
+                    </Suspense>
                   ) : (
                     <div className="flex flex-col items-center gap-2 bg-card border border-border rounded-xl px-4 py-3">
                       <div className="text-[11px] text-muted-foreground">{i18n.t('exportPreview.encodingVideo')}</div>

--- a/src/ui/fullview/VideoStepPlayer.tsx
+++ b/src/ui/fullview/VideoStepPlayer.tsx
@@ -1,0 +1,161 @@
+import {
+  FullscreenButton,
+  MediaPlayer,
+  MediaProvider,
+  PlayButton,
+  useMediaRemote,
+  useMediaState,
+} from '@vidstack/react';
+import { ChevronLeft, ChevronRight, Maximize, Minimize, Pause, Play } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+import { i18n } from '#imports';
+import type { StepKind, VideoChapter } from '@/core/export/video-export';
+
+const RATES = [1, 1.25, 1.5, 2];
+
+const KIND_DOT: Record<StepKind, string> = {
+  click: 'bg-accent',
+  type: 'bg-violet-light',
+  key: 'bg-violet',
+  navigate: 'bg-lavender',
+  note: 'bg-muted-foreground',
+};
+
+interface VideoStepPlayerProps {
+  src: string;
+  chapters: VideoChapter[];
+}
+
+function formatClock(seconds: number): string {
+  const total = Number.isFinite(seconds) ? Math.max(0, Math.round(seconds)) : 0;
+  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`;
+}
+
+function activeIndex(chapters: VideoChapter[], time: number): number {
+  for (let i = chapters.length - 1; i >= 0; i--) {
+    if (time >= chapters[i].start) return i;
+  }
+  return -1;
+}
+
+function StepList({
+  chapters,
+  index,
+  onJump,
+}: {
+  chapters: VideoChapter[];
+  index: number;
+  onJump: (n: number) => void;
+}) {
+  const list = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    list.current?.querySelectorAll('button')[index]?.scrollIntoView({ block: 'nearest' });
+  }, [index]);
+
+  return (
+    <aside ref={list} className="w-[228px] shrink-0 overflow-y-auto border-l border-white/10 bg-[#141232]">
+      <div className="px-3 pb-2 pt-3 font-mono text-[9px] uppercase tracking-[0.1em] text-white/45">
+        {i18n.t('videoPlayer.stepCount', [String(chapters.length)])}
+      </div>
+      {chapters.map((chapter, i) => (
+        <button
+          key={chapter.stepId}
+          type="button"
+          onClick={() => onJump(i)}
+          className={`flex w-full items-start gap-2.5 border-l-2 px-3 py-1.5 text-left transition-colors ${
+            i === index ? 'border-l-accent bg-white/10' : 'border-l-transparent hover:bg-white/5'
+          }`}
+        >
+          <span className={`mt-1.5 size-1.5 shrink-0 rounded-full ${KIND_DOT[chapter.kind]}`} />
+          <span className="min-w-0 flex-1 text-[10.5px] leading-snug text-white/80">{chapter.title}</span>
+          <span className="pt-0.5 font-mono text-[9px] tabular-nums text-white/40">{formatClock(chapter.start)}</span>
+        </button>
+      ))}
+    </aside>
+  );
+}
+
+function PlayerBody({ chapters }: { chapters: VideoChapter[] }) {
+  const remote = useMediaRemote();
+  const time = useMediaState('currentTime');
+  const duration = useMediaState('duration');
+  const rate = useMediaState('playbackRate');
+  const paused = useMediaState('paused');
+  const fullscreen = useMediaState('fullscreen');
+
+  const index = activeIndex(chapters, time);
+  const seekTo = (seconds: number) => remote.seek(Math.max(0, seconds + 0.01));
+  const jump = (i: number) => chapters[i] && seekTo(chapters[i].start);
+
+  return (
+    <>
+      <div className="relative min-w-0 flex-1">
+        <MediaProvider className="size-full [&_video]:size-full [&_video]:object-contain" />
+
+        <div className="absolute inset-x-0 bottom-0 flex items-center gap-2 bg-gradient-to-t from-black/85 to-transparent px-3 pb-2.5 pt-8 text-white">
+          <PlayButton className="rounded-md p-1 hover:bg-white/15">
+            {paused ? <Play size={16} fill="currentColor" /> : <Pause size={16} fill="currentColor" />}
+          </PlayButton>
+
+          <button
+            type="button"
+            disabled={index <= 0}
+            onClick={() => jump(index - 1)}
+            aria-label={i18n.t('videoPlayer.previousStep')}
+            className="rounded-md p-1 hover:bg-white/15 disabled:opacity-35 disabled:hover:bg-transparent"
+          >
+            <ChevronLeft size={16} />
+          </button>
+          <button
+            type="button"
+            disabled={index < 0 || index >= chapters.length - 1}
+            onClick={() => jump(index + 1)}
+            aria-label={i18n.t('videoPlayer.nextStep')}
+            className="rounded-md p-1 hover:bg-white/15 disabled:opacity-35 disabled:hover:bg-transparent"
+          >
+            <ChevronRight size={16} />
+          </button>
+
+          <span className="font-mono text-[11px] tabular-nums text-white/75">
+            {formatClock(time)} / {formatClock(duration)}
+          </span>
+
+          <span className="flex-1" />
+
+          <button
+            type="button"
+            onClick={() => remote.changePlaybackRate(RATES[(RATES.indexOf(rate) + 1) % RATES.length])}
+            aria-label={i18n.t('videoPlayer.speed')}
+            className="rounded-md px-1.5 py-1 font-mono text-[11px] tabular-nums hover:bg-white/15"
+          >
+            {rate}x
+          </button>
+
+          <FullscreenButton className="rounded-md p-1 hover:bg-white/15">
+            {fullscreen ? <Minimize size={16} /> : <Maximize size={16} />}
+          </FullscreenButton>
+        </div>
+      </div>
+
+      {chapters.length > 0 && <StepList chapters={chapters} index={index} onJump={jump} />}
+    </>
+  );
+}
+
+export default function VideoStepPlayer({ src, chapters }: VideoStepPlayerProps) {
+  return (
+    <MediaPlayer
+      src={{ src, type: 'video/mp4' }}
+      autoPlay
+      muted
+      playsInline
+      load="eager"
+      viewType="video"
+      streamType="on-demand"
+      className="flex size-full bg-[#0E0C28]"
+    >
+      <PlayerBody chapters={chapters} />
+    </MediaPlayer>
+  );
+}

--- a/src/ui/fullview/__tests__/ExportPreviewModal.test.tsx
+++ b/src/ui/fullview/__tests__/ExportPreviewModal.test.tsx
@@ -9,6 +9,7 @@ const exportGuideAsHTML = vi.hoisted(() => vi.fn());
 const canExportVideo = vi.hoisted(() => vi.fn());
 
 vi.mock('@/core/export/video-export', () => ({ exportGuideAsVideo }));
+vi.mock('@/ui/fullview/VideoStepPlayer', () => ({ default: () => <div data-testid="video-player" /> }));
 vi.mock('@/core/export/html-export', () => ({ exportGuideAsHTML }));
 vi.mock('@/core/export/video-support', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/core/export/video-support')>()),
@@ -59,7 +60,7 @@ describe('ExportPreviewModal video preview', () => {
     vi.clearAllMocks();
     canExportVideo.mockResolvedValue(true);
     exportGuideAsHTML.mockResolvedValue('<html lang="en"><head></head><body></body></html>');
-    exportGuideAsVideo.mockResolvedValue({ blob: new Blob(['video']), extension: 'mp4' });
+    exportGuideAsVideo.mockResolvedValue({ blob: new Blob(['video']), extension: 'mp4', chapters: [] });
     URL.createObjectURL = vi.fn(() => 'blob:video');
     URL.revokeObjectURL = vi.fn();
   });

--- a/src/ui/sidepanel/ExportMenu.tsx
+++ b/src/ui/sidepanel/ExportMenu.tsx
@@ -28,7 +28,9 @@ export default function ExportMenu({
   const [open, setOpen] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [videoSupported, setVideoSupported] = useState(false);
+  const [videoProgress, setVideoProgress] = useState<number | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const videoAbort = useRef<AbortController | null>(null);
 
   useEffect(() => {
     let active = true;
@@ -67,13 +69,23 @@ export default function ExportMenu({
         const md = await exportGuideAsMarkdown(guide, steps, screenshots);
         downloadText(md, safeFilename(guide.title, 'md'), 'text/markdown');
       } else if (type === 'video') {
+        const controller = new AbortController();
+        videoAbort.current = controller;
+        setVideoProgress(0);
         const { exportGuideAsVideo } = await import('@/core/export/video-export');
-        const { blob, extension } = await exportGuideAsVideo(guide, steps, screenshots);
+        const { blob, extension } = await exportGuideAsVideo(guide, steps, screenshots, undefined, {
+          signal: controller.signal,
+          onProgress: (encoded, frames) => setVideoProgress(frames > 0 ? encoded / frames : 0),
+        });
         downloadBlob(blob, safeFilename(guide.title, extension));
       } else {
         downloadBlob(await exportGuideAsPDF(guide, steps, screenshots), safeFilename(guide.title, 'pdf'));
       }
+    } catch (error) {
+      if (!(error instanceof DOMException && error.name === 'AbortError')) throw error;
     } finally {
+      videoAbort.current = null;
+      setVideoProgress(null);
       setExporting(false);
     }
   }
@@ -88,9 +100,15 @@ export default function ExportMenu({
 
   return (
     <div ref={menuRef} className="relative">
-      <Button size="sm" onClick={() => setOpen((prev) => !prev)} disabled={exporting}>
+      <Button
+        size="sm"
+        onClick={() => (videoProgress === null ? setOpen((prev) => !prev) : videoAbort.current?.abort())}
+        disabled={exporting && videoProgress === null}
+      >
         {exporting ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
-        {i18n.t('common.export')}
+        {videoProgress === null
+          ? i18n.t('common.export')
+          : i18n.t('exportMenu.cancelProgress', [String(Math.round(videoProgress * 100))])}
       </Button>
 
       {open && !exporting && (


### PR DESCRIPTION
Video frames inherited the still-screenshot auto-crop, then zoomed 3.5x on top — ~290px of source in a 1280px frame. Video now composes from the full capture and never magnifies past 1.5x.

The click ring was baked into the bitmap, so every step opened with the selection already made. The compositor now draws it once the camera lands, then the caption, with a pointer flying in from the last step's target.

Capture also measured the target inside the deferred queue, so anything that removed itself on click stored a zero rect, pinning the crop to the origin. It is frozen at event time now.

Also: end card, download progress and cancellation, caption and quality options, step-list player.

Still broken: the screenshot is taken after the click, so a menu that closes on click is absent from its frame. Tracked separately.

`pnpm lint`, 885 tests, `pnpm build` and `pnpm build:firefox` clean.
