### PR TITLE
test: cover the export render, pdf and video paths

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -36,8 +36,19 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
-      - name: Run tests
-        run: pnpm test
+      - name: Run tests with coverage
+        run: pnpm test:cov
+
+      - name: Publish coverage summary
+        if: always()
+        run: |
+          node -e '
+            const t = require("./coverage/coverage-summary.json").total;
+            const rows = ["statements", "branches", "functions", "lines"]
+              .map((k) => `| ${k} | ${t[k].pct}% | ${t[k].covered}/${t[k].total} |`)
+              .join("\n");
+            console.log(`## Test coverage\n\n| metric | % | covered |\n| --- | --- | --- |\n${rows}`);
+          ' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build Chrome
         run: pnpm build

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 .output/
 .wxt/
 dist/
+coverage/
 .planning/
 docs/
 .source/

--- a/src/core/export/__tests__/pdf-export.test.ts
+++ b/src/core/export/__tests__/pdf-export.test.ts
@@ -1,0 +1,445 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ExportOptions } from '@/core/export/options';
+import { DEFAULT_EXPORT_OPTIONS } from '@/core/export/options';
+import type { Guide, Screenshot, Step } from '@/core/guides/types';
+
+const BROKEN_LOGO = vi.hoisted(() => 'data:image/png;base64,BROKEN');
+
+const state = vi.hoisted(() => ({
+  calls: [] as { m: string; a: unknown[] }[],
+  pages: 1,
+  current: 1,
+}));
+
+const branding = vi.hoisted(() => ({
+  value: {
+    logo: null as null | { dataUrl: string; width: number; height: number },
+    footer: '',
+    attribution: false,
+    accent: '#4F46E5',
+    custom: false,
+  },
+}));
+
+vi.mock('jspdf', () => {
+  const record =
+    (m: string) =>
+    (...a: unknown[]) => {
+      state.calls.push({ m, a });
+    };
+  class FakeDoc {
+    setFontSize = record('setFontSize');
+    setFont = record('setFont');
+    setTextColor = record('setTextColor');
+    setDrawColor = record('setDrawColor');
+    setLineWidth = record('setLineWidth');
+    text = record('text');
+    textWithLink = record('textWithLink');
+    line = record('line');
+    rect = record('rect');
+    roundedRect = record('roundedRect');
+    setFillColor = record('setFillColor');
+
+    addImage(...a: unknown[]) {
+      state.calls.push({ m: 'addImage', a });
+      if (a[0] === BROKEN_LOGO) throw new Error('unsupported image format');
+    }
+
+    addPage(...a: unknown[]) {
+      state.calls.push({ m: 'addPage', a });
+      state.pages += 1;
+      state.current = state.pages;
+    }
+
+    setPage(p: number) {
+      state.calls.push({ m: 'setPage', a: [p] });
+      state.current = p;
+    }
+
+    getNumberOfPages() {
+      return state.pages;
+    }
+
+    splitTextToSize(text: string) {
+      return String(text).split('\n');
+    }
+
+    getTextWidth(text: string) {
+      return String(text).length * 1.6;
+    }
+
+    output() {
+      return new Blob(['pdf']);
+    }
+  }
+  return { jsPDF: FakeDoc };
+});
+
+vi.mock('@/core/screenshot/render', () => ({
+  renderScreenshot: vi.fn(async () => new Blob(['jpeg'])),
+}));
+
+vi.mock('@/core/export/branding', async () => {
+  const actual = await vi.importActual<typeof import('@/core/export/branding')>('@/core/export/branding');
+  return { ...actual, loadBranding: vi.fn(async () => branding.value) };
+});
+
+vi.mock('@/core/export/utils', async () => {
+  const actual = await vi.importActual<typeof import('@/core/export/utils')>('@/core/export/utils');
+  return { ...actual, blobToDataUrl: vi.fn(async () => 'data:image/jpeg;base64,AAA') };
+});
+
+const { exportGuideAsPDF } = await import('@/core/export/pdf-export');
+const { renderScreenshot } = await import('@/core/screenshot/render');
+
+const guide: Guide = {
+  id: 'g1',
+  title: 'Reset your password',
+  createdAt: new Date('2026-03-04T10:00:00Z').getTime(),
+  updatedAt: new Date('2026-03-04T10:00:00Z').getTime(),
+  stepIds: [],
+  starred: false,
+  deletedAt: null,
+};
+
+function makeStep(i: number, overrides: Partial<Step> = {}): Step {
+  return {
+    id: `s${i}`,
+    guideId: 'g1',
+    index: i,
+    description: `Step number ${i}`,
+    action: 'click',
+    url: 'https://example.com/settings',
+    timestamp: guide.createdAt,
+    screenshotId: `shot-${i}`,
+    ...overrides,
+  };
+}
+
+function makeShot(stepId: string): Screenshot {
+  return {
+    id: `shot-${stepId}`,
+    stepId,
+    blob: new Blob(['raw']),
+    mimeType: 'image/jpeg',
+    width: 800,
+    height: 1600,
+  };
+}
+
+function shotsFor(steps: Step[]): Map<string, Screenshot> {
+  return new Map(steps.map((s) => [s.id, makeShot(s.id)]));
+}
+
+const opts = (o: Partial<ExportOptions> = {}): ExportOptions => ({ ...DEFAULT_EXPORT_OPTIONS, ...o });
+
+const texts = () =>
+  state.calls
+    .filter((c) => c.m === 'text' || c.m === 'textWithLink')
+    .flatMap((c) => (Array.isArray(c.a[0]) ? (c.a[0] as string[]) : [String(c.a[0])]));
+
+const count = (m: string) => state.calls.filter((c) => c.m === m).length;
+
+beforeEach(() => {
+  state.calls = [];
+  state.pages = 1;
+  state.current = 1;
+  branding.value = { logo: null, footer: '', attribution: false, accent: '#4F46E5', custom: false };
+  vi.mocked(renderScreenshot).mockClear();
+  vi.mocked(renderScreenshot).mockResolvedValue(new Blob(['jpeg']));
+});
+
+describe('exportGuideAsPDF', () => {
+  it('returns a blob', async () => {
+    const steps = [makeStep(0)];
+    await expect(exportGuideAsPDF(guide, steps, shotsFor(steps), opts())).resolves.toBeInstanceOf(Blob);
+  });
+
+  it('puts the title and step count on a cover page', async () => {
+    const steps = [makeStep(0), makeStep(1), makeStep(2)];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: true }));
+
+    expect(texts()).toContain('Reset your password');
+    expect(texts()).toContain('03');
+  });
+
+  it('omits the cover when the option is off', async () => {
+    const steps = [makeStep(0)];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(texts()).not.toContain('export.guideLabel');
+  });
+
+  it('writes the guide description as a cover paragraph', async () => {
+    const steps = [makeStep(0)];
+    const withDesc = { ...guide, description: 'How to recover access' };
+    await exportGuideAsPDF(withDesc, steps, shotsFor(steps), opts({ cover: true }));
+
+    expect(texts()).toContain('How to recover access');
+  });
+
+  it('writes the description as a lead paragraph when there is no cover', async () => {
+    const steps = [makeStep(0)];
+    const withDesc = { ...guide, description: 'How to recover access' };
+    await exportGuideAsPDF(withDesc, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(texts()).toContain('How to recover access');
+  });
+});
+
+describe('exportGuideAsPDF pagination', () => {
+  it('starts a new page once the steps stop fitting', async () => {
+    const steps = Array.from({ length: 8 }, (_, i) => makeStep(i));
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(count('addPage')).toBeGreaterThan(0);
+    expect(state.pages).toBeGreaterThan(1);
+  });
+
+  it('keeps a single tall step on one page rather than looping onto blank pages', async () => {
+    const steps = [makeStep(0)];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(count('addPage')).toBe(0);
+  });
+
+  it('adds a page for the first step block when a cover is present', async () => {
+    const steps = [makeStep(0)];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: true }));
+
+    expect(count('addPage')).toBe(1);
+  });
+
+  it('numbers every page against the total', async () => {
+    const steps = Array.from({ length: 6 }, (_, i) => makeStep(i));
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    const total = state.pages;
+    for (let p = 1; p <= total; p++) {
+      expect(texts()).toContain(`${p} / ${total}`);
+    }
+  });
+
+  it('visits each page once when stamping the footer', async () => {
+    const steps = Array.from({ length: 6 }, (_, i) => makeStep(i));
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    const visited = state.calls.filter((c) => c.m === 'setPage').map((c) => c.a[0]);
+    expect(visited).toEqual(Array.from({ length: state.pages }, (_, i) => i + 1));
+  });
+
+  it('labels a page carrying one step differently from a range', async () => {
+    const steps = Array.from({ length: 4 }, (_, i) => makeStep(i));
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    const labels = texts().filter((t) => t.startsWith('export.step'));
+    expect(labels.length).toBeGreaterThan(0);
+    expect(labels.some((l) => l.startsWith('export.stepOf') || l.startsWith('export.stepsRange'))).toBe(true);
+  });
+});
+
+describe('exportGuideAsPDF screenshots', () => {
+  it('renders and embeds a screenshot per step', async () => {
+    const steps = [makeStep(0), makeStep(1)];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(renderScreenshot).toHaveBeenCalledTimes(2);
+    expect(count('addImage')).toBe(2);
+  });
+
+  it('skips screenshots entirely when the option is off', async () => {
+    const steps = [makeStep(0), makeStep(1)];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false, screenshots: false }));
+
+    expect(renderScreenshot).not.toHaveBeenCalled();
+    expect(count('addImage')).toBe(0);
+  });
+
+  it('renders as jpeg so the pdf stays small', async () => {
+    const steps = [makeStep(0)];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(vi.mocked(renderScreenshot).mock.calls[0][1]).toMatchObject({ format: 'image/jpeg' });
+  });
+
+  it('still writes the step when its screenshot fails to render', async () => {
+    vi.mocked(renderScreenshot).mockRejectedValueOnce(new Error('decode failed'));
+    const steps = [makeStep(0)];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(texts()).toContain('Step number 0');
+    expect(count('addImage')).toBe(0);
+  });
+
+  it('writes invisible alt text alongside the image', async () => {
+    const steps = [makeStep(0)];
+    const shots = shotsFor(steps);
+    shots.get('s0')!.edits = { alt: 'The settings page' };
+    await exportGuideAsPDF(guide, steps, shots, opts({ cover: false }));
+
+    expect(texts()).toContain('The settings page');
+    const invisible = state.calls.filter((c) => (c.a[3] as { renderingMode?: string })?.renderingMode === 'invisible');
+    expect(invisible.length).toBe(1);
+  });
+
+  it('falls back to a generated alt label when none is set', async () => {
+    const steps = [makeStep(0)];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(texts().some((t) => t.startsWith('export.stepLabel'))).toBe(true);
+  });
+});
+
+describe('exportGuideAsPDF step urls', () => {
+  it('links the step url when the option is on', async () => {
+    const steps = [makeStep(0)];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false, stepUrls: true }));
+
+    const links = state.calls.filter((c) => c.m === 'textWithLink');
+    expect(links.some((c) => (c.a[3] as { url?: string })?.url === 'https://example.com/settings')).toBe(true);
+  });
+
+  it('omits the url when the option is off', async () => {
+    const steps = [makeStep(0)];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false, stepUrls: false }));
+
+    const links = state.calls.filter((c) => c.m === 'textWithLink');
+    expect(links.some((c) => (c.a[3] as { url?: string })?.url === 'https://example.com/settings')).toBe(false);
+  });
+
+  it('wraps a long url onto its own line instead of running off the page', async () => {
+    const long = `https://example.com/${'segment/'.repeat(30)}`;
+    const steps = [makeStep(0, { url: long, description: 'A fairly long step description here' })];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false, stepUrls: true }));
+
+    const sep = state.calls.filter((c) => c.m === 'text' && c.a[0] === '   ·   ');
+    expect(sep.length).toBe(0);
+  });
+
+  it('leaves a step without a url alone', async () => {
+    const steps = [makeStep(0, { url: '' })];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false, stepUrls: true }));
+
+    expect(count('textWithLink')).toBe(0);
+  });
+
+  it('shortens a url to host and path', async () => {
+    const steps = [makeStep(0, { url: 'https://www.example.com/settings/profile' })];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false, stepUrls: true }));
+
+    expect(texts()).toContain('example.com/settings/profile');
+  });
+
+  it('drops a bare root path from the label', async () => {
+    const steps = [makeStep(0, { url: 'https://example.com/' })];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false, stepUrls: true }));
+
+    expect(texts()).toContain('example.com');
+  });
+
+  it('falls back to the raw value when the url cannot be parsed', async () => {
+    const steps = [makeStep(0, { url: 'not a url' })];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false, stepUrls: true }));
+
+    expect(texts()).toContain('not a url');
+  });
+
+  it('truncates a very long label', async () => {
+    const steps = [makeStep(0, { url: `https://example.com/${'a'.repeat(200)}` })];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false, stepUrls: true }));
+
+    const label = texts().find((t) => t.startsWith('example.com/aaa'));
+    expect(label).toBeDefined();
+    expect(label?.length).toBe(64);
+    expect(label?.endsWith('…')).toBe(true);
+  });
+});
+
+describe('exportGuideAsPDF branding', () => {
+  it('stamps the footer line on every page', async () => {
+    branding.value = { ...branding.value, footer: 'Acme internal' };
+    const steps = Array.from({ length: 5 }, (_, i) => makeStep(i));
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    const footers = texts().filter((t) => t === 'Acme internal');
+    expect(footers.length).toBe(state.pages);
+  });
+
+  it('adds the attribution when it is enabled', async () => {
+    branding.value = { ...branding.value, attribution: true };
+    const steps = [makeStep(0)];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(texts()).toContain('export.madeWith');
+  });
+
+  it('leaves the attribution out when it is disabled', async () => {
+    branding.value = { ...branding.value, attribution: false };
+    const steps = [makeStep(0)];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(texts()).not.toContain('export.madeWith');
+  });
+
+  it('draws the logo on the cover', async () => {
+    branding.value = {
+      ...branding.value,
+      logo: { dataUrl: 'data:image/png;base64,AAA', width: 100, height: 40 },
+    };
+    const steps = [makeStep(0)];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: true, screenshots: false }));
+
+    expect(count('addImage')).toBe(1);
+  });
+
+  it('repeats a small logo in the running head when there is no cover', async () => {
+    branding.value = {
+      ...branding.value,
+      logo: { dataUrl: 'data:image/png;base64,AAA', width: 100, height: 40 },
+    };
+    const steps = Array.from({ length: 5 }, (_, i) => makeStep(i));
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false, screenshots: false }));
+
+    expect(count('addImage')).toBe(state.pages);
+  });
+
+  it('still produces a pdf when the cover logo fails to draw', async () => {
+    branding.value = { ...branding.value, logo: { dataUrl: BROKEN_LOGO, width: 100, height: 40 } };
+    const steps = [makeStep(0)];
+    await expect(
+      exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: true, screenshots: false })),
+    ).resolves.toBeInstanceOf(Blob);
+  });
+
+  it('still produces a pdf when the running head logo fails to draw', async () => {
+    branding.value = { ...branding.value, logo: { dataUrl: BROKEN_LOGO, width: 100, height: 40 } };
+    const steps = Array.from({ length: 5 }, (_, i) => makeStep(i));
+    await expect(
+      exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false, screenshots: false })),
+    ).resolves.toBeInstanceOf(Blob);
+    expect(state.pages).toBeGreaterThan(0);
+  });
+});
+
+describe('exportGuideAsPDF blocks', () => {
+  it('renders a heading block without a step number', async () => {
+    const steps = [makeStep(0, { blockType: 'heading', description: 'Part one' }), makeStep(1)];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(texts()).toContain('Part one');
+  });
+
+  it('renders a callout block', async () => {
+    const steps = [makeStep(0, { blockType: 'callout', description: 'Remember to save' }), makeStep(1)];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(texts()).toContain('Remember to save');
+  });
+
+  it('numbers only the action steps', async () => {
+    const steps = [makeStep(0, { blockType: 'heading', description: 'Part one' }), makeStep(1), makeStep(2)];
+    await exportGuideAsPDF(guide, steps, shotsFor(steps), opts({ cover: true }));
+
+    expect(texts()).toContain('02');
+  });
+});

--- a/src/core/export/__tests__/video-export-encode.test.ts
+++ b/src/core/export/__tests__/video-export-encode.test.ts
@@ -1,0 +1,431 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ExportOptions } from '@/core/export/options';
+import { DEFAULT_EXPORT_OPTIONS } from '@/core/export/options';
+import type { Guide, Screenshot, Step } from '@/core/guides/types';
+
+const rec = vi.hoisted(() => ({
+  calls: [] as { m: string; a: unknown[] }[],
+  added: [] as { at: number; dur: number }[],
+  closed: 0,
+  container: 'mp4' as 'mp4' | 'webm' | null,
+  probed: [] as string[],
+  started: 0,
+  finalized: 0,
+  cancelled: 0,
+  buffer: true,
+}));
+
+const branding = vi.hoisted(() => ({
+  value: {
+    logo: null as null | { dataUrl: string; width: number; height: number },
+    footer: '',
+    attribution: false,
+    accent: '#4F46E5',
+    custom: false,
+  },
+}));
+
+function fakeCtx() {
+  const store: Record<string, unknown> = { filter: 'none' };
+  const base: Record<string, unknown> = {
+    canvas: { width: 1280, height: 720 },
+    measureText: (t: unknown) => ({ width: String(t).length * 8 }),
+  };
+  return new Proxy(base, {
+    has: () => true,
+    get(target, key) {
+      const k = String(key);
+      if (k in target) return target[k];
+      if (k in store) return store[k];
+      return (...a: unknown[]) => {
+        rec.calls.push({ m: k, a });
+      };
+    },
+    set(_target, key, value) {
+      store[String(key)] = value;
+      rec.calls.push({ m: `set:${String(key)}`, a: [value] });
+      return true;
+    },
+  }) as unknown as CanvasRenderingContext2D;
+}
+
+vi.mock('mediabunny', () => ({
+  QUALITY_HIGH: 'high',
+  Mp4OutputFormat: class {},
+  WebMOutputFormat: class {},
+  BufferTarget: class {
+    get buffer() {
+      return rec.buffer ? new ArrayBuffer(16) : null;
+    }
+  },
+  CanvasSource: class {
+    async add(at: number, dur: number) {
+      rec.added.push({ at, dur });
+    }
+  },
+  Output: class {
+    target: { buffer: ArrayBuffer | null };
+    constructor(o: { target: { buffer: ArrayBuffer | null } }) {
+      this.target = o.target;
+    }
+    addVideoTrack() {}
+    async start() {
+      rec.started += 1;
+    }
+    async finalize() {
+      rec.finalized += 1;
+    }
+    async cancel() {
+      rec.cancelled += 1;
+    }
+  },
+}));
+
+vi.mock('@/core/export/video-support', async () => {
+  const actual = await vi.importActual<typeof import('@/core/export/video-support')>('@/core/export/video-support');
+  return {
+    ...actual,
+    pickContainer: vi.fn(async (r = '720p') => {
+      rec.probed.push(r);
+      return rec.container;
+    }),
+  };
+});
+
+vi.mock('@/core/screenshot/render', () => ({
+  renderScreenshot: vi.fn(async () => new Blob(['webp'])),
+}));
+
+vi.mock('@/core/export/branding', async () => {
+  const actual = await vi.importActual<typeof import('@/core/export/branding')>('@/core/export/branding');
+  return { ...actual, loadBranding: vi.fn(async () => branding.value) };
+});
+
+const { exportGuideAsVideo } = await import('@/core/export/video-export');
+const { renderScreenshot } = await import('@/core/screenshot/render');
+const { FPS } = await import('@/core/export/video-support');
+
+const guide: Guide = {
+  id: 'g1',
+  title: 'Reset your password',
+  createdAt: new Date('2026-03-04T10:00:00Z').getTime(),
+  updatedAt: new Date('2026-03-04T10:00:00Z').getTime(),
+  stepIds: [],
+  starred: false,
+  deletedAt: null,
+};
+
+function makeStep(i: number, overrides: Partial<Step> = {}): Step {
+  return {
+    id: `s${i}`,
+    guideId: 'g1',
+    index: i,
+    description: `Click the button labelled ${i}`,
+    action: 'click',
+    url: 'https://example.com/settings',
+    timestamp: guide.createdAt,
+    screenshotId: `shot-${i}`,
+    ...overrides,
+  };
+}
+
+function makeShot(stepId: string, overrides: Partial<Screenshot> = {}): Screenshot {
+  return {
+    id: `shot-${stepId}`,
+    stepId,
+    blob: new Blob(['raw']),
+    mimeType: 'image/webp',
+    width: 1280,
+    height: 720,
+    bounds: { x: 100, y: 200, width: 120, height: 40 },
+    pixelRatio: 1,
+    ...overrides,
+  };
+}
+
+function shotsFor(steps: Step[]): Map<string, Screenshot> {
+  return new Map(steps.filter((s) => !s.blockType).map((s) => [s.id, makeShot(s.id)]));
+}
+
+const opts = (o: Partial<ExportOptions> = {}): ExportOptions => ({ ...DEFAULT_EXPORT_OPTIONS, ...o });
+
+beforeEach(() => {
+  rec.calls = [];
+  rec.added = [];
+  rec.closed = 0;
+  rec.container = 'mp4';
+  rec.probed = [];
+  rec.started = 0;
+  rec.finalized = 0;
+  rec.cancelled = 0;
+  rec.buffer = true;
+  branding.value = { logo: null, footer: '', attribution: false, accent: '#4F46E5', custom: false };
+  vi.mocked(renderScreenshot).mockClear();
+  vi.mocked(renderScreenshot).mockResolvedValue(new Blob(['webp']));
+
+  class FakeOffscreen {
+    constructor(
+      public width: number,
+      public height: number,
+    ) {}
+    getContext() {
+      return fakeCtx();
+    }
+  }
+  vi.stubGlobal('OffscreenCanvas', FakeOffscreen);
+  vi.stubGlobal(
+    'createImageBitmap',
+    vi.fn(async () => ({
+      width: 1280,
+      height: 720,
+      close: () => {
+        rec.closed += 1;
+      },
+    })),
+  );
+  vi.stubGlobal('document', {
+    createElement: () => ({ width: 0, height: 0, getContext: () => fakeCtx() }),
+  });
+});
+
+describe('exportGuideAsVideo guards', () => {
+  it('refuses a guide with nothing to show', async () => {
+    await expect(exportGuideAsVideo(guide, [makeStep(0)], new Map(), opts())).rejects.toThrow(/no screenshots/i);
+  });
+
+  it('refuses when the browser cannot encode at all', async () => {
+    rec.container = null;
+    const steps = [makeStep(0)];
+    await expect(exportGuideAsVideo(guide, steps, shotsFor(steps), opts())).rejects.toThrow(/cannot encode/i);
+  });
+
+  it('fails when encoding yields no buffer', async () => {
+    rec.buffer = false;
+    const steps = [makeStep(0)];
+    await expect(exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: false }))).rejects.toThrow(
+      /no output/i,
+    );
+  });
+});
+
+describe('exportGuideAsVideo output', () => {
+  it('produces an mp4 when the container is available', async () => {
+    const steps = [makeStep(0)];
+    const result = await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(result.extension).toBe('mp4');
+    expect(result.blob.type).toBe('video/mp4');
+    expect(result.blob).toBeInstanceOf(Blob);
+  });
+
+  it('falls back to webm when mp4 is unavailable', async () => {
+    rec.container = 'webm';
+    const steps = [makeStep(0)];
+    const result = await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(result.extension).toBe('webm');
+    expect(result.blob.type).toBe('video/webm');
+  });
+
+  it('starts and finalizes the output exactly once', async () => {
+    const steps = [makeStep(0)];
+    await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(rec.started).toBe(1);
+    expect(rec.finalized).toBe(1);
+    expect(rec.cancelled).toBe(0);
+  });
+
+  it('returns chapters describing the timeline', async () => {
+    const steps = [makeStep(0), makeStep(1)];
+    const result = await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(result.chapters.length).toBeGreaterThan(0);
+    expect(result.chapters[0]).toHaveProperty('title');
+  });
+
+  it('emits one encoded segment per frame at the frame rate', async () => {
+    const steps = [makeStep(0)];
+    await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(rec.added.length).toBeGreaterThan(FPS);
+    expect(rec.added.every((s) => s.dur === 1 / FPS)).toBe(true);
+    expect(rec.added[0].at).toBe(0);
+  });
+
+  it('falls back to 720p when the requested resolution cannot be encoded', async () => {
+    const steps = [makeStep(0)];
+    await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: false, resolution: '1080p' }));
+
+    expect(rec.probed[0]).toBe('1080p');
+  });
+});
+
+describe('exportGuideAsVideo cover cards', () => {
+  it('brackets the steps with an opening and closing card', async () => {
+    const steps = [makeStep(0)];
+    await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: true }));
+
+    const holds = rec.added.filter((s) => s.dur === 3);
+    expect(holds.length).toBe(2);
+    expect(holds[0].at).toBe(0);
+  });
+
+  it('offsets the step frames past the opening card', async () => {
+    const steps = [makeStep(0)];
+    await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: true }));
+
+    const stepSegments = rec.added.filter((s) => s.dur === 1 / FPS);
+    expect(stepSegments[0].at).toBe(3);
+  });
+
+  it('adds no cards when the cover is off', async () => {
+    const steps = [makeStep(0)];
+    await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(rec.added.filter((s) => s.dur === 3).length).toBe(0);
+  });
+
+  it('draws the brand logo on the card when one is set', async () => {
+    branding.value = { ...branding.value, logo: { dataUrl: 'data:image/png;base64,AAA', width: 80, height: 30 } };
+    const steps = [makeStep(0)];
+    await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: true }));
+
+    expect(rec.calls.some((c) => c.m === 'drawImage')).toBe(true);
+  });
+});
+
+describe('exportGuideAsVideo progress and abort', () => {
+  it('reports progress that ends on the total', async () => {
+    const steps = [makeStep(0)];
+    const seen: [number, number][] = [];
+    await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: true }), {
+      onProgress: (done, total) => seen.push([done, total]),
+    });
+
+    expect(seen.length).toBeGreaterThan(0);
+    const [done, total] = seen[seen.length - 1];
+    expect(done).toBe(total);
+  });
+
+  it('counts both cards into the total', async () => {
+    const steps = [makeStep(0)];
+    const seen: [number, number][] = [];
+    await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: true }), {
+      onProgress: (done, total) => seen.push([done, total]),
+    });
+    const withCover = seen[0][1];
+
+    seen.length = 0;
+    await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: false }), {
+      onProgress: (done, total) => seen.push([done, total]),
+    });
+
+    expect(withCover - seen[0][1]).toBe(2);
+  });
+
+  it('aborts before any encoding when the signal is already set', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const steps = [makeStep(0)];
+
+    await expect(
+      exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: false }), { signal: controller.signal }),
+    ).rejects.toThrow(/aborted/i);
+  });
+
+  it('cancels the output when aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const steps = [makeStep(0)];
+
+    await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: false }), {
+      signal: controller.signal,
+    }).catch(() => undefined);
+
+    expect(rec.cancelled).toBe(1);
+    expect(rec.finalized).toBe(0);
+  });
+
+  it('releases every decoded bitmap even when it aborts', async () => {
+    const controller = new AbortController();
+    const steps = [makeStep(0), makeStep(1)];
+    let ticks = 0;
+    await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: false }), {
+      signal: controller.signal,
+      onProgress: () => {
+        ticks += 1;
+        if (ticks === 5) controller.abort();
+      },
+    }).catch(() => undefined);
+
+    expect(rec.closed).toBeGreaterThan(0);
+  });
+});
+
+describe('exportGuideAsVideo layers', () => {
+  it('renders each screenshot once and reuses the decoded frame', async () => {
+    const steps = [makeStep(0), makeStep(1)];
+    await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(renderScreenshot).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders the screenshot without the baked target outline', async () => {
+    const steps = [makeStep(0)];
+    await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    expect(vi.mocked(renderScreenshot).mock.calls[0][1]).toMatchObject({ target: false });
+  });
+
+  it('drops step descriptions when the option is off', async () => {
+    const steps = [makeStep(0)];
+    await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: false, stepDescriptions: false }));
+
+    const written = rec.calls.filter((c) => c.m === 'fillText').flatMap((c) => String(c.a[0]));
+    expect(written.some((t) => t.includes('Click the button labelled'))).toBe(false);
+  });
+
+  it('writes the step description into the tooltip when the option is on', async () => {
+    const steps = [makeStep(0)];
+    await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: false, stepDescriptions: true }));
+
+    const written = rec.calls.filter((c) => c.m === 'fillText').flatMap((c) => String(c.a[0]));
+    expect(written.some((t) => t.includes('Click the button labelled'))).toBe(true);
+  });
+
+  it('renders a block step over a blurred backdrop of the previous screenshot', async () => {
+    const steps = [makeStep(0), makeStep(1, { blockType: 'heading', description: 'Part two' })];
+    const shots = shotsFor(steps);
+    await exportGuideAsVideo(guide, steps, shots, opts({ cover: false }));
+
+    expect(renderScreenshot).toHaveBeenCalledTimes(2);
+    const written = rec.calls.filter((c) => c.m === 'fillText').flatMap((c) => String(c.a[0]));
+    expect(written.some((t) => t.includes('Part two'))).toBe(true);
+  });
+
+  it('renders a leading block step with no backdrop behind it', async () => {
+    const steps = [makeStep(0, { blockType: 'callout', description: 'Heads up' }), makeStep(1)];
+    const shots = shotsFor(steps);
+    await exportGuideAsVideo(guide, steps, shots, opts({ cover: false }));
+
+    const written = rec.calls.filter((c) => c.m === 'fillText').flatMap((c) => String(c.a[0]));
+    expect(written.some((t) => t.includes('Heads up'))).toBe(true);
+  });
+
+  it('handles a screenshot with no click target', async () => {
+    const steps = [makeStep(0)];
+    const shots = new Map([['s0', makeShot('s0', { bounds: undefined })]]);
+    const result = await exportGuideAsVideo(guide, steps, shots, opts({ cover: false }));
+
+    expect(result.blob).toBeInstanceOf(Blob);
+  });
+
+  it('cross dissolves between consecutive steps', async () => {
+    const steps = [makeStep(0), makeStep(1)];
+    await exportGuideAsVideo(guide, steps, shotsFor(steps), opts({ cover: false }));
+
+    const alphas = rec.calls.filter((c) => c.m === 'set:globalAlpha').map((c) => c.a[0] as number);
+    expect(alphas.some((a) => a > 0 && a < 1)).toBe(true);
+  });
+});

--- a/src/core/screenshot/__tests__/draw.test.ts
+++ b/src/core/screenshot/__tests__/draw.test.ts
@@ -1,0 +1,339 @@
+import { describe, expect, it } from 'vitest';
+import { type Ctx, drawAnnotation, drawRoundedRect, TARGET_RADIUS, TARGET_STROKE } from '@/core/screenshot/draw';
+import { type Annotation, DEFAULT_LINE_HEIGHT, FONT_FAMILIES, LINE_WIDTHS } from '@/core/screenshot/types';
+
+interface Call {
+  m: string;
+  a: unknown[];
+}
+
+const TRACKED = ['lineWidth', 'strokeStyle', 'fillStyle', 'lineCap', 'lineJoin', 'font', 'filter'];
+
+const METHODS = [
+  'beginPath',
+  'closePath',
+  'moveTo',
+  'lineTo',
+  'arcTo',
+  'arc',
+  'rect',
+  'ellipse',
+  'stroke',
+  'fill',
+  'fillRect',
+  'fillText',
+  'drawImage',
+  'save',
+  'restore',
+  'translate',
+  'rotate',
+  'setLineDash',
+];
+
+function recorder() {
+  const calls: Call[] = [];
+  const state: Record<string, unknown> = {};
+  const ctx: Record<string, unknown> = { canvas: { width: 800, height: 600 } };
+
+  for (const m of METHODS) {
+    ctx[m] = (...a: unknown[]) => {
+      calls.push({ m, a });
+    };
+  }
+  for (const p of TRACKED) {
+    Object.defineProperty(ctx, p, {
+      get: () => state[p],
+      set: (v: unknown) => {
+        state[p] = v;
+        calls.push({ m: `set:${p}`, a: [v] });
+      },
+    });
+  }
+
+  return {
+    ctx: ctx as unknown as Ctx,
+    calls,
+    names: () => calls.map((c) => c.m),
+    first: (m: string) => calls.find((c) => c.m === m)?.a,
+    all: (m: string) => calls.filter((c) => c.m === m).map((c) => c.a),
+    count: (m: string) => calls.filter((c) => c.m === m).length,
+  };
+}
+
+describe('drawRoundedRect', () => {
+  it('emits a closed path of four corner arcs', () => {
+    const r = recorder();
+    drawRoundedRect(r.ctx, 10, 20, 100, 50, 8);
+
+    expect(r.names()).toEqual(['beginPath', 'moveTo', 'arcTo', 'arcTo', 'arcTo', 'arcTo', 'closePath']);
+    expect(r.first('moveTo')).toEqual([18, 20]);
+    expect(r.all('arcTo')[0]).toEqual([110, 20, 110, 70, 8]);
+  });
+});
+
+describe('drawAnnotation redact', () => {
+  it('paints an opaque rectangle for a solid redaction', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { id: 'r1', type: 'redact', style: 'solid', x: 40, y: 50, w: 120, h: 30 }, 0, 0);
+
+    expect(r.first('set:fillStyle')).toEqual(['#1E1B4B']);
+    expect(r.first('fillRect')).toEqual([40, 50, 120, 30]);
+    expect(r.count('drawImage')).toBe(0);
+  });
+
+  it('blurs by resampling the canvas over itself', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { id: 'r2', type: 'redact', style: 'blur', x: 40, y: 50, w: 120, h: 30 }, 0, 0);
+
+    expect(r.first('set:filter')).toEqual(['blur(12px)']);
+    expect(r.first('drawImage')).toEqual([{ width: 800, height: 600 }, 40, 50, 120, 30, 40, 50, 120, 30]);
+    expect(r.count('fillRect')).toBe(0);
+  });
+
+  it('offsets the blur source by the viewport origin so a cropped export blurs the same pixels', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { id: 'r3', type: 'redact', style: 'blur', x: 300, y: 220, w: 80, h: 40 }, 100, 60);
+
+    const [, sx, sy, sw, sh, dx, dy, dw, dh] = r.first('drawImage') as number[];
+    expect([sx, sy]).toEqual([200, 160]);
+    expect([dx, dy]).toEqual([300, 220]);
+    expect([sw, sh, dw, dh]).toEqual([80, 40, 80, 40]);
+  });
+
+  it('leaves the origin out of a solid redaction, which is drawn in destination space', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { id: 'r4', type: 'redact', style: 'solid', x: 300, y: 220, w: 80, h: 40 }, 100, 60);
+
+    expect(r.first('fillRect')).toEqual([300, 220, 80, 40]);
+  });
+
+  it('balances save and restore so a redaction cannot leak its filter onto later annotations', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { id: 'r5', type: 'redact', style: 'blur', x: 0, y: 0, w: 10, h: 10 }, 0, 0);
+
+    expect(r.count('save')).toBe(1);
+    expect(r.count('restore')).toBe(1);
+    expect(r.names().at(0)).toBe('save');
+    expect(r.names().at(-1)).toBe('restore');
+  });
+});
+
+describe('drawAnnotation box', () => {
+  const base = { id: 'b', type: 'box', x: 5, y: 6, w: 70, h: 40, color: '#EF4444' } as const;
+
+  it('strokes without filling when the fill is transparent', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { ...base, fill: 'transparent' }, 0, 0);
+
+    expect(r.count('fill')).toBe(0);
+    expect(r.count('stroke')).toBe(1);
+    expect(r.first('set:strokeStyle')).toEqual(['#EF4444']);
+  });
+
+  it('fills and strokes when a fill colour is set', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { ...base, fill: '#FACC15' }, 0, 0);
+
+    expect(r.first('set:fillStyle')).toEqual(['#FACC15']);
+    expect(r.count('fill')).toBe(1);
+    expect(r.count('stroke')).toBe(1);
+  });
+
+  it('skips the stroke when the line width is none', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { ...base, lineWidth: 'none', fill: '#FACC15' }, 0, 0);
+
+    expect(r.count('fill')).toBe(1);
+    expect(r.count('stroke')).toBe(0);
+  });
+
+  it('defaults the line width to ms', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, base, 0, 0);
+
+    expect(r.first('set:lineWidth')).toEqual([LINE_WIDTHS.ms]);
+  });
+
+  it('honours an explicit corner radius', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { ...base, radius: 14 }, 0, 0);
+
+    expect(r.first('moveTo')).toEqual([base.x + 14, base.y]);
+  });
+});
+
+describe('drawAnnotation ellipse', () => {
+  it('centres the ellipse in its bounding box and uses absolute radii', () => {
+    const r = recorder();
+    drawAnnotation(
+      r.ctx,
+      { id: 'e', type: 'ellipse', x: 10, y: 20, w: -60, h: 40, color: '#22C55E', fill: 'transparent' },
+      0,
+      0,
+    );
+
+    expect(r.first('ellipse')).toEqual([-20, 40, 30, 20, 0, 0, Math.PI * 2]);
+    expect(r.count('fill')).toBe(0);
+    expect(r.count('stroke')).toBe(1);
+  });
+
+  it('fills before stroking when given a fill', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { id: 'e', type: 'ellipse', x: 0, y: 0, w: 10, h: 10, color: '#000', fill: '#FFF' }, 0, 0);
+
+    expect(r.names().indexOf('fill')).toBeLessThan(r.names().indexOf('stroke'));
+  });
+});
+
+describe('drawAnnotation target', () => {
+  const base = { id: 't', type: 'target', x: 12, y: 14, w: 200, h: 90, color: '#4F46E5' } as const;
+
+  it('dashes the outline when the border is dashed', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { ...base, border: 'dashed' }, 0, 0);
+
+    expect(r.first('setLineDash')).toEqual([[8, 5]]);
+    expect(r.first('set:lineWidth')).toEqual([TARGET_STROKE]);
+    expect(r.first('moveTo')).toEqual([base.x + TARGET_RADIUS, base.y]);
+  });
+
+  it('leaves the outline solid when the border is solid', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { ...base, border: 'solid' }, 0, 0);
+
+    expect(r.count('setLineDash')).toBe(0);
+    expect(r.count('stroke')).toBe(1);
+  });
+});
+
+describe('drawAnnotation arrow', () => {
+  const base = { id: 'a', type: 'arrow', x1: 0, y1: 0, x2: 100, y2: 0, color: '#2563EB' } as const;
+
+  it('draws the shaft between both points', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { ...base, end: 'none' }, 0, 0);
+
+    expect(r.first('moveTo')).toEqual([0, 0]);
+    expect(r.first('lineTo')).toEqual([100, 0]);
+    expect(r.count('translate')).toBe(0);
+  });
+
+  it('rotates the head to the shaft angle', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { ...base, x2: 0, y2: 100, end: 'arrow' }, 0, 0);
+
+    expect(r.first('translate')).toEqual([0, 100]);
+    expect(r.first('rotate')).toEqual([Math.PI / 2]);
+  });
+
+  it.each([
+    ['bar', { stroke: 1, fill: 0 }],
+    ['arrow', { stroke: 1, fill: 0 }],
+    ['arrow-solid', { stroke: 0, fill: 1 }],
+    ['circle', { stroke: 1, fill: 0 }],
+    ['circle-solid', { stroke: 0, fill: 1 }],
+    ['square', { stroke: 1, fill: 0 }],
+    ['square-solid', { stroke: 0, fill: 1 }],
+  ] as const)('renders the %s head', (end, expected) => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { ...base, end }, 0, 0);
+
+    expect(r.count('stroke') - 1).toBe(expected.stroke);
+    expect(r.count('fill')).toBe(expected.fill);
+  });
+
+  it('defaults to a solid arrow head', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, base, 0, 0);
+
+    expect(r.count('fill')).toBe(1);
+  });
+});
+
+describe('drawAnnotation text', () => {
+  const base = { id: 'x', type: 'text', x: 20, y: 40, text: 'Hello', color: '#000', size: 32 } as const;
+
+  it('writes one line at the anchor', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, base, 0, 0);
+
+    expect(r.all('fillText')).toEqual([['Hello', 20, 40]]);
+  });
+
+  it('stacks each newline by the line height', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { ...base, text: 'a\nb\nc' }, 0, 0);
+
+    const step = 32 * DEFAULT_LINE_HEIGHT;
+    expect(r.all('fillText')).toEqual([
+      ['a', 20, 40],
+      ['b', 20, 40 + step],
+      ['c', 20, 40 + 2 * step],
+    ]);
+  });
+
+  it('honours an explicit line height', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { ...base, text: 'a\nb', lineHeight: 2 }, 0, 0);
+
+    expect(r.all('fillText')[1]).toEqual(['b', 20, 40 + 64]);
+  });
+
+  it('composes weight, slant and family into the font string', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { ...base, bold: true, italic: true, fontFamily: 'serif' }, 0, 0);
+
+    expect(r.first('set:font')).toEqual([`italic 700 32px ${FONT_FAMILIES.serif}`]);
+  });
+
+  it('defaults to medium weight, upright, sans-serif', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, base, 0, 0);
+
+    expect(r.first('set:font')).toEqual([`500 32px ${FONT_FAMILIES['sans-serif']}`]);
+  });
+});
+
+describe('drawAnnotation freehand', () => {
+  it('traces every point pair in order', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { id: 'f', type: 'freehand', points: [1, 2, 3, 4, 5, 6], color: '#EC4899' }, 0, 0);
+
+    expect(r.first('moveTo')).toEqual([1, 2]);
+    expect(r.all('lineTo')).toEqual([
+      [3, 4],
+      [5, 6],
+    ]);
+  });
+
+  it('defaults the stroke to md and rounds the joins', () => {
+    const r = recorder();
+    drawAnnotation(r.ctx, { id: 'f', type: 'freehand', points: [0, 0, 1, 1], color: '#000' }, 0, 0);
+
+    expect(r.first('set:lineWidth')).toEqual([LINE_WIDTHS.md]);
+    expect(r.first('set:lineJoin')).toEqual(['round']);
+    expect(r.first('set:lineCap')).toEqual(['round']);
+  });
+});
+
+describe('drawAnnotation state isolation', () => {
+  const each: Annotation[] = [
+    { id: '1', type: 'box', x: 0, y: 0, w: 1, h: 1, color: '#000' },
+    { id: '2', type: 'ellipse', x: 0, y: 0, w: 1, h: 1, color: '#000' },
+    { id: '3', type: 'target', x: 0, y: 0, w: 1, h: 1, color: '#000', border: 'dashed' },
+    { id: '4', type: 'arrow', x1: 0, y1: 0, x2: 1, y2: 1, color: '#000' },
+    { id: '5', type: 'text', x: 0, y: 0, text: 'a', color: '#000', size: 12 },
+    { id: '6', type: 'freehand', points: [0, 0, 1, 1], color: '#000' },
+    { id: '7', type: 'redact', x: 0, y: 0, w: 1, h: 1, style: 'solid' },
+    { id: '8', type: 'redact', x: 0, y: 0, w: 1, h: 1, style: 'blur' },
+  ];
+
+  it.each(each.map((a) => [`${a.type}:${a.id}`, a] as const))('balances save and restore for %s', (_label, a) => {
+    const r = recorder();
+    drawAnnotation(r.ctx, a, 0, 0);
+
+    expect(r.count('save')).toBe(r.count('restore'));
+    expect(r.names().at(0)).toBe('save');
+    expect(r.names().at(-1)).toBe('restore');
+  });
+});

--- a/src/core/screenshot/__tests__/render.test.ts
+++ b/src/core/screenshot/__tests__/render.test.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Screenshot } from '@/core/guides/types';
+import type { Annotation } from '@/core/screenshot/types';
+import { DEFAULT_TARGET_COLOR } from '@/core/screenshot/types';
+
+const drawAnnotation = vi.hoisted(() => vi.fn());
+vi.mock('@/core/screenshot/draw', () => ({ drawAnnotation }));
+
+const { imageDimensions, renderScreenshot } = await import('@/core/screenshot/render');
+
+interface Call {
+  m: string;
+  a: unknown[];
+}
+
+let calls: Call[] = [];
+let closed = 0;
+let canvases: FakeCanvas[] = [];
+let convertArgs: unknown[] = [];
+
+class FakeCanvas {
+  ctx: Record<string, unknown>;
+
+  constructor(
+    public width: number,
+    public height: number,
+  ) {
+    canvases.push(this);
+    const record =
+      (m: string) =>
+      (...a: unknown[]) => {
+        calls.push({ m, a });
+      };
+    this.ctx = {
+      canvas: this,
+      drawImage: record('drawImage'),
+      translate: record('translate'),
+      save: record('save'),
+      restore: record('restore'),
+    };
+  }
+
+  getContext() {
+    return this.ctx;
+  }
+
+  convertToBlob(opts: unknown) {
+    convertArgs.push(opts);
+    return Promise.resolve(new Blob(['out']));
+  }
+}
+
+function makeScreenshot(overrides: Partial<Screenshot> = {}): Screenshot {
+  return {
+    id: 'ss-1',
+    stepId: 'step-1',
+    blob: new Blob(['raw']),
+    mimeType: 'image/png',
+    width: 1200,
+    height: 900,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  calls = [];
+  canvases = [];
+  convertArgs = [];
+  closed = 0;
+  drawAnnotation.mockClear();
+  vi.stubGlobal(
+    'createImageBitmap',
+    vi.fn(async () => ({
+      width: 1200,
+      height: 900,
+      close: () => {
+        closed += 1;
+      },
+    })),
+  );
+  vi.stubGlobal('OffscreenCanvas', FakeCanvas);
+});
+
+describe('imageDimensions', () => {
+  it('reads the bitmap size and releases it', async () => {
+    await expect(imageDimensions(new Blob(['x']))).resolves.toEqual({ width: 1200, height: 900 });
+    expect(closed).toBe(1);
+  });
+});
+
+describe('renderScreenshot', () => {
+  it('sizes the canvas to the full image when there is no crop', async () => {
+    await renderScreenshot(makeScreenshot());
+
+    expect(canvases[0].width).toBe(1200);
+    expect(canvases[0].height).toBe(900);
+  });
+
+  it('rounds a fractional viewport to whole pixels', async () => {
+    const s = makeScreenshot({ edits: { viewport: { x: 10, y: 20, width: 640.6, height: 480.2 } } });
+    await renderScreenshot(s);
+
+    expect(canvases[0].width).toBe(641);
+    expect(canvases[0].height).toBe(480);
+  });
+
+  it('maps the viewport rectangle onto the whole canvas', async () => {
+    const s = makeScreenshot({ edits: { viewport: { x: 100, y: 50, width: 600, height: 400 } } });
+    await renderScreenshot(s);
+
+    const [, sx, sy, sw, sh, dx, dy, dw, dh] = calls.find((c) => c.m === 'drawImage')?.a as number[];
+    expect([sx, sy, sw, sh]).toEqual([100, 50, 600, 400]);
+    expect([dx, dy, dw, dh]).toEqual([0, 0, 600, 400]);
+  });
+
+  it('shifts the origin so annotations can use full image coordinates', async () => {
+    const s = makeScreenshot({ edits: { viewport: { x: 100, y: 50, width: 600, height: 400 } } });
+    await renderScreenshot(s);
+
+    expect(calls.find((c) => c.m === 'translate')?.a).toEqual([-100, -50]);
+  });
+
+  it('releases the bitmap after drawing it', async () => {
+    await renderScreenshot(makeScreenshot());
+
+    expect(closed).toBe(1);
+  });
+
+  it('defaults to webp at 0.85', async () => {
+    await renderScreenshot(makeScreenshot());
+
+    expect(convertArgs[0]).toEqual({ type: 'image/webp', quality: 0.85 });
+  });
+
+  it('honours an explicit format and quality', async () => {
+    await renderScreenshot(makeScreenshot(), { format: 'image/jpeg', quality: 0.5 });
+
+    expect(convertArgs[0]).toEqual({ type: 'image/jpeg', quality: 0.5 });
+  });
+
+  it('returns the encoded blob', async () => {
+    await expect(renderScreenshot(makeScreenshot())).resolves.toBeInstanceOf(Blob);
+  });
+});
+
+describe('renderScreenshot click target', () => {
+  const bounded = () => makeScreenshot({ bounds: { x: 30, y: 40, width: 120, height: 60 }, pixelRatio: 2 });
+
+  it('outlines the click target derived from bounds and pixel ratio', async () => {
+    await renderScreenshot(bounded());
+
+    expect(drawAnnotation).toHaveBeenCalledTimes(1);
+    expect(drawAnnotation.mock.calls[0][1]).toEqual({
+      id: 'target',
+      type: 'target',
+      x: 60,
+      y: 80,
+      w: 240,
+      h: 120,
+      color: DEFAULT_TARGET_COLOR,
+      border: 'dashed',
+    });
+  });
+
+  it('skips the outline when the caller opts out', async () => {
+    await renderScreenshot(bounded(), { target: false });
+
+    expect(drawAnnotation).not.toHaveBeenCalled();
+  });
+
+  it('draws no outline when the screenshot has no bounds', async () => {
+    await renderScreenshot(makeScreenshot());
+
+    expect(drawAnnotation).not.toHaveBeenCalled();
+  });
+
+  it('prefers an explicit edited target over the captured bounds', async () => {
+    const s = makeScreenshot({
+      bounds: { x: 30, y: 40, width: 120, height: 60 },
+      edits: { target: { x: 5, y: 6, width: 7, height: 8, border: 'solid', color: '#F43F5E' } },
+    });
+    await renderScreenshot(s);
+
+    expect(drawAnnotation.mock.calls[0][1]).toMatchObject({ x: 5, y: 6, w: 7, h: 8, border: 'solid' });
+  });
+
+  it('honours an edited target that was cleared', async () => {
+    const s = makeScreenshot({ bounds: { x: 30, y: 40, width: 120, height: 60 }, edits: { target: null } });
+    await renderScreenshot(s);
+
+    expect(drawAnnotation).not.toHaveBeenCalled();
+  });
+});
+
+describe('renderScreenshot annotations', () => {
+  const annotations: Annotation[] = [
+    { id: 'a1', type: 'box', x: 1, y: 2, w: 3, h: 4, color: '#000' },
+    { id: 'a2', type: 'redact', x: 5, y: 6, w: 7, h: 8, style: 'blur' },
+  ];
+
+  it('draws every annotation in order after the target', async () => {
+    const s = makeScreenshot({
+      bounds: { x: 10, y: 10, width: 20, height: 20 },
+      edits: { annotations },
+    });
+    await renderScreenshot(s);
+
+    const ids = drawAnnotation.mock.calls.map((c) => (c[1] as Annotation).id);
+    expect(ids).toEqual(['target', 'a1', 'a2']);
+  });
+
+  it('passes the viewport origin so a redaction lands on the right pixels', async () => {
+    const s = makeScreenshot({
+      edits: { viewport: { x: 100, y: 50, width: 600, height: 400 }, annotations },
+    });
+    await renderScreenshot(s);
+
+    for (const call of drawAnnotation.mock.calls) {
+      expect([call[2], call[3]]).toEqual([100, 50]);
+    }
+  });
+
+  it('draws nothing extra when there are no annotations', async () => {
+    await renderScreenshot(makeScreenshot({ edits: { annotations: [] } }));
+
+    expect(drawAnnotation).not.toHaveBeenCalled();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,13 @@ export default defineConfig({
     watch: false,
     coverage: {
       provider: "istanbul",
-      reporter: ["text", "html", "lcov"],
+      reporter: ["text", "json-summary", "html", "lcov"],
+      thresholds: {
+        statements: 78,
+        branches: 66,
+        functions: 76,
+        lines: 78,
+      },
     },
   },
 });


### PR DESCRIPTION
Mimik's export path had thin automated cover. The screenshot redraw every export depends on sat at 0 to 2%, PDF at 25%, video at 36%. Manual checking catches an obviously broken file, not one blur missing from step 14 of a long guide.

This covers that redraw, PDF page composition and pagination, and video frame composition, cover cards and abort handling. Statements go from 62.78% to 78.25% app wide, `core/export` to 89%, `core/screenshot` to 98%. `pnpm test:cov` now runs in CI behind a floor set at the level this lands on, so the number cannot slide quietly.

The coverage table goes to the job summary rather than an inline PR comment, which would need a third-party action and write permission.

Lint, typecheck, 1033 tests and both builds clean.
