### PR TITLE
fix(voice): fill step descriptions from narration while the recording runs

### DIFF
--- a/src/core/capture/voice/__tests__/partial-recording.test.ts
+++ b/src/core/capture/voice/__tests__/partial-recording.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { partialRecording } from '../partial-recording';
+
+const RATE = 16000;
+const EPOCH = 1_700_000_000_000;
+
+function recording(seconds: number) {
+  const pcm = new Int16Array(RATE * seconds);
+  for (let i = 0; i < pcm.length; i++) pcm[i] = i % 1000;
+  return { pcm, sampleRate: RATE, audioEpochMs: EPOCH, durationSeconds: seconds };
+}
+
+describe('partialRecording', () => {
+  it('takes only the samples inside the range', () => {
+    const part = partialRecording(recording(10), 4, 7);
+
+    expect(part?.pcm.length).toBe(RATE * 3);
+    expect(part?.durationSeconds).toBeCloseTo(3, 5);
+  });
+
+  it('moves the epoch forward to the start of the slice', () => {
+    const part = partialRecording(recording(10), 4, 7);
+
+    expect(part?.audioEpochMs).toBe(EPOCH + 4000);
+  });
+
+  it('carries the samples that were actually in the range', () => {
+    const full = recording(10);
+    const part = partialRecording(full, 4, 7);
+
+    expect(part?.pcm[0]).toBe(full.pcm[4 * RATE]);
+  });
+
+  it('clamps to the audio that exists when the range runs past the end', () => {
+    const part = partialRecording(recording(5), 3, 9);
+
+    expect(part?.pcm.length).toBe(RATE * 2);
+    expect(part?.durationSeconds).toBeCloseTo(2, 5);
+  });
+
+  it('returns nothing when the range is too short to hold speech', () => {
+    expect(partialRecording(recording(10), 4, 4.4)).toBeNull();
+  });
+
+  it('returns nothing when the range has already been consumed', () => {
+    expect(partialRecording(recording(10), 7, 4)).toBeNull();
+  });
+
+  it('returns nothing when the range starts past the end of the audio', () => {
+    expect(partialRecording(recording(5), 6, 9)).toBeNull();
+  });
+});

--- a/src/core/capture/voice/partial-recording.ts
+++ b/src/core/capture/voice/partial-recording.ts
@@ -1,0 +1,26 @@
+import { MIN_SPEECH_S } from './batching';
+
+export interface RecordingSlice {
+  pcm: Int16Array;
+  sampleRate: number;
+  audioEpochMs: number;
+  durationSeconds: number;
+}
+
+export function partialRecording(
+  recording: RecordingSlice,
+  fromSeconds: number,
+  toSeconds: number,
+): RecordingSlice | null {
+  const { pcm, sampleRate, audioEpochMs } = recording;
+  const from = Math.max(0, Math.floor(fromSeconds * sampleRate));
+  const to = Math.min(pcm.length, Math.floor(toSeconds * sampleRate));
+  if (to - from < MIN_SPEECH_S * sampleRate) return null;
+
+  return {
+    pcm: pcm.slice(from, to),
+    sampleRate,
+    audioEpochMs: audioEpochMs + Math.round((from / sampleRate) * 1000),
+    durationSeconds: (to - from) / sampleRate,
+  };
+}

--- a/src/core/guides/__tests__/ai-pending.test.ts
+++ b/src/core/guides/__tests__/ai-pending.test.ts
@@ -24,7 +24,13 @@ const { broadcasts } = vi.hoisted(() => {
 });
 
 import { db } from '../db';
-import { applyNarrationToSteps, clearStepAiPending, type GuideChangeEvent, updateStepDescription } from '../service';
+import {
+  applyAiDescription,
+  applyNarrationToSteps,
+  clearStepAiPending,
+  type GuideChangeEvent,
+  updateStepDescription,
+} from '../service';
 import type { Guide, Step } from '../types';
 
 const FALLBACK = 'Clicked Save';
@@ -191,5 +197,29 @@ describe('clearStepAiPending', () => {
     const sibling = await db.steps.get('s2');
     expect(sibling?.description).toBe('Clicked Cancel');
     expect(sibling?.aiPending).toBe(true);
+  });
+});
+
+describe('applyAiDescription', () => {
+  it('fills a step that narration did not cover', async () => {
+    await db.steps.add(makeStep({ id: 's9', aiPending: false }));
+
+    await applyAiDescription('s9', AI_TEXT);
+
+    const step = await db.steps.get('s9');
+    expect(step?.description).toBe(AI_TEXT);
+    expect(step?.descriptionSource).toBe('ai');
+  });
+
+  it('leaves a narrated step alone', async () => {
+    await db.steps.add(makeStep({ id: 's10', description: 'What I said out loud', descriptionSource: 'narration' }));
+
+    await applyAiDescription('s10', AI_TEXT);
+
+    expect((await db.steps.get('s10'))?.description).toBe('What I said out loud');
+  });
+
+  it('does nothing for a step that no longer exists', async () => {
+    await expect(applyAiDescription('gone', AI_TEXT)).resolves.toBeUndefined();
   });
 });

--- a/src/core/guides/__tests__/ai-pending.test.ts
+++ b/src/core/guides/__tests__/ai-pending.test.ts
@@ -223,3 +223,15 @@ describe('applyAiDescription', () => {
     await expect(applyAiDescription('gone', AI_TEXT)).resolves.toBeUndefined();
   });
 });
+
+describe('narration clears the pending spinner', () => {
+  it('stops a narrated step from waiting on a description', async () => {
+    await db.steps.add(makeStep({ id: 's20', aiPending: true }));
+
+    await applyNarrationToSteps([{ stepId: 's20', description: 'what I said' }]);
+
+    const step = await db.steps.get('s20');
+    expect(step?.description).toBe('what I said');
+    expect(step?.aiPending).toBe(false);
+  });
+});

--- a/src/core/guides/service.ts
+++ b/src/core/guides/service.ts
@@ -203,7 +203,7 @@ export async function applyNarrationToSteps(updates: readonly NarrationUpdate[])
   if (updates.length === 0) return;
   await db.transaction('rw', db.steps, async () => {
     for (const { stepId, description } of updates) {
-      await db.steps.update(stepId, { description, descriptionSource: 'narration' });
+      await db.steps.update(stepId, { description, descriptionSource: 'narration', aiPending: false });
     }
   });
   notifyGuidesChanged({ type: 'mutated' });

--- a/src/core/guides/service.ts
+++ b/src/core/guides/service.ts
@@ -209,6 +209,16 @@ export async function applyNarrationToSteps(updates: readonly NarrationUpdate[])
   notifyGuidesChanged({ type: 'mutated' });
 }
 
+export async function applyAiDescription(stepId: string, description: string): Promise<void> {
+  const wrote = await db.transaction('rw', db.steps, async () => {
+    const step = await db.steps.get(stepId);
+    if (!step || step.descriptionSource === 'narration') return false;
+    await db.steps.update(stepId, { description, descriptionSource: 'ai', aiPending: false });
+    return true;
+  });
+  if (wrote) notifyGuidesChanged({ type: 'mutated' });
+}
+
 export async function clearStepAiPending(stepId: string, description?: string): Promise<void> {
   const wrote = await db.transaction('rw', db.steps, async () => {
     const step = await db.steps.get(stepId);

--- a/src/entrypoints/background/__tests__/deferred-descriptions.test.ts
+++ b/src/entrypoints/background/__tests__/deferred-descriptions.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { DOMContext } from '@/core/capture/dom/context';
+import {
+  clearDeferredDescriptions,
+  deferDescription,
+  shouldQueueAiDescription,
+  takeDeferredDescriptions,
+} from '../deferred-descriptions';
+
+const ctx = (name: string) => ({ page: { title: name, path: '/' } }) as DOMContext;
+
+const base = { action: 'click', hasDomContext: true, hasAiKey: true, narrationCapturing: false };
+
+describe('shouldQueueAiDescription', () => {
+  it('queues a description for a normal click', () => {
+    expect(shouldQueueAiDescription(base)).toBe(true);
+  });
+
+  it('does not queue while narration is capturing', () => {
+    expect(shouldQueueAiDescription({ ...base, narrationCapturing: true })).toBe(false);
+  });
+
+  it('does not queue without an api key', () => {
+    expect(shouldQueueAiDescription({ ...base, hasAiKey: false })).toBe(false);
+  });
+
+  it('does not queue without dom context', () => {
+    expect(shouldQueueAiDescription({ ...base, hasDomContext: false })).toBe(false);
+  });
+
+  it('does not queue for input actions', () => {
+    expect(shouldQueueAiDescription({ ...base, action: 'input' })).toBe(false);
+  });
+});
+
+describe('takeDeferredDescriptions', () => {
+  beforeEach(() => {
+    clearDeferredDescriptions('g1');
+    clearDeferredDescriptions('g2');
+  });
+
+  it('returns the steps narration did not cover', () => {
+    deferDescription('g1', 's1', ctx('one'));
+    deferDescription('g1', 's2', ctx('two'));
+
+    const pending = takeDeferredDescriptions('g1', ['s1']);
+
+    expect(pending.map((p) => p.stepId)).toEqual(['s2']);
+  });
+
+  it('returns every step when nothing was narrated', () => {
+    deferDescription('g1', 's1', ctx('one'));
+    deferDescription('g1', 's2', ctx('two'));
+
+    expect(takeDeferredDescriptions('g1', []).map((p) => p.stepId)).toEqual(['s1', 's2']);
+  });
+
+  it('carries the dom context captured at the time', () => {
+    deferDescription('g1', 's1', ctx('billing'));
+
+    expect(takeDeferredDescriptions('g1', [])[0].domContext.page.title).toBe('billing');
+  });
+
+  it('drains, so a second call returns nothing', () => {
+    deferDescription('g1', 's1', ctx('one'));
+    takeDeferredDescriptions('g1', []);
+
+    expect(takeDeferredDescriptions('g1', [])).toEqual([]);
+  });
+
+  it('keeps guides separate', () => {
+    deferDescription('g1', 's1', ctx('one'));
+    deferDescription('g2', 's2', ctx('two'));
+
+    expect(takeDeferredDescriptions('g1', []).map((p) => p.stepId)).toEqual(['s1']);
+    expect(takeDeferredDescriptions('g2', []).map((p) => p.stepId)).toEqual(['s2']);
+  });
+
+  it('returns nothing for a guide that deferred nothing', () => {
+    expect(takeDeferredDescriptions('g1', [])).toEqual([]);
+  });
+});

--- a/src/entrypoints/background/__tests__/deferred-descriptions.test.ts
+++ b/src/entrypoints/background/__tests__/deferred-descriptions.test.ts
@@ -3,6 +3,7 @@ import type { DOMContext } from '@/core/capture/dom/context';
 import {
   clearDeferredDescriptions,
   deferDescription,
+  discardDeferred,
   shouldQueueAiDescription,
   takeDeferredDescriptions,
 } from '../deferred-descriptions';
@@ -78,5 +79,32 @@ describe('takeDeferredDescriptions', () => {
 
   it('returns nothing for a guide that deferred nothing', () => {
     expect(takeDeferredDescriptions('g1', [])).toEqual([]);
+  });
+});
+
+describe('discardDeferred', () => {
+  beforeEach(() => {
+    clearDeferredDescriptions('g1');
+  });
+
+  it('drops only the steps narration already covered', () => {
+    deferDescription('g1', 's1', ctx('one'));
+    deferDescription('g1', 's2', ctx('two'));
+
+    discardDeferred('g1', ['s1']);
+
+    expect(takeDeferredDescriptions('g1', []).map((p) => p.stepId)).toEqual(['s2']);
+  });
+
+  it('leaves the rest waiting for the end of the recording', () => {
+    deferDescription('g1', 's1', ctx('one'));
+
+    discardDeferred('g1', ['s2']);
+
+    expect(takeDeferredDescriptions('g1', []).map((p) => p.stepId)).toEqual(['s1']);
+  });
+
+  it('does nothing for a guide with nothing deferred', () => {
+    expect(() => discardDeferred('g1', ['s1'])).not.toThrow();
   });
 });

--- a/src/entrypoints/background/__tests__/start-narration.test.ts
+++ b/src/entrypoints/background/__tests__/start-narration.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { CaptureState } from '@/core/capture/machine';
+import { canStartNarrationNow } from '../voice';
+
+describe('canStartNarrationNow', () => {
+  it('starts narration when a recording is running and narration is not', () => {
+    expect(canStartNarrationNow(CaptureState.RECORDING, 'idle')).toBe(true);
+  });
+
+  it('does not start when nothing is being recorded', () => {
+    expect(canStartNarrationNow(CaptureState.IDLE, 'idle')).toBe(false);
+  });
+
+  it('does not start a second capture when narration is already running', () => {
+    expect(canStartNarrationNow(CaptureState.RECORDING, 'recording')).toBe(false);
+  });
+
+  it('does not start while a previous take is still transcribing', () => {
+    expect(canStartNarrationNow(CaptureState.RECORDING, 'transcribing')).toBe(false);
+  });
+
+  it('starts again after a failed take', () => {
+    expect(canStartNarrationNow(CaptureState.RECORDING, 'error')).toBe(true);
+  });
+});

--- a/src/entrypoints/background/ai-description.ts
+++ b/src/entrypoints/background/ai-description.ts
@@ -1,0 +1,13 @@
+import { getAIDescription } from '@/core/capture/ai/description';
+import type { DOMContext } from '@/core/capture/dom/context';
+import { localStorage } from '@/lib/browser-api';
+
+export async function generateAiDescription(domContext: DOMContext): Promise<string | undefined> {
+  const settings = await localStorage.get(['aiApiKey', 'aiProvider', 'aiModel']);
+  if (!settings.aiApiKey) return undefined;
+
+  const provider = (settings.aiProvider as string) || 'openai';
+  const model = (settings.aiModel as string) || 'gpt-4o-mini';
+  const description = await getAIDescription(domContext, provider, model, settings.aiApiKey as string);
+  return description || undefined;
+}

--- a/src/entrypoints/background/deferred-descriptions.ts
+++ b/src/entrypoints/background/deferred-descriptions.ts
@@ -1,0 +1,45 @@
+import type { DOMContext } from '@/core/capture/dom/context';
+
+export interface DeferredDescription {
+  stepId: string;
+  domContext: DOMContext;
+}
+
+export interface AiDescriptionInput {
+  action: string;
+  hasDomContext: boolean;
+  hasAiKey: boolean;
+  narrationCapturing: boolean;
+}
+
+const deferred = new Map<string, Map<string, DOMContext>>();
+
+export function shouldQueueAiDescription({
+  action,
+  hasDomContext,
+  hasAiKey,
+  narrationCapturing,
+}: AiDescriptionInput): boolean {
+  return action !== 'input' && hasDomContext && hasAiKey && !narrationCapturing;
+}
+
+export function deferDescription(guideId: string, stepId: string, domContext: DOMContext): void {
+  const forGuide = deferred.get(guideId) ?? new Map<string, DOMContext>();
+  forGuide.set(stepId, domContext);
+  deferred.set(guideId, forGuide);
+}
+
+export function takeDeferredDescriptions(guideId: string, narratedStepIds: readonly string[]): DeferredDescription[] {
+  const forGuide = deferred.get(guideId);
+  if (!forGuide) return [];
+  deferred.delete(guideId);
+
+  const narrated = new Set(narratedStepIds);
+  return [...forGuide]
+    .filter(([stepId]) => !narrated.has(stepId))
+    .map(([stepId, domContext]) => ({ stepId, domContext }));
+}
+
+export function clearDeferredDescriptions(guideId: string): void {
+  deferred.delete(guideId);
+}

--- a/src/entrypoints/background/deferred-descriptions.ts
+++ b/src/entrypoints/background/deferred-descriptions.ts
@@ -40,6 +40,12 @@ export function takeDeferredDescriptions(guideId: string, narratedStepIds: reado
     .map(([stepId, domContext]) => ({ stepId, domContext }));
 }
 
+export function discardDeferred(guideId: string, stepIds: readonly string[]): void {
+  const forGuide = deferred.get(guideId);
+  if (!forGuide) return;
+  for (const stepId of stepIds) forGuide.delete(stepId);
+}
+
 export function clearDeferredDescriptions(guideId: string): void {
   deferred.delete(guideId);
 }

--- a/src/entrypoints/background/describe-unnarrated.ts
+++ b/src/entrypoints/background/describe-unnarrated.ts
@@ -1,0 +1,13 @@
+import { applyAiDescription } from '@/core/guides/service';
+import { generateAiDescription } from './ai-description';
+import { takeDeferredDescriptions } from './deferred-descriptions';
+import { queueDescription } from './description-queue';
+
+export function describeUnnarratedSteps(guideId: string, narratedStepIds: readonly string[]): void {
+  for (const { stepId, domContext } of takeDeferredDescriptions(guideId, narratedStepIds)) {
+    queueDescription(guideId, async () => {
+      const description = await generateAiDescription(domContext);
+      if (description) await applyAiDescription(stepId, description);
+    });
+  }
+}

--- a/src/entrypoints/background/guide-meta.ts
+++ b/src/entrypoints/background/guide-meta.ts
@@ -13,6 +13,7 @@ import { localStorage } from '@/lib/browser-api';
 import { logger } from '@/lib/logger';
 import type { GenerateGuideDescriptionResponse, GuideDescriptionError } from '@/lib/messaging';
 import { drainDescriptions } from './description-queue';
+import { whenNarrationSettled } from './voice';
 
 type ResolveFailure = Extract<GuideDescriptionError, 'no-api-key' | 'no-steps'>;
 
@@ -47,6 +48,7 @@ async function applyFallbackTitle(guideId: string) {
 }
 
 export async function settlePendingDescriptions(guideId: string) {
+  await whenNarrationSettled();
   await drainDescriptions(guideId);
   const pending = (await getStepsForGuide(guideId)).filter((s) => s.aiPending);
   await Promise.all(pending.map((s) => clearStepAiPending(s.id)));

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -28,7 +28,13 @@ import { generateDescriptionOnDemand, generateGuideMetaOnStop, settlePendingDesc
 import { registerNavigationListeners } from './navigation';
 import { handleCaptureStep, handleFinalizeInputStep, handleUpdateInputStep } from './step-pipeline';
 import { broadcastStartCapture, broadcastStopCapture, showNotificationOnTab } from './tab-manager';
-import { getVoiceUpdate, registerVoiceListeners, startVoiceNarration, stopVoiceNarration } from './voice';
+import {
+  canStartNarrationNow,
+  getVoiceUpdate,
+  registerVoiceListeners,
+  startVoiceNarration,
+  stopVoiceNarration,
+} from './voice';
 
 async function resolveManual(step: Step): Promise<boolean> {
   if (!step.screenshotId) return stepRequiresManual(step, null);
@@ -140,6 +146,17 @@ export default defineBackground(() => {
     if (guideId) generateGuideMetaOnStop(guideId).catch(() => {});
 
     return { success: true, guideId: guideId ?? undefined, inserted: false };
+  });
+
+  onMessage('startNarration', async () => {
+    await waitUntilReady();
+    const actor = getActor();
+    if (!canStartNarrationNow(String(actor.getSnapshot().value), getVoiceUpdate().phase)) {
+      return { started: false };
+    }
+    const activeTab = await getActiveTab();
+    await startVoiceNarration(activeTab?.id);
+    return { started: getVoiceUpdate().phase === 'recording' };
   });
 
   onMessage('enterBlurMode', async () => {

--- a/src/entrypoints/background/step-pipeline.ts
+++ b/src/entrypoints/background/step-pipeline.ts
@@ -18,7 +18,7 @@ import { getActor } from './actor';
 import { generateAiDescription } from './ai-description';
 import { deferDescription, shouldQueueAiDescription } from './deferred-descriptions';
 import { queueDescription } from './description-queue';
-import { getVoiceUpdate } from './voice';
+import { flushNarrationForStep, getVoiceUpdate } from './voice';
 
 async function takeScreenshot(stepId: string, meta: ElementMeta): Promise<string | undefined> {
   try {
@@ -87,6 +87,7 @@ export async function handleCaptureStep(data: CaptureStepData): Promise<CaptureS
     narrationCapturing,
   });
 
+  const timestamp = Date.now();
   await createStep({
     id: stepId,
     guideId,
@@ -94,10 +95,10 @@ export async function handleCaptureStep(data: CaptureStepData): Promise<CaptureS
     description: buildFallbackDescription(data.action, data.elementMeta),
     action: data.action,
     url: snap.context.currentUrl,
-    timestamp: Date.now(),
+    timestamp,
     screenshotId,
     elementMeta: data.elementMeta,
-    aiPending: willUseAI,
+    aiPending: willUseAI || narrationCapturing,
   });
   await addStepToGuide(guideId, stepId);
 
@@ -106,6 +107,8 @@ export async function handleCaptureStep(data: CaptureStepData): Promise<CaptureS
     if (willUseAI) queueDescription(guideId, () => tryAIDescription(stepId, domContext));
     else if (narrationCapturing && hasAiKey) deferDescription(guideId, stepId, domContext);
   }
+
+  if (narrationCapturing) void flushNarrationForStep(guideId, stepId, timestamp);
 
   return { stepId };
 }

--- a/src/entrypoints/background/step-pipeline.ts
+++ b/src/entrypoints/background/step-pipeline.ts
@@ -1,4 +1,3 @@
-import { getAIDescription } from '@/core/capture/ai/description';
 import type { DOMContext } from '@/core/capture/dom/context';
 import { CaptureState } from '@/core/capture/machine';
 import { buildFallbackDescription } from '@/core/capture/step-description';
@@ -16,7 +15,10 @@ import { captureVisibleTab, localStorage } from '@/lib/browser-api';
 import { logger } from '@/lib/logger';
 import type { CaptureStepData, CaptureStepResponse } from '@/lib/messaging';
 import { getActor } from './actor';
+import { generateAiDescription } from './ai-description';
+import { deferDescription, shouldQueueAiDescription } from './deferred-descriptions';
 import { queueDescription } from './description-queue';
+import { getVoiceUpdate } from './voice';
 
 async function takeScreenshot(stepId: string, meta: ElementMeta): Promise<string | undefined> {
   try {
@@ -55,14 +57,9 @@ async function takeScreenshot(stepId: string, meta: ElementMeta): Promise<string
 }
 
 async function tryAIDescription(stepId: string, domContext: DOMContext) {
-  const settings = await localStorage.get(['aiApiKey', 'aiProvider', 'aiModel']);
-  if (!settings.aiApiKey) return;
-
-  const provider = (settings.aiProvider as string) || 'openai';
-  const model = (settings.aiModel as string) || 'gpt-4o-mini';
+  if (!(await localStorage.get(['aiApiKey'])).aiApiKey) return;
   try {
-    const description = await getAIDescription(domContext, provider, model, settings.aiApiKey as string);
-    await clearStepAiPending(stepId, description || undefined);
+    await clearStepAiPending(stepId, await generateAiDescription(domContext));
   } catch (err) {
     await clearStepAiPending(stepId);
     throw err;
@@ -81,7 +78,14 @@ export async function handleCaptureStep(data: CaptureStepData): Promise<CaptureS
 
   const screenshotId = await takeScreenshot(stepId, data.elementMeta);
 
-  const willUseAI = data.action !== 'input' && !!data.domContext && !!(await localStorage.get(['aiApiKey'])).aiApiKey;
+  const narrationCapturing = getVoiceUpdate().phase === 'recording';
+  const hasAiKey = !!(await localStorage.get(['aiApiKey'])).aiApiKey;
+  const willUseAI = shouldQueueAiDescription({
+    action: data.action,
+    hasDomContext: !!data.domContext,
+    hasAiKey,
+    narrationCapturing,
+  });
 
   await createStep({
     id: stepId,
@@ -99,7 +103,8 @@ export async function handleCaptureStep(data: CaptureStepData): Promise<CaptureS
 
   const domContext = data.domContext;
   if (data.action !== 'input' && domContext) {
-    queueDescription(guideId, () => tryAIDescription(stepId, domContext));
+    if (willUseAI) queueDescription(guideId, () => tryAIDescription(stepId, domContext));
+    else if (narrationCapturing && hasAiKey) deferDescription(guideId, stepId, domContext);
   }
 
   return { stepId };

--- a/src/entrypoints/background/voice.ts
+++ b/src/entrypoints/background/voice.ts
@@ -8,6 +8,7 @@ import {
   closeVoiceHost,
   closeVoiceHostIfIdle,
   ensureVoiceHost,
+  flushVoiceCapture,
   hasVoiceHost,
   openMicPermissionPage,
   queryMicPermission,
@@ -31,6 +32,7 @@ import {
 } from '@/lib/voice-messages';
 import { narrateRecording, readTranscriptionSettings, type VoiceRecording } from '@/lib/voice-narration';
 import { handedOffPcm, voiceStopAction } from '@/lib/voice-recovery';
+import { discardDeferred } from './deferred-descriptions';
 import { describeUnnarratedSteps } from './describe-unnarrated';
 
 const START_TIMEOUT_MS = 8000;
@@ -72,6 +74,30 @@ async function readVoiceSettings(): Promise<{ enabled: boolean; hasApiKey: boole
 
 let orphanAudio: VoiceRecording | null = null;
 let transcribingGuideId: string | null = null;
+let settleNarration: (() => void) | null = null;
+let narrationSettled: Promise<void> | null = null;
+
+const NARRATION_SETTLE_TIMEOUT_MS = 30000;
+
+export function whenNarrationSettled(): Promise<void> {
+  if (!narrationSettled) return Promise.resolve();
+  return Promise.race([
+    narrationSettled,
+    new Promise<void>((resolve) => setTimeout(resolve, NARRATION_SETTLE_TIMEOUT_MS)),
+  ]);
+}
+
+function markNarrationPending(): void {
+  narrationSettled = new Promise<void>((resolve) => {
+    settleNarration = resolve;
+  });
+}
+
+function markNarrationSettled(): void {
+  settleNarration?.();
+  settleNarration = null;
+  narrationSettled = null;
+}
 
 function requestMicPermission(tabId?: number): void {
   void openMicPermissionPage(tabId).catch((error) => logger.error('voice: mic permission page failed to open', error));
@@ -155,6 +181,18 @@ async function recoverNarration(guideId: string): Promise<void> {
   await applyNarration(guideId, result);
 }
 
+export async function flushNarrationForStep(guideId: string, stepId: string, timestamp: number): Promise<void> {
+  if (phase.phase !== 'recording') return;
+  try {
+    const settings = await readTranscriptionSettings();
+    if (!settings.apiKey) return;
+    const response = await flushVoiceCapture(guideId, { stepId, timestamp }, settings);
+    if (!response.ok) logger.warn('voice: could not narrate the step yet', response);
+  } catch (error) {
+    logger.warn('voice: narrating the step while recording failed', error);
+  }
+}
+
 export async function stopVoiceNarration(guideId: string): Promise<void> {
   if (!supportsVoice()) return;
   try {
@@ -181,6 +219,7 @@ export async function stopVoiceNarration(guideId: string): Promise<void> {
     if (response.ok) {
       logger.info('voice: transcribing narration', response);
       transcribingGuideId = guideId;
+      markNarrationPending();
       if (phase.phase === 'recording') report({ phase: 'transcribing' });
       return;
     }
@@ -196,23 +235,33 @@ export async function stopVoiceNarration(guideId: string): Promise<void> {
 }
 
 async function applyNarration(guideId: string, result: VoiceResultEvent['result']): Promise<void> {
+  const final = transcribingGuideId === guideId;
   try {
-    transcribingGuideId = null;
+    if (final) transcribingGuideId = null;
     const narrated = result.descriptions.map((entry) => entry.stepId);
     const surviving = await findExistingStepIds(narrated);
     const updates = narrationUpdates(result, surviving);
     await applyNarrationToSteps(updates);
-    logger.info('voice: narration applied', { narrated: updates.length, of: narrated.length, stats: result.stats });
-    report({ phase: 'idle', narrated: updates.length });
-    describeUnnarratedSteps(
-      guideId,
-      updates.map((update) => update.stepId),
-    );
+    const narratedIds = updates.map((update) => update.stepId);
+    discardDeferred(guideId, narratedIds);
+    logger.info('voice: narration applied', {
+      narrated: updates.length,
+      of: narrated.length,
+      final,
+      stats: result.stats,
+    });
+    if (final) {
+      report({ phase: 'idle', narrated: updates.length });
+      describeUnnarratedSteps(guideId, narratedIds);
+    }
   } catch (error) {
     logger.error('voice: narration could not be applied', error);
-    report({ phase: 'error', reason: 'unknown', error: String(error) });
+    if (final) report({ phase: 'error', reason: 'unknown', error: String(error) });
   } finally {
-    await closeVoiceHostIfIdle();
+    if (final) {
+      markNarrationSettled();
+      await closeVoiceHostIfIdle();
+    }
   }
 }
 

--- a/src/entrypoints/background/voice.ts
+++ b/src/entrypoints/background/voice.ts
@@ -1,3 +1,4 @@
+import { CaptureState } from '@/core/capture/machine';
 import { hasVoiceApiKey, VOICE_KEY_SETTINGS } from '@/core/capture/voice/api-key';
 import { narrationUpdates } from '@/core/capture/voice/narration-updates';
 import { applyNarrationToSteps, findExistingStepIds, getStepsForGuide } from '@/core/guides/service';
@@ -15,6 +16,7 @@ import {
   stopVoiceCapture,
   supportsVoice,
 } from '@/lib/offscreen';
+import type { VoicePhase } from '@/lib/port';
 import { broadcastVoiceToPanel, type PanelVoiceUpdate } from '@/lib/port';
 import {
   isVoiceMessageFor,
@@ -29,6 +31,7 @@ import {
 } from '@/lib/voice-messages';
 import { narrateRecording, readTranscriptionSettings, type VoiceRecording } from '@/lib/voice-narration';
 import { handedOffPcm, voiceStopAction } from '@/lib/voice-recovery';
+import { describeUnnarratedSteps } from './describe-unnarrated';
 
 const START_TIMEOUT_MS = 8000;
 
@@ -100,6 +103,10 @@ async function beginVoiceCapture(microphoneId: string | undefined, tabId: number
   report({ phase: 'error', reason: started.reason, error: started.error });
   if (started.reason === 'permission-denied') requestMicPermission(tabId);
   await closeVoiceHost();
+}
+
+export function canStartNarrationNow(captureState: string, voicePhase: VoicePhase): boolean {
+  return captureState === CaptureState.RECORDING && voicePhase !== 'recording' && voicePhase !== 'transcribing';
 }
 
 export async function startVoiceNarration(tabId?: number): Promise<void> {
@@ -188,7 +195,7 @@ export async function stopVoiceNarration(guideId: string): Promise<void> {
   }
 }
 
-async function applyNarration(_guideId: string, result: VoiceResultEvent['result']): Promise<void> {
+async function applyNarration(guideId: string, result: VoiceResultEvent['result']): Promise<void> {
   try {
     transcribingGuideId = null;
     const narrated = result.descriptions.map((entry) => entry.stepId);
@@ -197,6 +204,10 @@ async function applyNarration(_guideId: string, result: VoiceResultEvent['result
     await applyNarrationToSteps(updates);
     logger.info('voice: narration applied', { narrated: updates.length, of: narrated.length, stats: result.stats });
     report({ phase: 'idle', narrated: updates.length });
+    describeUnnarratedSteps(
+      guideId,
+      updates.map((update) => update.stepId),
+    );
   } catch (error) {
     logger.error('voice: narration could not be applied', error);
     report({ phase: 'error', reason: 'unknown', error: String(error) });

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -121,6 +121,10 @@ export interface EnterBlurModeResponse {
   entered: boolean;
 }
 
+export interface StartNarrationResponse {
+  started: boolean;
+}
+
 export interface ExitBlurModeResponse {
   exited: boolean;
 }
@@ -138,6 +142,7 @@ interface MimikProtocol {
   guideMeGoTo(data: GuideMe_GoToData): GuideMe_GoToResponse;
   enterBlurMode(): EnterBlurModeResponse;
   exitBlurMode(): ExitBlurModeResponse;
+  startNarration(): StartNarrationResponse;
   generateGuideDescription(data: GenerateGuideDescriptionData): GenerateGuideDescriptionResponse;
   validateApiKey(data: ValidateApiKeyData): ValidateApiKeyResponse;
   rewriteSelection(data: RewriteSelectionData): RewriteSelectionResponse;

--- a/src/lib/mic-recorder.ts
+++ b/src/lib/mic-recorder.ts
@@ -136,13 +136,17 @@ export class MicRecorder {
     return { deviceId: stream.getAudioTracks()[0]?.getSettings().deviceId ?? null, usedFallbackDevice };
   }
 
-  stop(): MicRecording {
-    const recording: MicRecording = {
+  snapshot(): MicRecording {
+    return {
       pcm: concat(this.chunks, this.samples),
       sampleRate: this.rate,
       audioEpochMs: this.epochMs,
       durationSeconds: this.durationSeconds,
     };
+  }
+
+  stop(): MicRecording {
+    const recording = this.snapshot();
     this.release();
     return recording;
   }

--- a/src/lib/offscreen.ts
+++ b/src/lib/offscreen.ts
@@ -8,6 +8,8 @@ import {
   VOICE_SIDEPANEL_TARGET,
   type VoiceAbortRequest,
   type VoiceAbortResponse,
+  type VoiceFlushRequest,
+  type VoiceFlushResponse,
   VoiceMessage,
   type VoicePermissionQueryRequest,
   type VoicePermissionQueryResponse,
@@ -203,6 +205,23 @@ export function stopVoiceCapture(
       target: VOICE_OFFSCREEN_TARGET,
       guideId,
       steps,
+      settings,
+    }),
+    { ok: false, reason: 'stream-ended', error: 'The microphone host is no longer available' },
+  );
+}
+
+export function flushVoiceCapture(
+  guideId: string,
+  step: VoiceStepMark,
+  settings: VoiceTranscriptionSettings,
+): Promise<VoiceFlushResponse> {
+  return answered<VoiceFlushResponse>(
+    voiceMessage<VoiceFlushRequest>({
+      type: VoiceMessage.VOICE_FLUSH,
+      target: VOICE_OFFSCREEN_TARGET,
+      guideId,
+      step,
       settings,
     }),
     { ok: false, reason: 'stream-ended', error: 'The microphone host is no longer available' },

--- a/src/lib/voice-host.ts
+++ b/src/lib/voice-host.ts
@@ -1,3 +1,4 @@
+import { partialRecording } from '@/core/capture/voice/partial-recording';
 import type { NarrationResult } from '@/core/capture/voice/types';
 import { getExtensionURL, onMessage, sendMessage } from './browser-api';
 import { logger } from './logger';
@@ -11,6 +12,8 @@ import {
   type VoiceErrorEvent,
   type VoiceErrorReason,
   type VoiceEvent,
+  type VoiceFlushRequest,
+  type VoiceFlushResponse,
   type VoiceHandoffEvent,
   type VoiceLevelEvent,
   VoiceMessage,
@@ -71,6 +74,7 @@ async function permissionState(): Promise<VoicePermissionQueryResponse> {
 export function createVoiceHost(): VoiceHost {
   let pending = 0;
   let retained: VoiceRecording | null = null;
+  let flushedUpToSeconds = 0;
 
   const recorder = new MicRecorder(getExtensionURL('/pcm-processor.js'), {
     onEpoch: (audioEpochMs) =>
@@ -133,6 +137,7 @@ export function createVoiceHost(): VoiceHost {
       return { started: false, reason: 'already-recording', error: 'Microphone capture is already running' };
     }
     try {
+      flushedUpToSeconds = 0;
       const stream = await recorder.start(request.deviceId);
       logger.info('voice: microphone capture started', stream);
       return { started: true, ...stream };
@@ -156,6 +161,32 @@ export function createVoiceHost(): VoiceHost {
     deliver(guideId, result);
   }
 
+  async function handleFlush(request: VoiceFlushRequest): Promise<VoiceFlushResponse> {
+    if (!recorder.recording) {
+      return { ok: false, reason: 'not-recording', error: 'Microphone capture is not running' };
+    }
+    if (!request.settings?.apiKey) {
+      return { ok: false, reason: 'missing-api-key', error: 'No transcription API key is configured' };
+    }
+
+    const full = usableRecording(recorder.snapshot());
+    if (!full) return { ok: true, flushed: false };
+
+    const closesAt = (request.step.timestamp - full.audioEpochMs) / 1000;
+    const slice = partialRecording(full, flushedUpToSeconds, closesAt);
+    if (!slice) return { ok: true, flushed: false };
+
+    flushedUpToSeconds = closesAt;
+    pending += 1;
+    try {
+      const result = await narrateRecording(slice, [request.step], request.settings);
+      if (result.descriptions.length > 0) deliver(request.guideId, result);
+      return { ok: true, flushed: result.descriptions.length > 0 };
+    } finally {
+      pending -= 1;
+    }
+  }
+
   async function handleStop(request: VoiceStopRequest): Promise<VoiceStopResponse> {
     if (!recorder.recording) {
       return { ok: false, reason: 'not-recording', error: 'Microphone capture is not running' };
@@ -177,8 +208,14 @@ export function createVoiceHost(): VoiceHost {
       return { ok: false, reason: 'missing-api-key', error: 'No transcription API key is configured' };
     }
 
-    retained = audio;
-    void transcribeInBackground(request.guideId, audio, request.steps, settings);
+    const tail = flushedUpToSeconds > 0 ? partialRecording(audio, flushedUpToSeconds, audio.durationSeconds) : audio;
+    if (!tail) {
+      deliver(request.guideId, EMPTY_NARRATION);
+      return { ok: true, audioEpochMs, durationSeconds };
+    }
+
+    retained = tail;
+    void transcribeInBackground(request.guideId, tail, request.steps, settings);
     return { ok: true, audioEpochMs, durationSeconds };
   }
 
@@ -197,6 +234,8 @@ export function createVoiceHost(): VoiceHost {
     switch (request.type) {
       case VoiceMessage.VOICE_START:
         return handleStart(request);
+      case VoiceMessage.VOICE_FLUSH:
+        return handleFlush(request);
       case VoiceMessage.VOICE_STOP:
         return handleStop(request);
       case VoiceMessage.VOICE_ABORT:

--- a/src/lib/voice-messages.ts
+++ b/src/lib/voice-messages.ts
@@ -13,6 +13,7 @@ export type VoiceTarget =
 export const VoiceMessage = {
   VOICE_START: 'VOICE_START',
   VOICE_STOP: 'VOICE_STOP',
+  VOICE_FLUSH: 'VOICE_FLUSH',
   VOICE_ABORT: 'VOICE_ABORT',
   VOICE_STATUS: 'VOICE_STATUS',
   VOICE_PERMISSION_QUERY: 'VOICE_PERMISSION_QUERY',
@@ -74,6 +75,18 @@ export interface VoiceStopRequest extends VoiceEnvelope {
 
 export type VoiceStopResponse =
   | { ok: true; audioEpochMs: number; durationSeconds: number }
+  | { ok: false; reason: VoiceErrorReason; error: string };
+
+export interface VoiceFlushRequest extends VoiceEnvelope {
+  type: typeof VoiceMessage.VOICE_FLUSH;
+  target: typeof VOICE_OFFSCREEN_TARGET;
+  guideId: string;
+  step: VoiceStepMark;
+  settings: VoiceTranscriptionSettings;
+}
+
+export type VoiceFlushResponse =
+  | { ok: true; flushed: boolean }
   | { ok: false; reason: VoiceErrorReason; error: string };
 
 export interface VoiceAbortRequest extends VoiceEnvelope {
@@ -155,6 +168,7 @@ export interface VoicePermissionResultEvent extends VoiceEnvelope {
 export type VoiceRequest =
   | VoiceStartRequest
   | VoiceStopRequest
+  | VoiceFlushRequest
   | VoiceAbortRequest
   | VoiceStatusRequest
   | VoicePermissionQueryRequest;

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -216,6 +216,7 @@ editor:
   descriptionErrorFailed: Beschreibung konnte nicht erstellt werden. Versuche es erneut.
   descriptionErrorSaveFailed: Die Beschreibung wurde erstellt, konnte aber nicht gespeichert werden. Versuche es erneut.
   writingStepDescription: "Beschreibung wird geschrieben…"
+  transcribingStepDescription: "Deine Aufnahme wird transkribiert…"
 
 capture:
   recordSteps: Schritte aufzeichnen

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -203,6 +203,7 @@ editor:
   descriptionErrorFailed: Could not generate a description. Try again.
   descriptionErrorSaveFailed: Generated the description but could not save it. Try again.
   writingStepDescription: "Writing description\u2026"
+  transcribingStepDescription: "Transcribing what you said…"
   rewriteAskAi: Ask AI
   rewritePlaceholder: "Tell AI how to edit this text\u2026"
   rewriteEnter: Enter

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -203,6 +203,7 @@ editor:
   descriptionErrorFailed: No se pudo generar una descripción. Inténtalo de nuevo.
   descriptionErrorSaveFailed: Se generó la descripción pero no se pudo guardar. Inténtalo de nuevo.
   writingStepDescription: "Escribiendo descripci\xF3n\u2026"
+  transcribingStepDescription: "Transcribiendo lo que dijiste…"
   rewriteAskAi: Preguntar a la IA
   rewritePlaceholder: "Dile a la IA c\xF3mo editar este texto\u2026"
   rewriteEnter: Intro

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -203,6 +203,7 @@ editor:
   descriptionErrorFailed: "Impossible de générer une description. Réessayez."
   descriptionErrorSaveFailed: "Description générée mais impossible de l'enregistrer. Réessayez."
   writingStepDescription: "R\xE9daction de la description\u2026"
+  transcribingStepDescription: "Transcription de ce que tu as dit…"
   rewriteAskAi: "Demander \xE0 l'IA"
   rewritePlaceholder: "Dites \xE0 l'IA comment modifier ce texte\u2026"
   rewriteEnter: "Entr\xE9e"

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -203,6 +203,7 @@ editor:
   descriptionErrorFailed: Não foi possível gerar uma descrição. Tente novamente.
   descriptionErrorSaveFailed: A descrição foi gerada mas não foi possível salvá-la. Tente novamente.
   writingStepDescription: "Escrevendo descri\xE7\xE3o\u2026"
+  transcribingStepDescription: "Transcrevendo o que você disse…"
   rewriteAskAi: "Perguntar \xE0 IA"
   rewritePlaceholder: "Diga \xE0 IA como editar este texto\u2026"
   rewriteEnter: Enter

--- a/src/ui/sidepanel/MicToggle.tsx
+++ b/src/ui/sidepanel/MicToggle.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { browser, i18n } from '#imports';
 import { hasVoiceApiKey, VOICE_KEY_SETTINGS } from '@/core/capture/voice/api-key';
 import { getActiveTab, localStorage } from '@/lib/browser-api';
+import { sendMessage } from '@/lib/messaging';
 import { abortVoiceCapture, openMicPermissionPage } from '@/lib/offscreen';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/components/ui/tooltip';
 
@@ -59,7 +60,10 @@ export default function MicToggle({ enabled, live, onChange }: MicToggleProps) {
       return;
     }
 
-    if (await microphoneGranted()) return;
+    if (await microphoneGranted()) {
+      await sendMessage('startNarration', undefined).catch(() => undefined);
+      return;
+    }
     const tab = await getActiveTab();
     await openMicPermissionPage(tab?.id).catch(() => undefined);
   }, [enabled, live, locked, onChange]);

--- a/src/ui/sidepanel/RecordingView.tsx
+++ b/src/ui/sidepanel/RecordingView.tsx
@@ -172,7 +172,11 @@ export default function RecordingView({ guideId, onStop, voice }: RecordingViewP
                       {liveStep.step.aiPending ? (
                         <p className="flex items-center gap-1.5 text-[13px] font-medium leading-snug text-muted-foreground">
                           <Loader2 size={13} className="animate-spin" />
-                          {i18n.t('editor.writingStepDescription')}
+                          {i18n.t(
+                            voice.phase === 'recording' || voice.phase === 'transcribing'
+                              ? 'editor.transcribingStepDescription'
+                              : 'editor.writingStepDescription',
+                          )}
                         </p>
                       ) : (
                         <p className="text-[13px] font-medium leading-snug text-foreground">


### PR DESCRIPTION
Narration text only appeared after Finish Recording, so for the whole session steps showed placeholder text like "Click Claro" and the feature looked dead.

A step owns the audio up to its own click, so that window is already closed by the time the step is captured. Capturing a step now transcribes just that slice through the existing pipeline while recording continues, and Finish only handles the tail. The recorder gained a snapshot that reads the buffer without tearing down the stream.

Steps captured while narrating show the existing spinner, relabelled "Transcribing what you said", so the placeholder is never on screen. Narration clears the pending flag, and the stop path now waits for narration to settle before clearing spinners, which also means the guide title is written from what was said rather than from placeholder text.

945 tests, typecheck and both targets clean.