### PR TITLE
fix(video): draw the cursor on the first frame of an exported video

### DIFF
--- a/src/core/export/__tests__/video-export.test.ts
+++ b/src/core/export/__tests__/video-export.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
 import {
+  CURSOR_ENTRY_ORIGIN,
+  cursorOriginFor,
   cursorProgress,
   cursorScale,
   easeInOut,
@@ -631,5 +633,29 @@ describe('tooltipPlacement', () => {
     const at = tooltipPlacement({ x: 500, y: FRAME_HEIGHT, width: 0, height: 0 }, tooltip);
     expect(at.y).toBeGreaterThanOrEqual(20);
     expect(at.y + tooltip.height).toBeLessThanOrEqual(FRAME_HEIGHT - 20);
+  });
+});
+
+describe('cursorOriginFor', () => {
+  const at = (targets: Record<number, { x: number; y: number }>) => (i: number) => targets[i] ?? null;
+
+  it('starts from the previous frame target', () => {
+    expect(cursorOriginFor(1, at({ 0: { x: 0.2, y: 0.3 } }))).toEqual({ x: 0.2, y: 0.3 });
+  });
+
+  it('skips earlier frames that have no target', () => {
+    expect(cursorOriginFor(2, at({ 0: { x: 0.1, y: 0.9 } }))).toEqual({ x: 0.1, y: 0.9 });
+  });
+
+  it('falls back to the entry origin on the first frame', () => {
+    expect(cursorOriginFor(0, at({}))).toEqual(CURSOR_ENTRY_ORIGIN);
+  });
+
+  it('falls back to the entry origin when no earlier frame has a target', () => {
+    expect(cursorOriginFor(3, at({}))).toEqual(CURSOR_ENTRY_ORIGIN);
+  });
+
+  it('places the entry origin below the frame so the cursor travels in', () => {
+    expect(CURSOR_ENTRY_ORIGIN.y).toBeGreaterThan(1);
   });
 });

--- a/src/core/export/video-export.ts
+++ b/src/core/export/video-export.ts
@@ -333,13 +333,23 @@ interface Point {
   y: number;
 }
 
+export const CURSOR_ENTRY_ORIGIN: Point = { x: 0.5, y: 1.08 };
+
+export function cursorOriginFor(index: number, targetAt: (i: number) => Point | null): Point {
+  for (let i = index - 1; i >= 0; i--) {
+    const behind = targetAt(i);
+    if (behind) return behind;
+  }
+  return CURSOR_ENTRY_ORIGIN;
+}
+
 interface ScreenshotLayer {
   kind: 'screenshot';
   bitmap: ImageBitmap;
   fit: ReturnType<typeof letterbox>;
   target: Rect | null;
   ring: { color: string; dashed: boolean } | null;
-  from: Point | null;
+  from: Point;
   description: string;
 }
 
@@ -416,7 +426,7 @@ export function normalizedTargetCenter(screenshot: Screenshot): Point | null {
   };
 }
 
-async function loadScreenshotLayer(step: Step, screenshot: Screenshot, from: Point | null): Promise<ScreenshotLayer> {
+async function loadScreenshotLayer(step: Step, screenshot: Screenshot, from: Point): Promise<ScreenshotLayer> {
   const viewport = resolveFrameViewport(screenshot);
   const rendered = await renderScreenshot(screenshot, { ...RENDER_OPTIONS, viewport, target: false });
   const bitmap = await createImageBitmap(rendered);
@@ -437,7 +447,7 @@ async function loadScreenshotLayer(step: Step, screenshot: Screenshot, from: Poi
         }
       : null,
     ring: target ? { color: target.color, dashed: target.border === 'dashed' } : null,
-    from: from ? { x: from.x * bitmap.width, y: from.y * bitmap.height } : null,
+    from: { x: from.x * bitmap.width, y: from.y * bitmap.height },
     description: step.description,
   };
 }
@@ -573,7 +583,7 @@ function drawStepFrame(ctx: Ctx, layer: StepLayer, frame: number, device: Size) 
     ctx.restore();
   }
 
-  if (layer.target && layer.from) {
+  if (layer.target) {
     const travel = easeInOut(cursorProgress(frame));
     const tip = project(
       layer.from.x + (layer.target.x + layer.target.width * 0.42 - layer.from.x) * travel,
@@ -756,12 +766,9 @@ export async function exportGuideAsVideo(
     return undefined;
   };
 
-  const cursorOriginFor = (index: number) => {
-    for (let i = index - 1; i >= 0; i--) {
-      const behind = screenshots.get(frames[i].id);
-      if (behind) return normalizedTargetCenter(behind);
-    }
-    return null;
+  const targetAt = (index: number) => {
+    const behind = screenshots.get(frames[index].id);
+    return behind ? normalizedTargetCenter(behind) : null;
   };
 
   const layerAt = async (index: number) => {
@@ -770,7 +777,7 @@ export async function exportGuideAsVideo(
     const step = frames[index];
     const layer = isBlock(step)
       ? await loadBlockLayer(step, backdropFor(index))
-      : await loadScreenshotLayer(step, screenshots.get(step.id) as Screenshot, cursorOriginFor(index));
+      : await loadScreenshotLayer(step, screenshots.get(step.id) as Screenshot, cursorOriginFor(index, targetAt));
     if (layer.kind === 'screenshot' && !options.stepDescriptions) layer.description = '';
     loaded.set(index, layer);
     return layer;


### PR DESCRIPTION
In an exported video the first step drew its ring and tooltip but no cursor, while every later step had one.

The cursor is modelled as travel between two points — the previous step's target to this one's. `cursorOriginFor` scanned backwards from `index - 1`, so at index 0 it returned `null`, `layer.from` was null, and the draw guard skipped `drawCursor` along with the click press. Not strictly step 1: content blocks count as frames but carry no target, so a guide opening with a heading lost its first real step too.

The first frame now falls back to an entry origin below the frame — `y: 1.08`, outside the 0–1 range real targets are clamped to — so the cursor glides up and presses like everywhere else. Pulling it out of the closure made it testable, and `from` can no longer be null, so that plumbing is gone.

915 tests, typecheck, both targets build.