### PR TITLE
fix(export): keep the pdf and its preview on one page geometry

### DIFF
--- a/src/core/export/__tests__/utils.test.ts
+++ b/src/core/export/__tests__/utils.test.ts
@@ -1,6 +1,14 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
-import { blobToBase64, blobToDataUrl, escapeHtml, extractDomain, fitImage, formatDate } from '@/core/export/utils';
+import {
+  blobToBase64,
+  blobToDataUrl,
+  containFit,
+  escapeHtml,
+  extractDomain,
+  fitImage,
+  formatDate,
+} from '@/core/export/utils';
 import type { Step } from '@/core/guides/types';
 
 function makeStep(overrides: Partial<Step> = {}): Step {
@@ -147,5 +155,39 @@ describe('fitImage', () => {
 
   it('leaves an image exactly at the cap untouched', () => {
     expect(fitImage(143, 211.5, 211.5)).toEqual({ width: 143, height: 211.5 });
+  });
+});
+
+describe('containFit', () => {
+  it('fills the box exactly when the ratios match', () => {
+    const fit = containFit(1600, 900, 143, 80.4375);
+    expect(fit.width).toBeCloseTo(143, 4);
+    expect(fit.height).toBeCloseTo(80.4375, 4);
+    expect(fit.x).toBeCloseTo(0, 4);
+    expect(fit.y).toBeCloseTo(0, 4);
+  });
+
+  it('pillarboxes a square inside a wide frame without exceeding it', () => {
+    const fit = containFit(1000, 1000, 143, 80.4375);
+    expect(fit.width).toBeCloseTo(80.4375, 4);
+    expect(fit.height).toBeCloseTo(80.4375, 4);
+    expect(fit.x).toBeCloseTo((143 - 80.4375) / 2, 4);
+    expect(fit.y).toBeCloseTo(0, 4);
+  });
+
+  it('letterboxes a wide image inside a tall frame', () => {
+    const fit = containFit(2000, 500, 100, 100);
+    expect(fit.width).toBeCloseTo(100, 4);
+    expect(fit.height).toBeCloseTo(25, 4);
+    expect(fit.y).toBeCloseTo(37.5, 4);
+  });
+
+  it('preserves the source aspect ratio', () => {
+    const fit = containFit(1366, 768, 143, 80.4375);
+    expect(fit.width / fit.height).toBeCloseTo(1366 / 768, 6);
+  });
+
+  it('falls back to the box for a degenerate source', () => {
+    expect(containFit(0, 0, 143, 80)).toEqual({ width: 143, height: 80, x: 0, y: 0 });
   });
 });

--- a/src/core/export/docx-export.ts
+++ b/src/core/export/docx-export.ts
@@ -467,7 +467,16 @@ export async function exportGuideAsDOCX(
   const domain = extractDomain(steps);
   const brand = await loadBranding();
 
-  const children: Array<Paragraph | Table> = opts.cover ? buildCover(guide, steps, domain, brand) : [];
+  const children: Array<Paragraph | Table> = opts.cover
+    ? buildCover(guide, steps, domain, brand)
+    : guide.description
+      ? [
+          new Paragraph({
+            spacing: { after: 320 },
+            children: [new TextRun({ text: guide.description, color: MUTED, size: 22, font: DOCX_FONT_FAMILY })],
+          }),
+        ]
+      : [];
   const numbers = stepNumbers(steps);
 
   for (const [i, step] of steps.entries()) {

--- a/src/core/export/html-export.ts
+++ b/src/core/export/html-export.ts
@@ -1,9 +1,21 @@
 import { i18n } from '#imports';
 import { fitLogo, loadBranding } from '@/core/export/branding';
 import { type ExportOptions, IMAGE_SCALE_FACTORS, loadExportOptions } from '@/core/export/options';
-import { blobToBase64, escapeHtml, extractDomain, formatDate } from '@/core/export/utils';
+import {
+  blobToBase64,
+  escapeHtml,
+  extractDomain,
+  formatDate,
+  LEAD_FONT_PX,
+  LEAD_LINE_RATIO,
+  LEAD_MARGIN_PX,
+  MAX_DESC_LINES,
+  MAX_LEAD_LINES,
+  MAX_TITLE_LINES,
+} from '@/core/export/utils';
 import { actionSteps, calloutAccent, isBlock, stepNumbers, tint, variantLabel } from '@/core/guides/blocks';
 import type { Guide, Screenshot, Step } from '@/core/guides/types';
+import { dominantRatio, resolveViewport } from '@/core/screenshot/geometry';
 import { renderScreenshot } from '@/core/screenshot/render';
 
 const LOGO_MAX_WIDTH = 148;
@@ -65,6 +77,7 @@ export async function exportGuideAsHTML(
   const brand = await loadBranding();
   const accent = brand.accent;
   const imgWidthPct = Math.round(IMAGE_SCALE_FACTORS[opts.imageScale] * 100);
+  const frameRatio = dominantRatio(screenshots);
   const domain = extractDomain(steps);
   const numbers = stepNumbers(steps);
   const stepSections: string[] = [];
@@ -81,7 +94,9 @@ export async function exportGuideAsHTML(
     if (screenshot) {
       const { type, b64 } = await embedScreenshot(screenshot);
       const altText = screenshot.edits?.alt || i18n.t('export.stepLabel', [String(number)]);
-      imgHtml = `<img src="data:${type};base64,${b64}" alt="${escapeHtml(altText)}" style="display:block;width:${imgWidthPct}%;margin-top:14px;border:1px solid #CBD5E1;" />`;
+      const viewport = resolveViewport(screenshot);
+      const ratio = frameRatio ?? viewport.width / viewport.height;
+      imgHtml = `<div style="width:${imgWidthPct}%;aspect-ratio:${ratio};margin-top:6px;border:1px solid #CBD5E1;background:#fff;display:flex;align-items:center;justify-content:center;overflow:hidden;"><img src="data:${type};base64,${b64}" alt="${escapeHtml(altText)}" style="display:block;max-width:100%;max-height:100%;" /></div>`;
     }
 
     const stepNumber = String(number).padStart(2, '0');
@@ -91,10 +106,10 @@ export async function exportGuideAsHTML(
         : '';
 
     stepSections.push(`
-      <section data-step="${number}" style="display:flex;gap:26px;margin-bottom:52px;">
-        <div style="flex:0 0 76px;font-size:34px;font-weight:700;color:${accent};line-height:.9;">${stepNumber}</div>
-        <div style="flex:1;min-width:0;border-top:1px solid #1E1B4B;padding-top:12px;">
-          <p style="margin:0;font-size:17px;font-weight:700;line-height:1.45;color:#1E1B4B;">${escapeHtml(step.description)}${
+      <section data-step="${number}" style="display:flex;gap:8mm;margin-bottom:13mm;">
+        <div style="flex:0 0 22mm;font-size:34px;font-weight:700;color:${accent};line-height:.9;">${stepNumber}</div>
+        <div style="flex:1;min-width:0;border-top:1px solid #1E1B4B;padding-top:6px;">
+          <p style="margin:0;font-size:17px;font-weight:700;line-height:1.45;color:#1E1B4B;overflow-wrap:anywhere;">${escapeHtml(step.description)}${
             urlHtml ? `<span style="color:#6B7280;font-weight:400;"> &nbsp;·&nbsp; </span>${urlHtml}` : ''
           }</p>
           ${imgHtml}
@@ -117,26 +132,37 @@ export async function exportGuideAsHTML(
   </footer>`
     : '';
 
+  const clamp = (n: number) =>
+    `display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:${n};line-clamp:${n};overflow:hidden;`;
+
+  const metaValue = 'height:38px;display:flex;align-items:center;margin-top:2px;';
   const metaCell = (label: string, value: string) => `
         <div style="flex:0 0 190px;">
           <div style="font-size:11px;font-weight:700;color:#6B7280;letter-spacing:0.06em;">${label}</div>
-          <div style="font-size:17px;color:#1E1B4B;margin-top:4px;">${value}</div>
+          <div style="font-size:17px;color:#1E1B4B;${metaValue}">${value}</div>
         </div>`;
+
+  const leadHtml =
+    !opts.cover && guide.description
+      ? `<p data-lead="true" style="font-size:${LEAD_FONT_PX}px;color:#6B7280;line-height:${LEAD_LINE_RATIO};margin-bottom:${LEAD_MARGIN_PX}px;max-width:60ch;overflow-wrap:anywhere;${clamp(MAX_LEAD_LINES)}">${escapeHtml(guide.description)}</p>`
+      : '';
 
   const headerHtml = opts.cover
     ? `<header data-cover="true" style="margin-bottom:56px;">
-    <div style="display:flex;align-items:flex-start;gap:24px;margin-bottom:26px;">
-      <div style="flex:1;">
-        <div style="font-size:11px;font-weight:700;color:#6B7280;letter-spacing:0.08em;">${i18n.t('export.guideLabel')}</div>
-        <h1 style="font-size:38px;font-weight:700;line-height:1.15;margin-top:18px;">${escapeHtml(guide.title)}</h1>
-        ${guide.description ? `<p style="font-size:16px;color:#6B7280;line-height:1.6;margin-top:14px;max-width:60ch;">${escapeHtml(guide.description)}</p>` : ''}
+    <div style="margin-bottom:26px;">
+      <div style="display:flex;align-items:flex-end;gap:24px;">
+        <div style="flex:1;min-width:0;">
+          <div style="font-size:11px;font-weight:700;color:#6B7280;letter-spacing:0.08em;">${i18n.t('export.guideLabel')}</div>
+          <h1 style="font-size:38px;font-weight:700;line-height:1.15;margin-top:18px;overflow-wrap:anywhere;${clamp(MAX_TITLE_LINES)}">${escapeHtml(guide.title)}</h1>
+        </div>
+        ${logoHtml}
       </div>
-      ${logoHtml}
+      ${guide.description ? `<p style="font-size:16px;color:#6B7280;line-height:1.6;margin-top:14px;max-width:60ch;overflow-wrap:anywhere;${clamp(MAX_DESC_LINES)}">${escapeHtml(guide.description)}</p>` : ''}
     </div>
     <div style="border-top:2px solid #1E1B4B;padding-top:18px;display:flex;align-items:baseline;">
       <div style="flex:0 0 190px;">
         <div style="font-size:11px;font-weight:700;color:#6B7280;letter-spacing:0.06em;">${i18n.t('export.steps').toUpperCase()}</div>
-        <div style="font-size:38px;font-weight:700;color:${accent};line-height:1;margin-top:2px;">${String(actionSteps(steps).length).padStart(2, '0')}</div>
+        <div style="font-size:38px;font-weight:700;color:${accent};line-height:1;${metaValue}">${String(actionSteps(steps).length).padStart(2, '0')}</div>
       </div>
       ${metaCell(i18n.t('export.created').toUpperCase(), formatDate(guide.createdAt))}
       ${
@@ -149,8 +175,8 @@ export async function exportGuideAsHTML(
       }
     </div>
   </header>`
-    : `<header style="display:flex;align-items:center;gap:16px;margin-bottom:40px;padding-bottom:14px;border-bottom:1px solid #E5E7EB;">
-    <h1 style="flex:1;font-size:20px;font-weight:700;line-height:1.2;">${escapeHtml(guide.title)}</h1>
+    : `<header data-doc-header="true" style="display:flex;align-items:center;gap:16px;margin-bottom:40px;padding-bottom:14px;border-bottom:1px solid #E5E7EB;">
+    <h1 style="flex:1;min-width:0;font-size:20px;font-weight:700;line-height:1.2;overflow-wrap:anywhere;${clamp(1)}">${escapeHtml(guide.title)}</h1>
     ${logoHtml}
   </header>`;
 
@@ -172,6 +198,7 @@ export async function exportGuideAsHTML(
 </head>
 <body>
   ${headerHtml}
+  ${leadHtml}
 
   ${stepSections.join('\n')}
   ${footerHtml}

--- a/src/core/export/page.ts
+++ b/src/core/export/page.ts
@@ -1,0 +1,4 @@
+export const PAGE_MARGIN_MM = 18.5;
+export const HEAD_BAND_MM = 6;
+export const STEP_TOP_MM = PAGE_MARGIN_MM + 10;
+export const CONTENT_BOTTOM_MM = 297 - 24 - 8;

--- a/src/core/export/pdf-export.ts
+++ b/src/core/export/pdf-export.ts
@@ -2,11 +2,26 @@ import { jsPDF } from 'jspdf';
 import { i18n } from '#imports';
 import { fitLogo, loadBranding } from '@/core/export/branding';
 import { type ExportOptions, IMAGE_SCALE_FACTORS, loadExportOptions } from '@/core/export/options';
-import { blobToDataUrl, extractDomain, fitImage, formatDate } from '@/core/export/utils';
+import { CONTENT_BOTTOM_MM, HEAD_BAND_MM, PAGE_MARGIN_MM, STEP_TOP_MM } from '@/core/export/page';
+import {
+  blobToDataUrl,
+  clampLines,
+  containFit,
+  extractDomain,
+  fitImage,
+  formatDate,
+  LEAD_FONT_PX,
+  LEAD_LINE_RATIO,
+  LEAD_MARGIN_PX,
+  MAX_DESC_LINES,
+  MAX_LEAD_LINES,
+  MAX_TITLE_LINES,
+  pxToMm,
+} from '@/core/export/utils';
 import { actionSteps, calloutAccent, isBlock, stepNumbers, tint } from '@/core/guides/blocks';
 import type { Guide, Screenshot, Step } from '@/core/guides/types';
 import { hexToRgb } from '@/core/screenshot/color';
-import { resolveViewport } from '@/core/screenshot/geometry';
+import { dominantRatio, resolveViewport } from '@/core/screenshot/geometry';
 import { renderScreenshot } from '@/core/screenshot/render';
 import { logger } from '@/lib/logger';
 
@@ -14,7 +29,7 @@ const JPEG_QUALITY = 0.85;
 
 const PAGE_W = 210;
 const PAGE_H = 297;
-const MARGIN = 18.5;
+const MARGIN = PAGE_MARGIN_MM;
 const CONTENT_W = PAGE_W - MARGIN * 2;
 const NUM_COL = 22;
 const COL_GAP = 8;
@@ -22,15 +37,26 @@ const TEXT_COL = CONTENT_W - NUM_COL - COL_GAP;
 const TEXT_X = MARGIN + NUM_COL + COL_GAP;
 const RIGHT = PAGE_W - MARGIN;
 const FOOTER_Y = PAGE_H - 24;
-const HEAD_BOTTOM = MARGIN + 6;
-const STEP_TOP = MARGIN + 20;
+const HEAD_BOTTOM = MARGIN + HEAD_BAND_MM;
+const STEP_TOP = STEP_TOP_MM;
 const STEP_GAP = 13;
 const LOGO_MAX_W = 34;
 const LOGO_MAX_H = 15;
 const HEAD_LOGO_W = 18;
-const HEAD_LOGO_H = 7;
+const HEAD_LOGO_H = 5;
+const COVER_RULE_GAP = 8;
+const TITLE_LINE_H = 11;
+const TEXT_LINE_H = 5;
+const LEAD_SIZE = (LEAD_FONT_PX * 72) / 96;
+const LEAD_LINE_H = pxToMm(LEAD_FONT_PX * LEAD_LINE_RATIO);
+const LEAD_BASELINE = 4;
+const LEAD_GAP = pxToMm(LEAD_MARGIN_PX) + LEAD_LINE_H - LEAD_BASELINE;
 const META_COL_W = 43;
 const META_DROP = 9;
+const META_NUM_SIZE = 30;
+const META_VALUE_SIZE = 11;
+const META_CAP_RATIO = 0.7;
+const META_VALUE_LIFT = (((META_NUM_SIZE - META_VALUE_SIZE) * META_CAP_RATIO) / 72) * 25.4 * 0.5;
 const BLOCK_GAP = 9;
 const HEADING_SIZE = 14;
 const HEADING_LINE_H = 6.5;
@@ -66,15 +92,8 @@ export async function exportGuideAsPDF(
   const headLogo = !opts.cover && brand.logo ? fitLogo(brand.logo, HEAD_LOGO_W, HEAD_LOGO_H) : null;
   const headRight = headLogo ? RIGHT - headLogo.width - 4 : RIGHT;
   const imgWidth = TEXT_COL * IMAGE_SCALE_FACTORS[opts.imageScale];
+  const frameRatio = dominantRatio(screenshots);
   if (opts.cover) {
-    if (brand.logo && logo) {
-      try {
-        doc.addImage(brand.logo.dataUrl, 'PNG', RIGHT - logo.width, MARGIN, logo.width, logo.height);
-      } catch (err) {
-        logger.warn('PDF: failed to draw brand logo', err);
-      }
-    }
-
     doc.setFontSize(8);
     doc.setFont('helvetica', 'bold');
     doc.setTextColor(...MUTED);
@@ -82,18 +101,28 @@ export async function exportGuideAsPDF(
 
     doc.setFontSize(30);
     doc.setTextColor(...INK);
-    const titleLines = doc.splitTextToSize(guide.title, CONTENT_W * 0.82);
+    const titleLines = clampLines(doc.splitTextToSize(guide.title, CONTENT_W * 0.82), MAX_TITLE_LINES);
     doc.text(titleLines, MARGIN, MARGIN + 26);
 
-    let y = MARGIN + 26 + (titleLines.length - 1) * 11 + 8;
+    const titleBottom = MARGIN + 26 + (titleLines.length - 1) * TITLE_LINE_H;
+    if (brand.logo && logo) {
+      try {
+        doc.addImage(brand.logo.dataUrl, 'PNG', RIGHT - logo.width, titleBottom - logo.height, logo.width, logo.height);
+      } catch (err) {
+        logger.warn('PDF: failed to draw brand logo', err);
+      }
+    }
+
+    let y = titleBottom + COVER_RULE_GAP;
     if (guide.description) {
       doc.setFontSize(11);
       doc.setFont('helvetica', 'normal');
       doc.setTextColor(...MUTED);
-      const descLines = doc.splitTextToSize(guide.description, CONTENT_W * 0.7);
+      const descLines = clampLines(doc.splitTextToSize(guide.description, CONTENT_W * 0.7), MAX_DESC_LINES);
       doc.text(descLines, MARGIN, y + 4);
-      y += 4 + (descLines.length - 1) * 5 + 8;
+      y += 4 + (descLines.length - 1) * 5 + COVER_RULE_GAP;
     }
+
     doc.setDrawColor(...INK);
     doc.setLineWidth(0.4);
     doc.line(MARGIN, y, RIGHT, y);
@@ -107,25 +136,27 @@ export async function exportGuideAsPDF(
       doc.text(text, x, yLabel, { charSpace: 0.4 });
     };
 
+    const yText = yValue - META_VALUE_LIFT;
+
     drawLabel(i18n.t('export.steps').toUpperCase(), MARGIN);
-    doc.setFontSize(30);
+    doc.setFontSize(META_NUM_SIZE);
     doc.setFont('helvetica', 'bold');
     doc.setTextColor(...accent);
     doc.text(String(actions.length).padStart(2, '0'), MARGIN, yValue);
 
     drawLabel(i18n.t('export.created').toUpperCase(), MARGIN + META_COL_W);
-    doc.setFontSize(11);
+    doc.setFontSize(META_VALUE_SIZE);
     doc.setFont('helvetica', 'normal');
     doc.setTextColor(...INK);
-    doc.text(formatDate(guide.createdAt), MARGIN + META_COL_W, yValue);
+    doc.text(formatDate(guide.createdAt), MARGIN + META_COL_W, yText);
 
     if (domain) {
       const x = MARGIN + META_COL_W * 2;
       drawLabel(i18n.t('export.source').toUpperCase(), x);
-      doc.setFontSize(11);
+      doc.setFontSize(META_VALUE_SIZE);
       doc.setFont('helvetica', 'normal');
       doc.setTextColor(...accent);
-      doc.textWithLink(domain, x, yValue, { url: `https://${domain}` });
+      doc.textWithLink(domain, x, yText, { url: `https://${domain}` });
     }
   }
   const pageSteps: number[][] = [];
@@ -144,7 +175,7 @@ export async function exportGuideAsPDF(
           brand.logo.dataUrl,
           'PNG',
           RIGHT - headLogo.width,
-          HEAD_BOTTOM - 1.5 - headLogo.height,
+          MARGIN + (HEAD_BOTTOM - MARGIN - headLogo.height) / 2,
           headLogo.width,
           headLogo.height,
         );
@@ -160,6 +191,15 @@ export async function exportGuideAsPDF(
 
   let sy = startStepPage();
 
+  if (!opts.cover && guide.description) {
+    doc.setFontSize(LEAD_SIZE);
+    doc.setFont('helvetica', 'normal');
+    doc.setTextColor(...MUTED);
+    const leadLines = clampLines(doc.splitTextToSize(guide.description, CONTENT_W * 0.8), MAX_LEAD_LINES);
+    doc.text(leadLines, MARGIN, sy + LEAD_BASELINE);
+    sy += LEAD_BASELINE + (leadLines.length - 1) * LEAD_LINE_H + LEAD_GAP;
+  }
+
   for (const step of steps) {
     if (isBlock(step)) {
       sy = drawBlock(doc, step, sy, startStepPage);
@@ -173,28 +213,24 @@ export async function exportGuideAsPDF(
 
     const screenshot = opts.screenshots ? screenshots.get(step.id) : undefined;
     let imgDataUrl: string | null = null;
-    let imgHeight = 0;
-    let stepImgWidth = imgWidth;
-    const textOverhead = 6 + descLines.length * 5 + 4;
+    let frame = { width: imgWidth, height: 0 };
+    let img = { width: 0, height: 0, x: 0, y: 0 };
+    const textOverhead = 6 + descLines.length * TEXT_LINE_H + 4;
     if (screenshot) {
       try {
         const rendered = await renderScreenshot(screenshot, { format: 'image/jpeg', quality: JPEG_QUALITY });
         imgDataUrl = await blobToDataUrl(rendered);
         const viewport = resolveViewport(screenshot);
-        const fitted = fitImage(
-          imgWidth,
-          (viewport.height / viewport.width) * imgWidth,
-          FOOTER_Y - 8 - STEP_TOP - textOverhead,
-        );
-        stepImgWidth = fitted.width;
-        imgHeight = fitted.height;
+        const ratio = frameRatio ?? viewport.width / viewport.height;
+        frame = fitImage(imgWidth, imgWidth / ratio, CONTENT_BOTTOM_MM - STEP_TOP - textOverhead);
+        img = containFit(viewport.width, viewport.height, frame.width, frame.height);
       } catch (err) {
         logger.warn('PDF: failed to load screenshot for step', step.index, err);
       }
     }
 
-    const blockH = textOverhead + imgHeight;
-    if (sy + blockH > FOOTER_Y - 8 && sy > STEP_TOP) {
+    const blockH = textOverhead - TEXT_LINE_H + frame.height;
+    if (sy + blockH > CONTENT_BOTTOM_MM && sy > STEP_TOP) {
       sy = startStepPage();
     }
     pageSteps[pageSteps.length - 1].push(numbers.get(step.id) ?? 0);
@@ -240,10 +276,10 @@ export async function exportGuideAsPDF(
 
     let iy = uy + 4;
     if (imgDataUrl) {
-      doc.addImage(imgDataUrl, 'JPEG', TEXT_X, iy, stepImgWidth, imgHeight);
+      doc.addImage(imgDataUrl, 'JPEG', TEXT_X + img.x, iy + img.y, img.width, img.height);
       const altText = screenshot?.edits?.alt || i18n.t('export.stepLabel', [stepNum]);
-      doc.text(doc.splitTextToSize(altText, stepImgWidth), TEXT_X, iy + 4, { renderingMode: 'invisible' });
-      iy += imgHeight;
+      doc.text(doc.splitTextToSize(altText, frame.width), TEXT_X, iy + 4, { renderingMode: 'invisible' });
+      iy += frame.height;
     }
     sy = iy + STEP_GAP;
   }
@@ -283,7 +319,7 @@ function drawBlock(doc: jsPDF, step: Step, y: number, nextPage: () => number): n
     const lines = doc.splitTextToSize(step.description, CONTENT_W);
     const blockH = HEADING_BASELINE + (lines.length - 1) * HEADING_LINE_H + HEADING_RULE_GAP;
     let sy = y;
-    if (sy + blockH > FOOTER_Y - 8 && sy > STEP_TOP) sy = nextPage();
+    if (sy + blockH > CONTENT_BOTTOM_MM && sy > STEP_TOP) sy = nextPage();
     doc.setTextColor(...INK);
     doc.text(lines, MARGIN, sy + HEADING_BASELINE);
     const ruleY = sy + blockH;
@@ -302,7 +338,7 @@ function drawBlock(doc: jsPDF, step: Step, y: number, nextPage: () => number): n
   const lines = doc.splitTextToSize(step.description, RIGHT - CALLOUT_PAD_X - textX);
   const boxH = CALLOUT_PAD_Y * 2 + lines.length * CALLOUT_LINE_H;
   let sy = y;
-  if (sy + boxH > FOOTER_Y - 8 && sy > STEP_TOP) sy = nextPage();
+  if (sy + boxH > CONTENT_BOTTOM_MM && sy > STEP_TOP) sy = nextPage();
   doc.setFillColor(...fill);
   doc.roundedRect(MARGIN, sy, CONTENT_W, boxH, CALLOUT_RADIUS, CALLOUT_RADIUS, 'F');
   doc.setFillColor(...bar);

--- a/src/core/export/preview.ts
+++ b/src/core/export/preview.ts
@@ -1,3 +1,5 @@
+import { CONTENT_BOTTOM_MM, HEAD_BAND_MM, PAGE_MARGIN_MM, STEP_TOP_MM } from '@/core/export/page';
+
 const PREVIEW_CSS = `
   html { background: #3F3F46; }
   body {
@@ -17,14 +19,39 @@ const PREVIEW_CSS = `
     flex-shrink: 0;
   }
   .mimik-sheet-body {
-    padding: 18.5mm 18.5mm 0;
-    height: calc(297mm - 34mm);
+    padding: ${STEP_TOP_MM}mm ${PAGE_MARGIN_MM}mm 0;
+    height: ${CONTENT_BOTTOM_MM}mm;
     overflow: hidden;
+  }
+  .mimik-sheet-body.mimik-sheet-cover { padding-top: ${PAGE_MARGIN_MM}mm; }
+  .mimik-sheet-head {
+    position: absolute;
+    left: ${PAGE_MARGIN_MM}mm;
+    right: ${PAGE_MARGIN_MM}mm;
+    top: ${PAGE_MARGIN_MM}mm;
+    height: ${HEAD_BAND_MM}mm;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 11px;
+    font-weight: 700;
+    color: #1E1B4B;
+    border-bottom: 1px solid #E5E7EB;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+  .mimik-sheet-head .mimik-head-title { overflow: hidden; text-overflow: ellipsis; }
+  .mimik-sheet-head img {
+    width: 18mm;
+    height: 5mm;
+    object-fit: contain;
+    object-position: right center;
+    margin-left: auto;
   }
   .mimik-sheet-foot {
     position: absolute;
-    left: 18.5mm;
-    right: 18.5mm;
+    left: ${PAGE_MARGIN_MM}mm;
+    right: ${PAGE_MARGIN_MM}mm;
     bottom: 11mm;
     display: flex;
     align-items: center;
@@ -36,7 +63,6 @@ const PREVIEW_CSS = `
   }
   .mimik-sheet-foot .mimik-page { margin-left: auto; }
   .mimik-sheet-body > *:last-child { margin-bottom: 0 !important; }
-  .mimik-sheet-body section { margin-bottom: 34px !important; }
   .mimik-sheet-body header { margin-bottom: 34px !important; }
 `;
 
@@ -50,16 +76,22 @@ export function paginatePreview(doc: Document): number {
 
   const blocks: HTMLElement[] = [];
   let footer: HTMLElement | null = null;
+  let header: HTMLElement | null = null;
 
   for (const node of Array.from(body.children)) {
     if (!(node instanceof doc.defaultView!.HTMLElement)) continue;
     if (node.tagName === 'SCRIPT' || node.tagName === 'STYLE') continue;
     if (node.hasAttribute('data-doc-footer')) footer = node;
+    else if (node.hasAttribute('data-doc-header')) header = node;
     else blocks.push(node);
   }
 
   for (const node of blocks) node.remove();
   footer?.remove();
+  header?.remove();
+
+  const headTitle = header?.querySelector('h1')?.textContent ?? doc.title;
+  const headLogo = header?.querySelector('img') ?? null;
 
   const stack = doc.createElement('div');
   stack.className = 'mimik-sheets';
@@ -80,6 +112,7 @@ export function paginatePreview(doc: Document): number {
   let current = addSheet();
   for (const block of blocks) {
     if (block.hasAttribute('data-cover')) {
+      current.classList.add('mimik-sheet-cover');
       current.appendChild(block);
       current = addSheet();
       continue;
@@ -98,6 +131,17 @@ export function paginatePreview(doc: Document): number {
   }
 
   bodies.forEach((inner, index) => {
+    if (!inner.classList.contains('mimik-sheet-cover')) {
+      const head = doc.createElement('div');
+      head.className = 'mimik-sheet-head';
+      const title = doc.createElement('span');
+      title.className = 'mimik-head-title';
+      title.textContent = headTitle;
+      head.appendChild(title);
+      if (headLogo) head.appendChild(headLogo.cloneNode(true));
+      inner.parentElement?.appendChild(head);
+    }
+
     const foot = doc.createElement('div');
     foot.className = 'mimik-sheet-foot';
     if (footer) {

--- a/src/core/export/utils.ts
+++ b/src/core/export/utils.ts
@@ -71,3 +71,35 @@ export function fitImage(width: number, height: number, maxHeight: number): { wi
   if (!Number.isFinite(height) || height <= 0 || height <= maxHeight) return { width, height };
   return { width: width * (maxHeight / height), height: maxHeight };
 }
+
+export const MAX_TITLE_LINES = 3;
+export const MAX_DESC_LINES = 4;
+export const MAX_LEAD_LINES = 2;
+
+export function clampLines(lines: string[], max: number): string[] {
+  if (lines.length <= max) return lines;
+  const kept = lines.slice(0, max);
+  kept[max - 1] = `${kept[max - 1].replace(/\s+$/, '')}…`;
+  return kept;
+}
+
+export const LEAD_FONT_PX = 13;
+export const LEAD_LINE_RATIO = 1.5;
+export const LEAD_MARGIN_PX = 14;
+
+export function pxToMm(px: number): number {
+  return (px * 25.4) / 96;
+}
+
+export function containFit(
+  srcWidth: number,
+  srcHeight: number,
+  boxWidth: number,
+  boxHeight: number,
+): { width: number; height: number; x: number; y: number } {
+  if (!(srcWidth > 0) || !(srcHeight > 0)) return { width: boxWidth, height: boxHeight, x: 0, y: 0 };
+  const scale = Math.min(boxWidth / srcWidth, boxHeight / srcHeight);
+  const width = srcWidth * scale;
+  const height = srcHeight * scale;
+  return { width, height, x: (boxWidth - width) / 2, y: (boxHeight - height) / 2 };
+}

--- a/src/core/screenshot/__tests__/dominant-ratio.test.ts
+++ b/src/core/screenshot/__tests__/dominant-ratio.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Screenshot } from '@/core/guides/types';
-import { dominantRatio } from '@/ui/shared/ImagePlaceholder';
+import { dominantRatio } from '@/core/screenshot/geometry';
 
 function makeScreenshot(id: string, overrides: Partial<Screenshot> = {}): Screenshot {
   return {

--- a/src/core/screenshot/geometry.ts
+++ b/src/core/screenshot/geometry.ts
@@ -54,6 +54,28 @@ export function resolveViewport(screenshot: Screenshot): ScreenshotBounds {
   };
 }
 
+const RATIO_BUCKET_PRECISION = 100;
+
+export function dominantRatio(screenshots: Map<string, Screenshot>): number | undefined {
+  const buckets = new Map<number, { ratio: number; count: number }>();
+
+  for (const screenshot of screenshots.values()) {
+    const viewport = resolveViewport(screenshot);
+    if (!viewport.width || !viewport.height) continue;
+    const ratio = viewport.width / viewport.height;
+    const key = Math.round(ratio * RATIO_BUCKET_PRECISION) / RATIO_BUCKET_PRECISION;
+    const bucket = buckets.get(key);
+    if (bucket) bucket.count += 1;
+    else buckets.set(key, { ratio, count: 1 });
+  }
+
+  let winner: { ratio: number; count: number } | undefined;
+  for (const bucket of buckets.values()) {
+    if (!winner || bucket.count > winner.count) winner = bucket;
+  }
+  return winner?.ratio;
+}
+
 const MIN_VIEWPORT = 40;
 const MIN_ANNOTATION = 8;
 

--- a/src/ui/fullview/GuideContent.tsx
+++ b/src/ui/fullview/GuideContent.tsx
@@ -122,15 +122,18 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
       document.title = `${newTitle} — ${i18n.t('app_name')}`;
       setGuideTitle(newTitle);
       setGuideStepCount(actionSteps(result.steps).length);
-      setGuideExportData({ guideId, ...result });
     }
     setLoading(false);
-  }, [guideId, setGuideTitle, setGuideStepCount, setGuideExportData]);
+  }, [guideId, setGuideTitle, setGuideStepCount]);
 
   useEffect(() => {
     loadGuide();
     return onGuidesChanged(() => loadGuide());
   }, [loadGuide]);
+
+  useEffect(() => {
+    if (data) setGuideExportData({ guideId, ...data });
+  }, [data, guideId, setGuideExportData]);
 
   useEffect(() => {
     localStorage.get(['aiApiKey']).then((s) => setHasApiKey(Boolean(s.aiApiKey)));

--- a/src/ui/fullview/components/GuideStepList.tsx
+++ b/src/ui/fullview/components/GuideStepList.tsx
@@ -4,6 +4,7 @@ import { i18n } from '#imports';
 import { isBlock, stepNumbers } from '@/core/guides/blocks';
 import { createSnapshot, deleteSteps, insertBlock, reorderSteps } from '@/core/guides/service';
 import type { BlockType, Screenshot, Step } from '@/core/guides/types';
+import { dominantRatio } from '@/core/screenshot/geometry';
 import { logger } from '@/lib/logger';
 import { useFullview } from '@/stores/fullview';
 import { Button } from '@/ui/components/ui/button';
@@ -11,7 +12,6 @@ import BlockCard from '@/ui/shared/BlockCard';
 import CaptureTabDialog from '@/ui/shared/CaptureTabDialog';
 import ConfirmDialog from '@/ui/shared/ConfirmDialog';
 import EmptyGuideState from '@/ui/shared/EmptyGuideState';
-import { dominantRatio } from '@/ui/shared/ImagePlaceholder';
 import InsertBlockMenu from '@/ui/shared/InsertBlockMenu';
 import StepCard from '@/ui/sidepanel/StepCard';
 

--- a/src/ui/shared/ImagePlaceholder.tsx
+++ b/src/ui/shared/ImagePlaceholder.tsx
@@ -1,8 +1,6 @@
 import { ImageUp } from 'lucide-react';
 import { useState } from 'react';
 import { i18n } from '#imports';
-import type { Screenshot } from '@/core/guides/types';
-import { resolveViewport } from '@/core/screenshot/geometry';
 import MascotIcon from '@/ui/shared/MascotIcon';
 import ReplaceImageDialog from '@/ui/shared/ReplaceImageDialog';
 
@@ -52,26 +50,4 @@ export default function ImagePlaceholder({
       )}
     </div>
   );
-}
-
-const RATIO_BUCKET_PRECISION = 100;
-
-export function dominantRatio(screenshots: Map<string, Screenshot>): number | undefined {
-  const buckets = new Map<number, { ratio: number; count: number }>();
-
-  for (const screenshot of screenshots.values()) {
-    const viewport = resolveViewport(screenshot);
-    if (!viewport.width || !viewport.height) continue;
-    const ratio = viewport.width / viewport.height;
-    const key = Math.round(ratio * RATIO_BUCKET_PRECISION) / RATIO_BUCKET_PRECISION;
-    const bucket = buckets.get(key);
-    if (bucket) bucket.count += 1;
-    else buckets.set(key, { ratio, count: 1 });
-  }
-
-  let winner: { ratio: number; count: number } | undefined;
-  for (const bucket of buckets.values()) {
-    if (!winner || bucket.count > winner.count) winner = bucket;
-  }
-  return winner?.ratio;
 }

--- a/src/ui/sidepanel/GuideEditor.tsx
+++ b/src/ui/sidepanel/GuideEditor.tsx
@@ -4,6 +4,7 @@ import { i18n } from '#imports';
 import { actionSteps, isBlock, stepNumbers } from '@/core/guides/blocks';
 import { getGuide, onGuidesChanged } from '@/core/guides/service';
 import type { Guide, Screenshot, Step } from '@/core/guides/types';
+import { dominantRatio } from '@/core/screenshot/geometry';
 import { createTab, focusWindow, getExtensionURL, queryTabs, updateTab } from '@/lib/browser-api';
 import { sendMessage } from '@/lib/messaging';
 import { getMostCommonDomain } from '@/lib/utils';
@@ -11,7 +12,6 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/components/ui/tool
 import BlockCard from '@/ui/shared/BlockCard';
 import EmptyGuideState from '@/ui/shared/EmptyGuideState';
 import FaviconImg from '@/ui/shared/FaviconImg';
-import { dominantRatio } from '@/ui/shared/ImagePlaceholder';
 import StepCard from './StepCard';
 
 interface GuideEditorProps {


### PR DESCRIPTION
PDF pagination derived each block's height from its own screenshot ratio, so mixing a 16:9 capture with a square upload stranded one step per page behind ~130mm of whitespace. Screenshots are now framed to the guide's dominant ratio — the frame the editor already draws.

The preview was a second layout that matched the PDF only by luck. It now draws the same running head and shares page geometry through `core/export/page.ts`, so breaks match by construction.

Also caps titles and descriptions rather than letting them run off the sheet, keeps the description when the cover is off, and stops a stale title reaching the export.

Still approximate: multi-line step captions advance 5mm/line in the PDF and 6.52mm in HTML, so a long one can split differently.

`pnpm lint`, 910 tests, Chrome and Firefox builds, plus a headless sweep matching preview pagination to the PDF across 48 cases.
