### PR TITLE
fix(manifest): declare the data collection mimik actually performs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimik",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "packageManager": "pnpm@10.32.1",

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -3,8 +3,8 @@ meta:
 
 app:
   name: Mimik
-  store_title: "Mimik: Schritt-für-Schritt-Anleitungen, Tutorials & Screenshots"
-  description: Erfasse jeden Browser-Workflow automatisch als Schritt-für-Schritt-Anleitung mit Screenshots. Local-first, Open Source, eigener KI-Schlüssel.
+  store_title: "Mimik: Schritt-für-Schritt-Anleitungen"
+  description: "Nimm jeden Browser-Workflow als Schritt-für-Schritt-Anleitung auf. Bearbeiten, vertonen, als Video, PDF oder DOCX exportieren."
 
 common:
   loading: Wird geladen...

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -3,8 +3,8 @@ meta:
 
 app:
   name: Mimik
-  store_title: "Mimik: Step-by-Step Guides, Tutorials & Screenshots"
-  description: Auto-capture any browser workflow into a step-by-step guide with screenshots. Local-first, open source, bring your own AI key.
+  store_title: "Mimik: Step-by-Step Guides & Tutorials"
+  description: "Record any browser workflow as a step-by-step guide. Edit, voice-narrate, export to video, PDF or DOCX. Local-first, open source."
 
 common:
   loading: Loading...

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -3,8 +3,8 @@ meta:
 
 app:
   name: Mimik
-  store_title: "Mimik: guías paso a paso, tutoriales y capturas"
-  description: Convierte cualquier tarea del navegador en una guía paso a paso con capturas. Local, código abierto, con tu propia clave de IA.
+  store_title: "Mimik: guías paso a paso y tutoriales"
+  description: "Graba cualquier tarea del navegador como una guía paso a paso. Edita, narra con voz y exporta a vídeo, PDF o DOCX. Código abierto."
 
 common:
   loading: Cargando...

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -3,8 +3,8 @@ meta:
 
 app:
   name: Mimik
-  store_title: "Mimik : guides pas-à-pas, tutoriels et captures"
-  description: "Transformez toute tâche dans le navigateur en guide pas-à-pas avec captures. Local, open source, avec votre propre clé IA."
+  store_title: "Mimik : guides pas-à-pas et tutoriels"
+  description: "Enregistrez toute tâche du navigateur en guide pas-à-pas. Éditez, narrez à la voix, exportez en vidéo, PDF ou DOCX. Open source."
 
 common:
   loading: "Chargement..."

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -3,8 +3,8 @@ meta:
 
 app:
   name: Mimik
-  store_title: "Mimik: guias passo a passo, tutoriais e prints"
-  description: Capture qualquer tarefa do navegador em um guia passo a passo com prints. Local, código aberto, com sua própria chave de IA.
+  store_title: "Mimik: guias passo a passo e tutoriais"
+  description: "Grave qualquer tarefa do navegador como um guia passo a passo. Edite, narre com voz e exporte em vídeo, PDF ou DOCX. Código aberto."
 
 common:
   loading: Carregando...

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -72,7 +72,11 @@ export default defineConfig({
                 id: "mimik@westpoint.io",
                 strict_min_version: "128.0",
                 data_collection_permissions: {
-                  required: ["none"],
+                  required: ["websiteActivity"],
+                  optional: [
+                    "websiteContent",
+                    "personallyIdentifyingInfo",
+                  ],
                 },
               },
             },


### PR DESCRIPTION
The manifest claimed `data_collection_permissions: {required: ["none"]}` — no data transmitted. That was never true. `FaviconImg` fetches each recorded site's icon from Google's favicon service, sending that domain to `t1.gstatic.com` on every view that lists guides, with no setting gating it. Unconditional `websiteActivity`, so it belongs in `required`.

Declared rather than removed: real favicons are worth the install-time notice. Removing the lookup, or making it opt-in, would let `required` go back to `["none"]` later — the optional list is unaffected either way.

`optional` covers the key-gated transmissions: DOM context and step URLs to OpenAI/Anthropic, microphone audio to OpenAI/Groq.

The extension name was over the 45-character store limit in all five locales, and the descriptions predated voice narration and video/DOCX export.

910 tests, typecheck, addons-linter clean.