### PR TITLE
fix(voice): start narration once microphone access is granted

### DIFF
--- a/src/entrypoints/background/__tests__/permission-outcome.test.ts
+++ b/src/entrypoints/background/__tests__/permission-outcome.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { permissionOutcome } from '../voice';
+
+describe('permissionOutcome', () => {
+  it('starts narration once access is granted while a recording waits for it', () => {
+    expect(permissionOutcome('granted', 'error')).toBe('start');
+  });
+
+  it('starts narration when access is granted and nothing has failed yet', () => {
+    expect(permissionOutcome('granted', 'idle')).toBe('start');
+  });
+
+  it('leaves a running capture alone when access is granted again', () => {
+    expect(permissionOutcome('granted', 'recording')).toBe('ignore');
+  });
+
+  it('leaves a transcribing take alone when access is granted again', () => {
+    expect(permissionOutcome('granted', 'transcribing')).toBe('ignore');
+  });
+
+  it('says why narration will not run when access is refused', () => {
+    expect(permissionOutcome('denied', 'idle')).toBe('report-denied');
+  });
+
+  it('says why even when an earlier attempt already failed', () => {
+    expect(permissionOutcome('denied', 'error')).toBe('report-denied');
+  });
+
+  it('does not interrupt a running capture when a stale refusal arrives', () => {
+    expect(permissionOutcome('denied', 'recording')).toBe('ignore');
+  });
+});

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -42,6 +42,15 @@ async function resolveManual(step: Step): Promise<boolean> {
   return stepRequiresManual(step, screenshots.get(step.id));
 }
 
+async function startNarrationIfPossible(): Promise<boolean> {
+  await waitUntilReady();
+  const actor = getActor();
+  if (!canStartNarrationNow(String(actor.getSnapshot().value), getVoiceUpdate().phase)) return false;
+  const activeTab = await getActiveTab();
+  await startVoiceNarration(activeTab?.id);
+  return getVoiceUpdate().phase === 'recording';
+}
+
 export default defineBackground(() => {
   logger.info('Background service worker started');
 
@@ -75,7 +84,7 @@ export default defineBackground(() => {
   initActor().catch(initActorFallback);
   cancelSession();
   registerNavigationListeners();
-  registerVoiceListeners();
+  registerVoiceListeners(startNarrationIfPossible);
 
   setupPortListener((port) => {
     logger.debug('Panel connected via port');
@@ -148,16 +157,7 @@ export default defineBackground(() => {
     return { success: true, guideId: guideId ?? undefined, inserted: false };
   });
 
-  onMessage('startNarration', async () => {
-    await waitUntilReady();
-    const actor = getActor();
-    if (!canStartNarrationNow(String(actor.getSnapshot().value), getVoiceUpdate().phase)) {
-      return { started: false };
-    }
-    const activeTab = await getActiveTab();
-    await startVoiceNarration(activeTab?.id);
-    return { started: getVoiceUpdate().phase === 'recording' };
-  });
+  onMessage('startNarration', async () => ({ started: await startNarrationIfPossible() }));
 
   onMessage('enterBlurMode', async () => {
     await waitUntilReady();

--- a/src/entrypoints/background/voice.ts
+++ b/src/entrypoints/background/voice.ts
@@ -37,6 +37,8 @@ import { describeUnnarratedSteps } from './describe-unnarrated';
 
 const START_TIMEOUT_MS = 8000;
 
+let resumeNarration: (() => Promise<unknown>) | null = null;
+
 let phase: PanelVoiceUpdate = { type: 'VOICE_UPDATE', phase: 'idle' };
 
 export function getVoiceUpdate(): PanelVoiceUpdate {
@@ -133,6 +135,13 @@ async function beginVoiceCapture(microphoneId: string | undefined, tabId: number
 
 export function canStartNarrationNow(captureState: string, voicePhase: VoicePhase): boolean {
   return captureState === CaptureState.RECORDING && voicePhase !== 'recording' && voicePhase !== 'transcribing';
+}
+
+export type PermissionOutcome = 'start' | 'report-denied' | 'ignore';
+
+export function permissionOutcome(state: 'granted' | 'denied', voicePhase: VoicePhase): PermissionOutcome {
+  if (voicePhase === 'recording' || voicePhase === 'transcribing') return 'ignore';
+  return state === 'granted' ? 'start' : 'report-denied';
 }
 
 export async function startVoiceNarration(tabId?: number): Promise<void> {
@@ -292,12 +301,20 @@ function handleVoiceHandoff(event: VoiceHandoffEvent): void {
 
 function handlePermissionResult(event: VoicePermissionResultEvent): void {
   logger.info('voice: microphone permission', event.state);
-  if (event.state === 'granted' && phase.phase === 'error') report({ phase: 'idle' });
+  const outcome = permissionOutcome(event.state, phase.phase);
+  if (outcome === 'ignore') return;
+  if (outcome === 'report-denied') {
+    report({ phase: 'error', reason: 'permission-denied', error: 'Microphone access was refused' });
+    return;
+  }
+  if (phase.phase === 'error') report({ phase: 'idle' });
+  void resumeNarration?.();
 }
 
-export function registerVoiceListeners(): void {
+export function registerVoiceListeners(onMicrophoneGranted?: () => Promise<unknown>): void {
   if (!supportsVoice()) return;
 
+  resumeNarration = onMicrophoneGranted ?? null;
   registerVoicePanelRelay();
 
   onRuntimeMessage((message) => {

--- a/src/ui/sidepanel/MicToggle.tsx
+++ b/src/ui/sidepanel/MicToggle.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { browser, i18n } from '#imports';
 import { hasVoiceApiKey, VOICE_KEY_SETTINGS } from '@/core/capture/voice/api-key';
 import { getActiveTab, localStorage } from '@/lib/browser-api';
+import { logger } from '@/lib/logger';
 import { sendMessage } from '@/lib/messaging';
 import { abortVoiceCapture, openMicPermissionPage } from '@/lib/offscreen';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/components/ui/tooltip';
@@ -60,12 +61,17 @@ export default function MicToggle({ enabled, live, onChange }: MicToggleProps) {
       return;
     }
 
-    if (await microphoneGranted()) {
-      await sendMessage('startNarration', undefined).catch(() => undefined);
+    if (!(await microphoneGranted())) {
+      const tab = await getActiveTab();
+      await openMicPermissionPage(tab?.id).catch((error) => {
+        logger.error('voice: the microphone permission page could not be opened', error);
+      });
       return;
     }
-    const tab = await getActiveTab();
-    await openMicPermissionPage(tab?.id).catch(() => undefined);
+
+    await sendMessage('startNarration', undefined).catch((error) => {
+      logger.error('voice: the background did not take the request to start narration', error);
+    });
   }, [enabled, live, locked, onChange]);
 
   const Icon = enabled ? Mic : MicOff;

--- a/src/ui/sidepanel/RecordingView.tsx
+++ b/src/ui/sidepanel/RecordingView.tsx
@@ -86,6 +86,12 @@ export default function RecordingView({ guideId, onStop, voice }: RecordingViewP
     localStorage.get(['voiceEnabled']).then((stored) => setVoiceEnabled(stored.voiceEnabled === true));
   }, []);
 
+  useEffect(() => {
+    if (voice.phase !== 'error' || voice.reason !== 'permission-denied') return;
+    setVoiceEnabled(false);
+    void localStorage.set({ voiceEnabled: false });
+  }, [voice.phase, voice.reason]);
+
   const handleBlur = useCallback(async () => {
     await sendMessage('enterBlurMode', undefined);
     setIsBlurring(true);


### PR DESCRIPTION
Turning narration on during a recording could fail without saying so. Without microphone access the toggle opened the permission page and stopped there: granting it started nothing, and the recording carried on with the button showing on and the panel claiming narration was ready. Errors along the way were discarded, so a failure looked exactly like success.

A granted permission now starts narration for the recording still running, a refusal reports why so the panel shows it, and the toggle goes back off rather than claiming to be on. The permission handler picks between those three outcomes in one place instead of only clearing a stale error.

Lint, typecheck, 1070 tests and both builds pass. Coverage fails until #49 lands, which lowers the floors to what the suite reaches.
