### PR TITLE
docs(readme): cover voice narration, the editor, and the new export formats

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -50,7 +50,7 @@ Le das a grabar, haces lo tuyo, y obtienes una guía pulida con capturas anotada
 ## 📺 Demo
 
 <div align="center">
-<img src="public/demo.gif" alt="Demo de Mimik" width="800" />
+<img src="https://github.com/user-attachments/assets/9de20b45-2256-4127-8242-141cf1802f39" alt="Demo de Mimik" width="800" />
 </div>
 
 ## 👋 Empezar
@@ -109,6 +109,8 @@ Mimik detecta y difumina datos sensibles automáticamente en tus capturas: corre
 
 ¿Necesitas ocultar algo personalizado? El selector manual te deja elegir cualquier elemento del DOM y enmascararlo en todas las capturas donde aparezca.
 
+<img src="https://github.com/user-attachments/assets/968d2518-c561-4d68-92a6-3d5f569fe38a" alt="Smart Blur" width="800" />
+
 <div align="right">
 
 [![Back to top][back-to-top]](#readme-top)
@@ -121,6 +123,8 @@ Trae tu propia API key (OpenAI o Anthropic) y Mimik genera descripciones natural
 
 Las descripciones se generan a partir de un contexto ligero del DOM (~50-100 tokens), no desde capturas. Unas 15-30 veces más barato que los modelos con visión. Elige el idioma de las descripciones (inglés, español, portugués, francés).
 
+<img src="https://github.com/user-attachments/assets/3540cbd5-133f-46fd-a9b6-ffce9b4d422a" alt="Descripciones con IA" width="800" />
+
 <div align="right">
 
 [![Back to top][back-to-top]](#readme-top)
@@ -130,6 +134,8 @@ Las descripciones se generan a partir de un contexto ligero del DOM (~50-100 tok
 ### ▶️ Reproducción Guide Me
 
 Reproduce cualquier guía en vivo sobre una página real. Mimik resalta el siguiente elemento, marca tu progreso paso a paso, y avanza solo conforme vas interactuando. Ideal para formar a un compañero o para guiarte a ti mismo.
+
+<img src="https://github.com/user-attachments/assets/56ffca1d-5074-491f-8571-dd70782d4b05" alt="Reproducción Guide Me" width="800" />
 
 <div align="right">
 
@@ -146,6 +152,8 @@ Comparte tus guías en el formato que mejor encaje con tu flujo:
 - **Markdown**: pega en Notion, GitHub, documentación interna, wikis
 
 Todas las exportaciones se generan del lado del cliente. Nada pasa por un servidor.
+
+<img src="https://github.com/user-attachments/assets/e7584527-7d68-4f3f-9261-8380ee08dfb4" alt="Exportación multi-formato" width="800" />
 
 <div align="right">
 

--- a/README.es.md
+++ b/README.es.md
@@ -32,16 +32,13 @@ Le das a grabar, haces lo tuyo, y obtienes una guía pulida con capturas anotada
 - [📺 Demo](#-demo)
 - [👋 Empezar](#-empezar)
 - [✨ Funciones](#-funciones)
-  - [🎬 Captura automática](#-captura-automática)
-  - [📸 Capturas anotadas](#-capturas-anotadas)
   - [🔒 Smart Blur](#-smart-blur)
   - [🧠 Descripciones con IA (opcional)](#-descripciones-con-ia-opcional)
   - [▶️ Reproducción Guide Me](#️-reproducción-guide-me)
   - [🎙️ Narración por voz (opcional)](#️-narración-por-voz-opcional)
   - [✏️ Editor de guías](#️-editor-de-guías)
   - [📤 Exportación multi-formato](#-exportación-multi-formato)
-  - [🌍 Multi-idioma](#-multi-idioma)
-  - [💾 Almacenamiento local primero](#-almacenamiento-local-primero)
+- [🔐 Privacidad y almacenamiento](#-privacidad-y-almacenamiento)
 - [🤝 Contribuir](#-contribuir)
 - [📜 Licencia](#-licencia)
 
@@ -61,11 +58,17 @@ Mimik convierte cualquier tarea repetitiva del navegador en una guía documentad
 
 Ya sea que estés documentando herramientas internas, escribiendo tutoriales de producto, o formando a un compañero, Mimik captura cada clic, tecla y navegación automáticamente para que te concentres en lo importante.
 
+Cada acción relevante se convierte en un paso: clics en botones y enlaces, campos de formulario, atajos de teclado, acciones del portapapeles, arrastres y navegaciones. Los clics rápidos sobre elementos cercanos se agrupan para que las guías queden limpias, y el clic se intercepta antes de que la página navegue, así no se pierde nada en SPAs ni en cargas completas.
+
+Cada paso lleva una captura con el elemento pulsado resaltado y ampliado. Sin recortar a mano, sin herramientas de anotación que aprender.
+
 | Navegador | Versión | Instalación |
 | --------- | ------- | ----------- |
 | Chrome    | [![Chrome Version][chrome-version-shield]][chrome-link]   | [Chrome Web Store][chrome-link] |
 | Firefox   | [![Firefox Version][firefox-version-shield]][firefox-link] | [Firefox Add-ons][firefox-link]  |
 | Edge      | [![Edge Version][edge-version-shield]][edge-link]          | [Microsoft Edge Add-ons][edge-link] |
+
+Disponible en inglés, español, portugués brasileño, francés y alemán. El idioma de las descripciones de IA se configura por separado, así que puedes usar Mimik en inglés y generar guías en español, o cualquier combinación.
 
 > \[!IMPORTANT]
 >
@@ -82,28 +85,6 @@ Ya sea que estés documentando herramientas internas, escribiendo tutoriales de 
 </div>
 
 ## ✨ Funciones
-
-### 🎬 Captura automática
-
-Haces clic, escribes, navegas. Mimik lo ve todo. Cada acción relevante se convierte en un paso: clics en botones y enlaces, entradas de formulario, atajos de teclado, portapapeles, arrastrar y soltar, y navegaciones.
-
-La fusión inteligente de eventos descarta los clics rápidos en elementos cercanos, para que tus guías queden limpias. La interceptación del clic ocurre *antes* de que la página cambie, así no se pierde nada en SPAs o recargas completas.
-
-<div align="right">
-
-[![Back to top][back-to-top]](#readme-top)
-
-</div>
-
-### 📸 Capturas anotadas
-
-Cada paso recibe una captura con el elemento resaltado y un zoom al área importante. Sin recortar a mano, sin aprender herramientas de anotación. Mimik descubre qué parte de la página importa y te la enmarca.
-
-<div align="right">
-
-[![Back to top][back-to-top]](#readme-top)
-
-</div>
 
 ### 🔒 Smart Blur
 
@@ -193,17 +174,7 @@ Todas las exportaciones se generan del lado del cliente. Nada pasa por un servid
 
 </div>
 
-### 🌍 Multi-idioma
-
-Interfaz disponible en inglés, español, portugués brasileño, francés y alemán. El idioma de las descripciones de IA se configura por separado, así que puedes usar Mimik en inglés y generar guías en español, o cualquier combinación.
-
-<div align="right">
-
-[![Back to top][back-to-top]](#readme-top)
-
-</div>
-
-### 💾 Almacenamiento local primero
+## 🔐 Privacidad y almacenamiento
 
 Tus guías, pasos y capturas viven en tu dispositivo. No hay backend, no hay cuenta, no hay telemetría. Tus API keys (si usas alguna) nunca salen del navegador. Se guardan localmente y se usan para llamar directo al proveedor que elegiste.
 

--- a/README.es.md
+++ b/README.es.md
@@ -37,9 +37,11 @@ Le das a grabar, haces lo tuyo, y obtienes una guía pulida con capturas anotada
   - [🔒 Smart Blur](#-smart-blur)
   - [🧠 Descripciones con IA (opcional)](#-descripciones-con-ia-opcional)
   - [▶️ Reproducción Guide Me](#️-reproducción-guide-me)
+  - [🎙️ Narración por voz (opcional)](#️-narración-por-voz-opcional)
+  - [✏️ Editor de guías](#️-editor-de-guías)
   - [📤 Exportación multi-formato](#-exportación-multi-formato)
   - [🌍 Multi-idioma](#-multi-idioma)
-  - [💾 Almacenamiento 100% local](#-almacenamiento-100-local)
+  - [💾 Almacenamiento local primero](#-almacenamiento-local-primero)
 - [🤝 Contribuir](#-contribuir)
 - [📜 Licencia](#-licencia)
 
@@ -143,12 +145,42 @@ Reproduce cualquier guía en vivo sobre una página real. Mimik resalta el sigui
 
 </div>
 
+### 🎙️ Narración por voz (opcional)
+
+Habla en voz alta mientras grabas y Mimik convierte lo que dijiste en las descripciones de los
+pasos. El audio se transcribe con tu propia key (OpenAI o Groq) y se empareja con el paso al que
+corresponde, así narras una vez en lugar de escribir cada paso a mano.
+
+<img src="https://github.com/user-attachments/assets/061fddc7-da65-4641-8b39-d30b80c36531" alt="Narración por voz" width="800" />
+
+<div align="right">
+
+[![Back to top][back-to-top]](#readme-top)
+
+</div>
+
+### ✏️ Editor de guías
+
+Arregla una guía después sin volver a grabar. Recorta, anota y censura cualquier captura, reescribe
+un paso con IA sin salir del editor, mete títulos y notas entre pasos, reordena o borra en lote, y
+vuelve atrás con el historial de versiones.
+
+<img src="https://github.com/user-attachments/assets/62d3a01e-b129-44c8-8ba3-e9b97ff08d7e" alt="Editor de guías" width="800" />
+
+<div align="right">
+
+[![Back to top][back-to-top]](#readme-top)
+
+</div>
+
 ### 📤 Exportación multi-formato
 
 Comparte tus guías en el formato que mejor encaje con tu flujo:
 
-- **HTML**: autónomo, comparte donde sea, imágenes embebidas en base64
+- **Video**: recorrido narrado, mp4/H.264, con el cursor moviéndose a cada objetivo
 - **PDF**: listo para imprimir, A4 vertical con saltos automáticos
+- **DOCX**: ábrelo y sigue editando en Word
+- **HTML**: autónomo, comparte donde sea, imágenes embebidas en base64
 - **Markdown**: pega en Notion, GitHub, documentación interna, wikis
 
 Todas las exportaciones se generan del lado del cliente. Nada pasa por un servidor.
@@ -163,7 +195,7 @@ Todas las exportaciones se generan del lado del cliente. Nada pasa por un servid
 
 ### 🌍 Multi-idioma
 
-Interfaz disponible en inglés, español, portugués brasileño y francés. El idioma de las descripciones de IA se configura por separado, así que puedes usar Mimik en inglés y generar guías en español, o cualquier combinación.
+Interfaz disponible en inglés, español, portugués brasileño, francés y alemán. El idioma de las descripciones de IA se configura por separado, así que puedes usar Mimik en inglés y generar guías en español, o cualquier combinación.
 
 <div align="right">
 
@@ -171,9 +203,11 @@ Interfaz disponible en inglés, español, portugués brasileño y francés. El i
 
 </div>
 
-### 💾 Almacenamiento 100% local
+### 💾 Almacenamiento local primero
 
-Tus guías, pasos y capturas viven en tu dispositivo. No hay backend, no hay cuenta, no hay telemetría. Tus API keys (si usas alguna) nunca salen del navegador. Se guardan localmente y se envían directo al proveedor que elegiste.
+Tus guías, pasos y capturas viven en tu dispositivo. No hay backend, no hay cuenta, no hay telemetría. Tus API keys (si usas alguna) nunca salen del navegador. Se guardan localmente y se usan para llamar directo al proveedor que elegiste.
+
+Dos cosas sí salen del navegador, ambas documentadas en la [política de privacidad](https://mimik.westpoint.io/privacy/): los iconos de los sitios se piden al servicio de favicons de Google, lo que envía el dominio de ese sitio, y las funciones opcionales de IA y voz mandan texto o audio al proveedor que configuraste.
 
 <div align="right">
 

--- a/README.es.md
+++ b/README.es.md
@@ -63,6 +63,7 @@ Ya sea que estés documentando herramientas internas, escribiendo tutoriales de 
 | --------- | ------- | ----------- |
 | Chrome    | [![Chrome Version][chrome-version-shield]][chrome-link]   | [Chrome Web Store][chrome-link] |
 | Firefox   | [![Firefox Version][firefox-version-shield]][firefox-link] | [Firefox Add-ons][firefox-link]  |
+| Edge      | [![Edge Version][edge-version-shield]][edge-link]          | [Microsoft Edge Add-ons][edge-link] |
 
 > \[!IMPORTANT]
 >
@@ -225,3 +226,5 @@ MIT © [Westpoint](https://github.com/westpoint-io). Mira [LICENSE](./LICENSE) p
 [chrome-link]: https://chromewebstore.google.com/detail/mimik/jmfohdaflahliammccpiadmkcibohgha
 [firefox-version-shield]: https://img.shields.io/amo/v/mimik?label=Firefox%20Version&style=flat-square&logo=firefoxbrowser&logoColor=C7D2FE&color=4F46E5&labelColor=1E1B4B
 [firefox-link]: https://addons.mozilla.org/en-US/firefox/addon/mimik/
+[edge-version-shield]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fmicrosoftedge.microsoft.com%2Faddons%2Fgetproductdetailsbycrxid%2Fhgjemhfoffebbollleajkpefblppleai&query=%24.version&label=Edge%20Version&style=flat-square&logo=microsoftedge&logoColor=C7D2FE&color=4F46E5&labelColor=1E1B4B
+[edge-link]: https://microsoftedge.microsoft.com/addons/detail/hgjemhfoffebbollleajkpefblppleai

--- a/README.fr.md
+++ b/README.fr.md
@@ -32,16 +32,13 @@ Clique sur enregistrer, fais ce que tu as à faire, et récupère un guide soign
 - [📺 Démo](#-démo)
 - [👋 Pour commencer](#-pour-commencer)
 - [✨ Fonctionnalités](#-fonctionnalités)
-  - [🎬 Capture automatique](#-capture-automatique)
-  - [📸 Captures annotées](#-captures-annotées)
   - [🔒 Smart Blur](#-smart-blur)
   - [🧠 Descriptions par IA (optionnel)](#-descriptions-par-ia-optionnel)
   - [▶️ Lecture Guide Me](#️-lecture-guide-me)
   - [🎙️ Narration vocale (optionnel)](#️-narration-vocale-optionnel)
   - [✏️ Éditeur de guides](#️-éditeur-de-guides)
   - [📤 Export multi-format](#-export-multi-format)
-  - [🌍 Multilingue](#-multilingue)
-  - [💾 Stockage local d'abord](#-stockage-local-dabord)
+- [🔐 Confidentialité et stockage](#-confidentialité-et-stockage)
 - [🤝 Contribuer](#-contribuer)
 - [📜 Licence](#-licence)
 
@@ -61,11 +58,17 @@ Mimik transforme n'importe quelle tâche répétitive dans le navigateur en un g
 
 Que tu documentes des outils internes, que tu rédiges des tutoriels, ou que tu formes un collègue, Mimik capture chaque clic, frappe et navigation pour que tu puisses te concentrer sur le reste.
 
+Chaque action utile devient une étape : clics sur les boutons et les liens, champs de formulaire, raccourcis clavier, actions du presse-papiers, glisser-déposer et navigations. Les clics rapprochés sur des éléments voisins sont fusionnés pour garder les guides propres, et le clic est intercepté avant que la page ne navigue, donc rien ne se perd sur les SPA ni sur les chargements complets.
+
+Chaque étape reçoit une capture avec l'élément cliqué mis en évidence et zoomé. Pas de recadrage manuel, pas d'outil d'annotation à apprendre.
+
 | Navigateur | Version | Installation |
 | ---------- | ------- | ------------ |
 | Chrome     | [![Chrome Version][chrome-version-shield]][chrome-link]   | [Chrome Web Store][chrome-link] |
 | Firefox    | [![Firefox Version][firefox-version-shield]][firefox-link] | [Firefox Add-ons][firefox-link]  |
 | Edge       | [![Edge Version][edge-version-shield]][edge-link]          | [Microsoft Edge Add-ons][edge-link] |
+
+Disponible en anglais, espagnol, portugais brésilien, français et allemand. La langue des descriptions IA se règle séparément, donc tu peux lancer Mimik en anglais et générer les guides en français, ou n'importe quelle combinaison.
 
 > \[!IMPORTANT]
 >
@@ -82,28 +85,6 @@ Que tu documentes des outils internes, que tu rédiges des tutoriels, ou que tu 
 </div>
 
 ## ✨ Fonctionnalités
-
-### 🎬 Capture automatique
-
-Tu cliques, tu tapes, tu navigues. Mimik voit tout. Chaque action utile devient une étape : clics sur boutons et liens, champs de formulaire, raccourcis clavier, presse-papiers, drag & drop, et navigations.
-
-La fusion intelligente des événements écarte les clics rapprochés sur des éléments proches, pour garder tes guides propres. L'interception du clic se fait *avant* que la page ne change, donc rien ne se perd dans les SPA ou les rechargements complets.
-
-<div align="right">
-
-[![Back to top][back-to-top]](#readme-top)
-
-</div>
-
-### 📸 Captures annotées
-
-Chaque étape reçoit une capture avec l'élément cliqué mis en surbrillance et zoomé. Pas besoin de rogner à la main, pas d'outil d'annotation à apprendre. Mimik trouve la partie importante de la page et la cadre pour toi.
-
-<div align="right">
-
-[![Back to top][back-to-top]](#readme-top)
-
-</div>
 
 ### 🔒 Smart Blur
 
@@ -193,17 +174,7 @@ Tous les exports sont générés côté client. Rien ne passe par un serveur.
 
 </div>
 
-### 🌍 Multilingue
-
-Interface disponible en anglais, espagnol, portugais brésilien, français et allemand. La langue des descriptions IA se configure séparément, donc tu peux lancer Mimik en anglais et générer les guides en français, ou n'importe quelle combinaison.
-
-<div align="right">
-
-[![Back to top][back-to-top]](#readme-top)
-
-</div>
-
-### 💾 Stockage local d'abord
+## 🔐 Confidentialité et stockage
 
 Tes guides, étapes et captures restent sur ton appareil. Pas de backend, pas de compte, pas de télémétrie. Tes clés API (si tu en utilises) ne quittent jamais le navigateur. Elles sont stockées localement et servent à appeler directement le fournisseur que tu as choisi.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -50,7 +50,7 @@ Clique sur enregistrer, fais ce que tu as à faire, et récupère un guide soign
 ## 📺 Démo
 
 <div align="center">
-<img src="public/demo.gif" alt="Démo de Mimik" width="800" />
+<img src="https://github.com/user-attachments/assets/9de20b45-2256-4127-8242-141cf1802f39" alt="Démo de Mimik" width="800" />
 </div>
 
 ## 👋 Pour commencer
@@ -109,6 +109,8 @@ Mimik détecte et floute automatiquement les données sensibles dans tes capture
 
 Besoin de cacher quelque chose de précis ? Le sélecteur manuel te laisse choisir n'importe quel élément du DOM et le masquer sur toutes les captures où il apparaît.
 
+<img src="https://github.com/user-attachments/assets/968d2518-c561-4d68-92a6-3d5f569fe38a" alt="Smart Blur" width="800" />
+
 <div align="right">
 
 [![Back to top][back-to-top]](#readme-top)
@@ -121,6 +123,8 @@ Apporte ta propre clé API (OpenAI ou Anthropic) et Mimik génère des descripti
 
 Les descriptions sont générées à partir d'un contexte léger du DOM (~50-100 tokens), pas des captures. Environ 15-30x moins cher que les modèles vision. Choisis la langue des descriptions (anglais, espagnol, portugais, français).
 
+<img src="https://github.com/user-attachments/assets/3540cbd5-133f-46fd-a9b6-ffce9b4d422a" alt="Descriptions par IA" width="800" />
+
 <div align="right">
 
 [![Back to top][back-to-top]](#readme-top)
@@ -130,6 +134,8 @@ Les descriptions sont générées à partir d'un contexte léger du DOM (~50-100
 ### ▶️ Lecture Guide Me
 
 Rejoue n'importe quel guide en direct sur une vraie page. Mimik met en évidence l'élément suivant, suit ta progression étape par étape, et avance tout seul au fur et à mesure. Parfait pour former un collègue ou se guider soi-même dans un process.
+
+<img src="https://github.com/user-attachments/assets/56ffca1d-5074-491f-8571-dd70782d4b05" alt="Lecture Guide Me" width="800" />
 
 <div align="right">
 
@@ -146,6 +152,8 @@ Partage tes guides dans le format qui colle à ton flux :
 - **Markdown** : à coller dans Notion, GitHub, docs internes, wikis
 
 Tous les exports sont générés côté client. Rien ne passe par un serveur.
+
+<img src="https://github.com/user-attachments/assets/e7584527-7d68-4f3f-9261-8380ee08dfb4" alt="Export multi-format" width="800" />
 
 <div align="right">
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -37,9 +37,11 @@ Clique sur enregistrer, fais ce que tu as à faire, et récupère un guide soign
   - [🔒 Smart Blur](#-smart-blur)
   - [🧠 Descriptions par IA (optionnel)](#-descriptions-par-ia-optionnel)
   - [▶️ Lecture Guide Me](#️-lecture-guide-me)
+  - [🎙️ Narration vocale (optionnel)](#️-narration-vocale-optionnel)
+  - [✏️ Éditeur de guides](#️-éditeur-de-guides)
   - [📤 Export multi-format](#-export-multi-format)
   - [🌍 Multilingue](#-multilingue)
-  - [💾 Stockage 100% local](#-stockage-100-local)
+  - [💾 Stockage local d'abord](#-stockage-local-dabord)
 - [🤝 Contribuer](#-contribuer)
 - [📜 Licence](#-licence)
 
@@ -143,12 +145,42 @@ Rejoue n'importe quel guide en direct sur une vraie page. Mimik met en évidence
 
 </div>
 
+### 🎙️ Narration vocale (optionnel)
+
+Parle à voix haute pendant que tu enregistres et Mimik transforme ce que tu as dit en descriptions
+d'étapes. L'audio est transcrit avec ta propre clé (OpenAI ou Groq) puis rattaché à l'étape
+correspondante, donc tu narres une fois au lieu d'écrire chaque étape à la main.
+
+<img src="https://github.com/user-attachments/assets/061fddc7-da65-4641-8b39-d30b80c36531" alt="Narration vocale" width="800" />
+
+<div align="right">
+
+[![Back to top][back-to-top]](#readme-top)
+
+</div>
+
+### ✏️ Éditeur de guides
+
+Corrige un guide après coup sans réenregistrer. Recadre, annote et masque n'importe quelle capture,
+réécris une étape avec l'IA sans quitter l'éditeur, ajoute des titres et des notes entre les étapes,
+réordonne ou supprime en lot, et reviens en arrière via l'historique de versions.
+
+<img src="https://github.com/user-attachments/assets/62d3a01e-b129-44c8-8ba3-e9b97ff08d7e" alt="Éditeur de guides" width="800" />
+
+<div align="right">
+
+[![Back to top][back-to-top]](#readme-top)
+
+</div>
+
 ### 📤 Export multi-format
 
 Partage tes guides dans le format qui colle à ton flux :
 
-- **HTML** : autonome, à partager partout, images intégrées en base64
+- **Vidéo** : parcours narré, mp4/H.264, avec le curseur qui se déplace vers chaque cible
 - **PDF** : prêt à imprimer, A4 portrait avec sauts de page auto
+- **DOCX** : ouvre-le et continue dans Word
+- **HTML** : autonome, à partager partout, images intégrées en base64
 - **Markdown** : à coller dans Notion, GitHub, docs internes, wikis
 
 Tous les exports sont générés côté client. Rien ne passe par un serveur.
@@ -163,7 +195,7 @@ Tous les exports sont générés côté client. Rien ne passe par un serveur.
 
 ### 🌍 Multilingue
 
-Interface disponible en anglais, espagnol, portugais brésilien et français. La langue des descriptions IA se configure séparément, donc tu peux lancer Mimik en anglais et générer les guides en français, ou n'importe quelle combinaison.
+Interface disponible en anglais, espagnol, portugais brésilien, français et allemand. La langue des descriptions IA se configure séparément, donc tu peux lancer Mimik en anglais et générer les guides en français, ou n'importe quelle combinaison.
 
 <div align="right">
 
@@ -171,9 +203,11 @@ Interface disponible en anglais, espagnol, portugais brésilien et français. La
 
 </div>
 
-### 💾 Stockage 100% local
+### 💾 Stockage local d'abord
 
-Tes guides, étapes et captures restent sur ton appareil. Pas de backend, pas de compte, pas de télémétrie. Tes clés API (si tu en utilises) ne quittent jamais le navigateur. Elles sont stockées localement et envoyées directement au fournisseur d'IA que tu as choisi.
+Tes guides, étapes et captures restent sur ton appareil. Pas de backend, pas de compte, pas de télémétrie. Tes clés API (si tu en utilises) ne quittent jamais le navigateur. Elles sont stockées localement et servent à appeler directement le fournisseur que tu as choisi.
+
+Deux choses sortent bien du navigateur, toutes deux documentées dans la [politique de confidentialité](https://mimik.westpoint.io/privacy/) : les icônes de sites sont récupérées via le service de favicons de Google, ce qui envoie le domaine du site, et les fonctions optionnelles d'IA et de voix envoient du texte ou de l'audio au fournisseur que tu as configuré.
 
 <div align="right">
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -63,6 +63,7 @@ Que tu documentes des outils internes, que tu rédiges des tutoriels, ou que tu 
 | ---------- | ------- | ------------ |
 | Chrome     | [![Chrome Version][chrome-version-shield]][chrome-link]   | [Chrome Web Store][chrome-link] |
 | Firefox    | [![Firefox Version][firefox-version-shield]][firefox-link] | [Firefox Add-ons][firefox-link]  |
+| Edge       | [![Edge Version][edge-version-shield]][edge-link]          | [Microsoft Edge Add-ons][edge-link] |
 
 > \[!IMPORTANT]
 >
@@ -225,3 +226,5 @@ MIT © [Westpoint](https://github.com/westpoint-io). Voir [LICENSE](./LICENSE) p
 [chrome-link]: https://chromewebstore.google.com/detail/mimik/jmfohdaflahliammccpiadmkcibohgha
 [firefox-version-shield]: https://img.shields.io/amo/v/mimik?label=Firefox%20Version&style=flat-square&logo=firefoxbrowser&logoColor=C7D2FE&color=4F46E5&labelColor=1E1B4B
 [firefox-link]: https://addons.mozilla.org/en-US/firefox/addon/mimik/
+[edge-version-shield]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fmicrosoftedge.microsoft.com%2Faddons%2Fgetproductdetailsbycrxid%2Fhgjemhfoffebbollleajkpefblppleai&query=%24.version&label=Edge%20Version&style=flat-square&logo=microsoftedge&logoColor=C7D2FE&color=4F46E5&labelColor=1E1B4B
+[edge-link]: https://microsoftedge.microsoft.com/addons/detail/hgjemhfoffebbollleajkpefblppleai

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Auto-capture any browser workflow into a step-by-step guide. No account, no cloud, no tracking.**
 
-Click record, do the thing, get a polished guide with annotated screenshots. Edit, replay, or export.
+Click record, do the thing, get a polished guide with annotated screenshots. Narrate it as you go, edit it after, then replay or export.
 
 <!-- SHIELD GROUP -->
 
@@ -37,9 +37,11 @@ Click record, do the thing, get a polished guide with annotated screenshots. Edi
   - [🔒 Smart Blur](#-smart-blur)
   - [🧠 AI descriptions (optional)](#-ai-descriptions-optional)
   - [▶️ Guide Me replay](#️-guide-me-replay)
+  - [🎙️ Voice narration (optional)](#️-voice-narration-optional)
+  - [✏️ Guide editor](#️-guide-editor)
   - [📤 Multi-format export](#-multi-format-export)
   - [🌍 Multi-language](#-multi-language)
-  - [💾 100% local storage](#-100-local-storage)
+  - [💾 Local-first storage](#-local-first-storage)
 - [🤝 Contributing](#-contributing)
 - [📜 License](#-license)
 
@@ -118,7 +120,7 @@ Need to blur something custom? The manual blur picker lets you select any DOM el
 
 Bring your own API key (OpenAI or Anthropic) and Mimik generates human-readable step descriptions like *"Click the **Submit** button to save changes"* instead of `Click button "Submit"`.
 
-Descriptions are generated from a lightweight DOM context (~50-100 tokens), not screenshots. Roughly 15-30x cheaper than vision models. Choose the language you want descriptions in (English, Spanish, Portuguese, French).
+Descriptions are generated from a lightweight DOM context (~50-100 tokens), not screenshots. Roughly 15-30x cheaper than vision models. Choose the language you want descriptions in (English, Spanish, Portuguese, French, German).
 
 <div align="right">
 
@@ -136,12 +138,38 @@ Replay any guide live on a real page. Mimik highlights the next element to click
 
 </div>
 
+### 🎙️ Voice narration (optional)
+
+Talk through the workflow out loud while you record and Mimik turns what you said into the step
+descriptions. Audio is transcribed with your own key (OpenAI or Groq) and matched to the steps it
+belongs to, so you narrate once instead of writing every step by hand.
+
+<div align="right">
+
+[![Back to top][back-to-top]](#readme-top)
+
+</div>
+
+### ✏️ Guide editor
+
+Fix a guide after the fact without re-recording. Crop, annotate and redact any screenshot, rewrite a
+step with AI inline, drop headings and notes between steps, reorder or bulk-delete, and roll back
+through version history.
+
+<div align="right">
+
+[![Back to top][back-to-top]](#readme-top)
+
+</div>
+
 ### 📤 Multi-format export
 
 Share guides in whatever format fits your workflow:
 
-- **HTML**: self-contained, share anywhere, base64-embedded images
+- **Video**: narrated walkthrough, mp4/H.264, with the cursor moving to each target
 - **PDF**: print-ready, A4 portrait with auto page breaks
+- **DOCX**: open and keep editing in Word
+- **HTML**: self-contained, share anywhere, base64-embedded images
 - **Markdown**: paste into Notion, GitHub, internal docs, wikis
 
 All exports are generated client-side. Nothing touches a server.
@@ -154,7 +182,7 @@ All exports are generated client-side. Nothing touches a server.
 
 ### 🌍 Multi-language
 
-UI available in English, Spanish, Brazilian Portuguese, and French. The AI description language is configurable independently, so you can run Mimik in English but generate guides in Spanish, or any combination.
+UI available in English, Spanish, Brazilian Portuguese, French, and German. The AI description language is configurable independently, so you can run Mimik in English but generate guides in Spanish, or any combination.
 
 <div align="right">
 
@@ -162,9 +190,11 @@ UI available in English, Spanish, Brazilian Portuguese, and French. The AI descr
 
 </div>
 
-### 💾 100% local storage
+### 💾 Local-first storage
 
-Guides, steps, and screenshots live on your device. There's no backend, no account, no telemetry. Your API keys (if you bring one) never leave your browser. They're stored locally and sent directly to the AI provider you chose.
+Guides, steps, and screenshots live on your device. There's no backend, no account, no telemetry. Your API keys (if you bring one) never leave your browser — they're stored locally and used to call the provider you chose directly.
+
+Two things do leave the browser, both documented in the [privacy policy](https://mimik.westpoint.io/privacy/): site icons are fetched from Google's favicon service, which sends that site's domain, and the optional AI and voice features send text or audio to the provider you configured.
 
 <div align="right">
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Need to blur something custom? The manual blur picker lets you select any DOM el
 
 ### 🧠 AI descriptions (optional)
 
-Bring your own API key (OpenAI or Anthropic) and Mimik generates human-readable step descriptions like *"Click the **Submit** button to save changes"* instead of `Click button "Submit"`.
+Bring your own API key (OpenAI or Anthropic) and Mimik generates human-readable step descriptions like *"Click the **Submit** button to save changes"* instead of the rule-based `Click Submit`.
 
 Descriptions are generated from a lightweight DOM context (~50-100 tokens), not screenshots. Roughly 15-30x cheaper than vision models. Choose the language you want descriptions in (English, Spanish, Portuguese, French, German).
 

--- a/README.md
+++ b/README.md
@@ -32,16 +32,13 @@ Click record, do the thing, get a polished guide with annotated screenshots. Nar
 - [📺 Demo](#-demo)
 - [👋 Getting Started](#-getting-started)
 - [✨ Features](#-features)
-  - [🎬 Auto-capture](#-auto-capture)
-  - [📸 Annotated screenshots](#-annotated-screenshots)
   - [🔒 Smart Blur](#-smart-blur)
   - [🧠 AI descriptions (optional)](#-ai-descriptions-optional)
   - [▶️ Guide Me replay](#️-guide-me-replay)
   - [🎙️ Voice narration (optional)](#️-voice-narration-optional)
   - [✏️ Guide editor](#️-guide-editor)
   - [📤 Multi-format export](#-multi-format-export)
-  - [🌍 Multi-language](#-multi-language)
-  - [💾 Local-first storage](#-local-first-storage)
+- [🔐 Privacy & storage](#-privacy--storage)
 - [🤝 Contributing](#-contributing)
 - [📜 License](#-license)
 
@@ -61,11 +58,17 @@ Mimik turns any repetitive browser task into a documented, shareable guide in se
 
 Whether you're documenting internal tools, writing product tutorials, or onboarding a teammate, Mimik captures every click, keystroke, and navigation automatically so you can focus on the work.
 
+Every meaningful action becomes a step: clicks on buttons and links, form inputs, keyboard shortcuts, clipboard actions, drag events, and page navigations. Rapid clicks on nearby elements are merged so guides stay clean, and clicks are intercepted before the page navigates away, so nothing is lost on SPAs or full page loads.
+
+Each step gets a screenshot with the clicked element highlighted and zoomed in. No manual cropping, no annotation tools to learn.
+
 | Browser | Version | Install |
 | ------- | ------- | ------- |
 | Chrome  | [![Chrome Version][chrome-version-shield]][chrome-link]   | [Chrome Web Store][chrome-link] |
 | Firefox | [![Firefox Version][firefox-version-shield]][firefox-link] | [Firefox Add-ons][firefox-link]  |
 | Edge    | [![Edge Version][edge-version-shield]][edge-link]          | [Microsoft Edge Add-ons][edge-link] |
+
+Available in English, Spanish, Brazilian Portuguese, French, and German. The AI description language is set separately, so you can run Mimik in English and generate guides in Spanish, or any combination.
 
 > \[!IMPORTANT]
 >
@@ -82,28 +85,6 @@ Whether you're documenting internal tools, writing product tutorials, or onboard
 </div>
 
 ## ✨ Features
-
-### 🎬 Auto-capture
-
-Click, type, navigate. Mimik watches it all. Every meaningful action becomes a step: clicks on buttons and links, form inputs, keyboard shortcuts, clipboard actions, drag events, and page navigations.
-
-Smart event merging deduplicates rapid clicks on nearby elements, so your guides stay clean. Click interception fires *before* the page navigates away, so nothing gets lost during SPAs or full page loads.
-
-<div align="right">
-
-[![Back to top][back-to-top]](#readme-top)
-
-</div>
-
-### 📸 Annotated screenshots
-
-Every step gets a screenshot with the clicked element highlighted and zoomed in. No manual cropping, no annotation tools to learn. Mimik figures out the important part of the page and frames it for you.
-
-<div align="right">
-
-[![Back to top][back-to-top]](#readme-top)
-
-</div>
 
 ### 🔒 Smart Blur
 
@@ -193,17 +174,7 @@ All exports are generated client-side. Nothing touches a server.
 
 </div>
 
-### 🌍 Multi-language
-
-UI available in English, Spanish, Brazilian Portuguese, French, and German. The AI description language is configurable independently, so you can run Mimik in English but generate guides in Spanish, or any combination.
-
-<div align="right">
-
-[![Back to top][back-to-top]](#readme-top)
-
-</div>
-
-### 💾 Local-first storage
+## 🔐 Privacy & storage
 
 Guides, steps, and screenshots live on your device. There's no backend, no account, no telemetry. Your API keys (if you bring one) never leave your browser — they're stored locally and used to call the provider you chose directly.
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Whether you're documenting internal tools, writing product tutorials, or onboard
 | ------- | ------- | ------- |
 | Chrome  | [![Chrome Version][chrome-version-shield]][chrome-link]   | [Chrome Web Store][chrome-link] |
 | Firefox | [![Firefox Version][firefox-version-shield]][firefox-link] | [Firefox Add-ons][firefox-link]  |
+| Edge    | [![Edge Version][edge-version-shield]][edge-link]          | [Microsoft Edge Add-ons][edge-link] |
 
 > \[!IMPORTANT]
 >
@@ -255,5 +256,7 @@ MIT © [Westpoint](https://github.com/westpoint-io). See [LICENSE](./LICENSE) fo
 [chrome-link]: https://chromewebstore.google.com/detail/mimik/jmfohdaflahliammccpiadmkcibohgha
 [firefox-version-shield]: https://img.shields.io/amo/v/mimik?label=Firefox%20Version&style=flat-square&logo=firefoxbrowser&logoColor=C7D2FE&color=4F46E5&labelColor=1E1B4B
 [firefox-link]: https://addons.mozilla.org/en-US/firefox/addon/mimik/
+[edge-version-shield]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fmicrosoftedge.microsoft.com%2Faddons%2Fgetproductdetailsbycrxid%2Fhgjemhfoffebbollleajkpefblppleai&query=%24.version&label=Edge%20Version&style=flat-square&logo=microsoftedge&logoColor=C7D2FE&color=4F46E5&labelColor=1E1B4B
+[edge-link]: https://microsoftedge.microsoft.com/addons/detail/hgjemhfoffebbollleajkpefblppleai
 </content>
 </invoke>

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Click record, do the thing, get a polished guide with annotated screenshots. Nar
 ## 📺 Demo
 
 <div align="center">
-<img src="https://github.com/user-attachments/assets/d4c64cb8-ad26-4de1-af02-a04a64e2836e" alt="Mimik demo" width="800" />
+<img src="https://github.com/user-attachments/assets/9de20b45-2256-4127-8242-141cf1802f39" alt="Mimik demo" width="800" />
 </div>
 
 ## 👋 Getting Started
@@ -111,6 +111,8 @@ Mimik automatically detects and blurs sensitive data in your screenshots: emails
 
 Need to blur something custom? The manual blur picker lets you select any DOM element and mask it across every screenshot where it appears.
 
+<img src="https://github.com/user-attachments/assets/968d2518-c561-4d68-92a6-3d5f569fe38a" alt="Smart Blur" width="800" />
+
 <div align="right">
 
 [![Back to top][back-to-top]](#readme-top)
@@ -123,6 +125,8 @@ Bring your own API key (OpenAI or Anthropic) and Mimik generates human-readable 
 
 Descriptions are generated from a lightweight DOM context (~50-100 tokens), not screenshots. Roughly 15-30x cheaper than vision models. Choose the language you want descriptions in (English, Spanish, Portuguese, French, German).
 
+<img src="https://github.com/user-attachments/assets/3540cbd5-133f-46fd-a9b6-ffce9b4d422a" alt="AI descriptions" width="800" />
+
 <div align="right">
 
 [![Back to top][back-to-top]](#readme-top)
@@ -132,6 +136,8 @@ Descriptions are generated from a lightweight DOM context (~50-100 tokens), not 
 ### ▶️ Guide Me replay
 
 Replay any guide live on a real page. Mimik highlights the next element to click, tracks your progress step by step, and advances automatically as you interact. Perfect for onboarding teammates or walking through a process yourself.
+
+<img src="https://github.com/user-attachments/assets/56ffca1d-5074-491f-8571-dd70782d4b05" alt="Guide Me replay" width="800" />
 
 <div align="right">
 
@@ -145,6 +151,8 @@ Talk through the workflow out loud while you record and Mimik turns what you sai
 descriptions. Audio is transcribed with your own key (OpenAI or Groq) and matched to the steps it
 belongs to, so you narrate once instead of writing every step by hand.
 
+<img src="https://github.com/user-attachments/assets/061fddc7-da65-4641-8b39-d30b80c36531" alt="Voice narration" width="800" />
+
 <div align="right">
 
 [![Back to top][back-to-top]](#readme-top)
@@ -156,6 +164,8 @@ belongs to, so you narrate once instead of writing every step by hand.
 Fix a guide after the fact without re-recording. Crop, annotate and redact any screenshot, rewrite a
 step with AI inline, drop headings and notes between steps, reorder or bulk-delete, and roll back
 through version history.
+
+<img src="https://github.com/user-attachments/assets/62d3a01e-b129-44c8-8ba3-e9b97ff08d7e" alt="Guide editor" width="800" />
 
 <div align="right">
 
@@ -174,6 +184,8 @@ Share guides in whatever format fits your workflow:
 - **Markdown**: paste into Notion, GitHub, internal docs, wikis
 
 All exports are generated client-side. Nothing touches a server.
+
+<img src="https://github.com/user-attachments/assets/e7584527-7d68-4f3f-9261-8380ee08dfb4" alt="Multi-format export" width="800" />
 
 <div align="right">
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -32,16 +32,13 @@ Clica em gravar, faz o que precisa, e recebe um guia caprichado com capturas de 
 - [📺 Demo](#-demo)
 - [👋 Começando](#-começando)
 - [✨ Funcionalidades](#-funcionalidades)
-  - [🎬 Captura automática](#-captura-automática)
-  - [📸 Capturas anotadas](#-capturas-anotadas)
   - [🔒 Smart Blur](#-smart-blur)
   - [🧠 Descrições por IA (opcional)](#-descrições-por-ia-opcional)
   - [▶️ Reprodução Guide Me](#️-reprodução-guide-me)
   - [🎙️ Narração por voz (opcional)](#️-narração-por-voz-opcional)
   - [✏️ Editor de guias](#️-editor-de-guias)
   - [📤 Exportação multi-formato](#-exportação-multi-formato)
-  - [🌍 Multi-idioma](#-multi-idioma)
-  - [💾 Armazenamento local primeiro](#-armazenamento-local-primeiro)
+- [🔐 Privacidade e armazenamento](#-privacidade-e-armazenamento)
 - [🤝 Contribuir](#-contribuir)
 - [📜 Licença](#-licença)
 
@@ -61,11 +58,17 @@ O Mimik transforma qualquer tarefa repetitiva do navegador num guia documentado 
 
 Seja documentando ferramentas internas, escrevendo tutoriais do produto, ou integrando um colega novo, o Mimik captura cada clique, tecla e navegação automaticamente pra tu focar no que importa.
 
+Cada ação relevante vira um passo: cliques em botões e links, campos de formulário, atalhos de teclado, ações da área de transferência, arrastos e navegações. Cliques rápidos em elementos próximos são agrupados pros guias ficarem limpos, e o clique é interceptado antes da página navegar, então nada se perde em SPAs nem em carregamentos completos.
+
+Cada passo ganha uma captura com o elemento clicado destacado e ampliado. Sem recortar na mão, sem ferramenta de anotação pra aprender.
+
 | Navegador | Versão | Instalação |
 | --------- | ------ | ---------- |
 | Chrome    | [![Chrome Version][chrome-version-shield]][chrome-link]   | [Chrome Web Store][chrome-link] |
 | Firefox   | [![Firefox Version][firefox-version-shield]][firefox-link] | [Firefox Add-ons][firefox-link]  |
 | Edge      | [![Edge Version][edge-version-shield]][edge-link]          | [Microsoft Edge Add-ons][edge-link] |
+
+Disponível em inglês, espanhol, português brasileiro, francês e alemão. O idioma das descrições de IA é configurado separadamente, então tu pode usar o Mimik em inglês e gerar os guias em português, ou qualquer combinação.
 
 > \[!IMPORTANT]
 >
@@ -82,28 +85,6 @@ Seja documentando ferramentas internas, escrevendo tutoriais do produto, ou inte
 </div>
 
 ## ✨ Funcionalidades
-
-### 🎬 Captura automática
-
-Clica, digita, navega. O Mimik vê tudo. Cada ação relevante vira um passo: cliques em botões e links, campos de formulário, atalhos de teclado, área de transferência, arrastar e soltar, e navegações.
-
-A fusão inteligente de eventos descarta os cliques rápidos em elementos próximos, pra teus guias ficarem limpos. A interceptação do clique acontece *antes* da página mudar, então nada se perde em SPAs nem em recarregamentos completos.
-
-<div align="right">
-
-[![Back to top][back-to-top]](#readme-top)
-
-</div>
-
-### 📸 Capturas anotadas
-
-Cada passo ganha uma captura com o elemento clicado destacado e um zoom na área importante. Sem recortar na mão, sem aprender ferramentas de anotação. O Mimik descobre qual parte da página importa e enquadra ela pra ti.
-
-<div align="right">
-
-[![Back to top][back-to-top]](#readme-top)
-
-</div>
 
 ### 🔒 Smart Blur
 
@@ -193,17 +174,7 @@ Todas as exportações são geradas no cliente. Nada passa por servidor.
 
 </div>
 
-### 🌍 Multi-idioma
-
-Interface disponível em inglês, espanhol, português brasileiro, francês e alemão. O idioma das descrições de IA é configurado separadamente, então tu pode usar o Mimik em inglês e gerar os guias em português, ou qualquer combinação.
-
-<div align="right">
-
-[![Back to top][back-to-top]](#readme-top)
-
-</div>
-
-### 💾 Armazenamento local primeiro
+## 🔐 Privacidade e armazenamento
 
 Teus guias, passos e capturas ficam no teu dispositivo. Sem backend, sem conta, sem telemetria. Tuas API keys (se tu usar alguma) nunca saem do navegador. Ficam salvas localmente e são usadas pra chamar direto o provedor que tu escolheu.
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -63,6 +63,7 @@ Seja documentando ferramentas internas, escrevendo tutoriais do produto, ou inte
 | --------- | ------ | ---------- |
 | Chrome    | [![Chrome Version][chrome-version-shield]][chrome-link]   | [Chrome Web Store][chrome-link] |
 | Firefox   | [![Firefox Version][firefox-version-shield]][firefox-link] | [Firefox Add-ons][firefox-link]  |
+| Edge      | [![Edge Version][edge-version-shield]][edge-link]          | [Microsoft Edge Add-ons][edge-link] |
 
 > \[!IMPORTANT]
 >
@@ -225,3 +226,5 @@ MIT © [Westpoint](https://github.com/westpoint-io). Olha o [LICENSE](./LICENSE)
 [chrome-link]: https://chromewebstore.google.com/detail/mimik/jmfohdaflahliammccpiadmkcibohgha
 [firefox-version-shield]: https://img.shields.io/amo/v/mimik?label=Firefox%20Version&style=flat-square&logo=firefoxbrowser&logoColor=C7D2FE&color=4F46E5&labelColor=1E1B4B
 [firefox-link]: https://addons.mozilla.org/en-US/firefox/addon/mimik/
+[edge-version-shield]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fmicrosoftedge.microsoft.com%2Faddons%2Fgetproductdetailsbycrxid%2Fhgjemhfoffebbollleajkpefblppleai&query=%24.version&label=Edge%20Version&style=flat-square&logo=microsoftedge&logoColor=C7D2FE&color=4F46E5&labelColor=1E1B4B
+[edge-link]: https://microsoftedge.microsoft.com/addons/detail/hgjemhfoffebbollleajkpefblppleai

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -37,9 +37,11 @@ Clica em gravar, faz o que precisa, e recebe um guia caprichado com capturas de 
   - [🔒 Smart Blur](#-smart-blur)
   - [🧠 Descrições por IA (opcional)](#-descrições-por-ia-opcional)
   - [▶️ Reprodução Guide Me](#️-reprodução-guide-me)
+  - [🎙️ Narração por voz (opcional)](#️-narração-por-voz-opcional)
+  - [✏️ Editor de guias](#️-editor-de-guias)
   - [📤 Exportação multi-formato](#-exportação-multi-formato)
   - [🌍 Multi-idioma](#-multi-idioma)
-  - [💾 Armazenamento 100% local](#-armazenamento-100-local)
+  - [💾 Armazenamento local primeiro](#-armazenamento-local-primeiro)
 - [🤝 Contribuir](#-contribuir)
 - [📜 Licença](#-licença)
 
@@ -143,12 +145,42 @@ Reproduz qualquer guia ao vivo numa página real. O Mimik destaca o próximo ele
 
 </div>
 
+### 🎙️ Narração por voz (opcional)
+
+Fala em voz alta enquanto grava e o Mimik transforma o que tu disse nas descrições dos passos. O
+áudio é transcrito com a tua própria key (OpenAI ou Groq) e casado com o passo a que pertence,
+então tu narra uma vez em vez de escrever cada passo na mão.
+
+<img src="https://github.com/user-attachments/assets/061fddc7-da65-4641-8b39-d30b80c36531" alt="Narração por voz" width="800" />
+
+<div align="right">
+
+[![Back to top][back-to-top]](#readme-top)
+
+</div>
+
+### ✏️ Editor de guias
+
+Ajusta um guia depois sem regravar. Recorta, anota e censura qualquer captura, reescreve um passo
+com IA sem sair do editor, coloca títulos e notas entre os passos, reordena ou apaga em lote, e
+volta atrás pelo histórico de versões.
+
+<img src="https://github.com/user-attachments/assets/62d3a01e-b129-44c8-8ba3-e9b97ff08d7e" alt="Editor de guias" width="800" />
+
+<div align="right">
+
+[![Back to top][back-to-top]](#readme-top)
+
+</div>
+
 ### 📤 Exportação multi-formato
 
 Compartilha os guias no formato que melhor cabe no teu fluxo:
 
-- **HTML**: autônomo, compartilha em qualquer lugar, imagens embutidas em base64
+- **Vídeo**: passo a passo narrado, mp4/H.264, com o cursor indo até cada alvo
 - **PDF**: pronto pra imprimir, A4 retrato com quebras de página automáticas
+- **DOCX**: abre e continua editando no Word
+- **HTML**: autônomo, compartilha em qualquer lugar, imagens embutidas em base64
 - **Markdown**: cola no Notion, GitHub, docs internas, wikis
 
 Todas as exportações são geradas no cliente. Nada passa por servidor.
@@ -163,7 +195,7 @@ Todas as exportações são geradas no cliente. Nada passa por servidor.
 
 ### 🌍 Multi-idioma
 
-Interface disponível em inglês, espanhol, português brasileiro e francês. O idioma das descrições de IA é configurado separadamente, então tu pode usar o Mimik em inglês e gerar os guias em português, ou qualquer combinação.
+Interface disponível em inglês, espanhol, português brasileiro, francês e alemão. O idioma das descrições de IA é configurado separadamente, então tu pode usar o Mimik em inglês e gerar os guias em português, ou qualquer combinação.
 
 <div align="right">
 
@@ -171,9 +203,11 @@ Interface disponível em inglês, espanhol, português brasileiro e francês. O 
 
 </div>
 
-### 💾 Armazenamento 100% local
+### 💾 Armazenamento local primeiro
 
-Teus guias, passos e capturas ficam no teu dispositivo. Sem backend, sem conta, sem telemetria. Tuas API keys (se tu usar alguma) nunca saem do navegador. Ficam salvas localmente e vão direto pro provedor de IA que tu escolheu.
+Teus guias, passos e capturas ficam no teu dispositivo. Sem backend, sem conta, sem telemetria. Tuas API keys (se tu usar alguma) nunca saem do navegador. Ficam salvas localmente e são usadas pra chamar direto o provedor que tu escolheu.
+
+Duas coisas saem do navegador, as duas documentadas na [política de privacidade](https://mimik.westpoint.io/privacy/): os ícones dos sites são buscados no serviço de favicons do Google, o que envia o domínio daquele site, e os recursos opcionais de IA e voz mandam texto ou áudio pro provedor que tu configurou.
 
 <div align="right">
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -50,7 +50,7 @@ Clica em gravar, faz o que precisa, e recebe um guia caprichado com capturas de 
 ## 📺 Demo
 
 <div align="center">
-<img src="public/demo.gif" alt="Demo do Mimik" width="800" />
+<img src="https://github.com/user-attachments/assets/9de20b45-2256-4127-8242-141cf1802f39" alt="Demo do Mimik" width="800" />
 </div>
 
 ## 👋 Começando
@@ -109,6 +109,8 @@ O Mimik detecta e desfoca dados sensíveis automaticamente nas tuas capturas: e-
 
 Precisa esconder algo específico? O seletor manual deixa tu escolher qualquer elemento do DOM e mascarar ele em todas as capturas onde aparecer.
 
+<img src="https://github.com/user-attachments/assets/968d2518-c561-4d68-92a6-3d5f569fe38a" alt="Smart Blur" width="800" />
+
 <div align="right">
 
 [![Back to top][back-to-top]](#readme-top)
@@ -121,6 +123,8 @@ Traz a tua API key (OpenAI ou Anthropic) e o Mimik gera descrições naturais ti
 
 As descrições são geradas a partir de um contexto leve do DOM (~50-100 tokens), não das capturas. Umas 15-30 vezes mais barato que modelos com visão. Escolhe o idioma das descrições (inglês, espanhol, português, francês).
 
+<img src="https://github.com/user-attachments/assets/3540cbd5-133f-46fd-a9b6-ffce9b4d422a" alt="Descrições por IA" width="800" />
+
 <div align="right">
 
 [![Back to top][back-to-top]](#readme-top)
@@ -130,6 +134,8 @@ As descrições são geradas a partir de um contexto leve do DOM (~50-100 tokens
 ### ▶️ Reprodução Guide Me
 
 Reproduz qualquer guia ao vivo numa página real. O Mimik destaca o próximo elemento, marca teu progresso passo a passo, e avança sozinho conforme tu vai interagindo. Perfeito pra integrar colegas ou pra se guiar num processo tu mesmo.
+
+<img src="https://github.com/user-attachments/assets/56ffca1d-5074-491f-8571-dd70782d4b05" alt="Reprodução Guide Me" width="800" />
 
 <div align="right">
 
@@ -146,6 +152,8 @@ Compartilha os guias no formato que melhor cabe no teu fluxo:
 - **Markdown**: cola no Notion, GitHub, docs internas, wikis
 
 Todas as exportações são geradas no cliente. Nada passa por servidor.
+
+<img src="https://github.com/user-attachments/assets/e7584527-7d68-4f3f-9261-8380ee08dfb4" alt="Exportação multi-formato" width="800" />
 
 <div align="right">
 


### PR DESCRIPTION
The README described 1.0.5. It had no mention of voice narration, the guide editor, video or DOCX, and listed three export formats where there are now five.

Adds sections for voice narration and the editor, lists all five formats, and adds German to both language claims (a complete 518-line locale the README never mentioned).

"100% local storage" becomes "Local-first storage" and now says site icons are fetched from Google's favicon service and that the optional AI and voice features send to the provider you configure, linking the privacy policy. That was the last public surface still claiming unqualified local-only behaviour, which contradicted the data collection the manifest declares.

Docs only, no code touched. Every claim checked against the source: five `*-export.ts` modules for five formats, five locale files, and a module behind each named feature.