### PR TITLE
fix(editor): keep the click target pulsing while it is selected

### DIFF
--- a/src/ui/shared/AnnotationEditor.tsx
+++ b/src/ui/shared/AnnotationEditor.tsx
@@ -496,7 +496,7 @@ export default function AnnotationEditor({ screenshot, tool, onDone, onCancel }:
     ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
 
     for (const a of annotations) {
-      if (a.type === 'target' && a.id !== selectedId) {
+      if (a.type === 'target') {
         const gradient = ctx.createConicGradient(pulse * Math.PI * 2, a.x + a.w / 2, a.y + a.h / 2);
         for (const [stop, v, s] of TARGET_SWEEP) gradient.addColorStop(stop, shadeOf(a.color, v, s));
         ctx.save();


### PR DESCRIPTION
Opening a step in the screenshot editor pulsed the captured click target — a conic sweep with marching dashes — but only while nothing was selected. Dragging the target requires selecting it first, so the pulse stopped on the drag and never returned after undo: `undo` restores the annotations and never touches `selectedId`. Only a click on empty canvas revived it. The same gate meant the pulse never appeared at all when the editor opens from the target tool, which preselects the target.

The pulse now reads as a persistent "this is the captured element" marker rather than an on-entry cue — the target always draws animated, and the selection box and handles layer over it. Undo and redo are left alone.

`pnpm lint`, 910 tests, and the Chrome and Firefox builds all clean.
