### PR TITLE
fix(voice): count every step narrated during the recording

### DIFF
--- a/src/core/guides/__tests__/ai-pending.test.ts
+++ b/src/core/guides/__tests__/ai-pending.test.ts
@@ -104,6 +104,14 @@ describe('clearStepAiPending', () => {
     expect(step?.descriptionSource).toBe('ai');
   });
 
+  it('says nothing when the step was not spinning in the first place', async () => {
+    await db.steps.add(makeStep({ id: 's1', aiPending: false }));
+
+    await clearStepAiPending('s1');
+
+    expect(guideEvents()).toEqual([]);
+  });
+
   it('clears the flag and leaves the description alone when no AI text arrives', async () => {
     await seedPendingStep('s1');
 
@@ -113,7 +121,7 @@ describe('clearStepAiPending', () => {
     expect(step?.description).toBe(FALLBACK);
     expect(step?.descriptionSource).toBeUndefined();
     expect(step?.aiPending).toBe(false);
-    expect(guideEvents()).toEqual([]);
+    expect(guideEvents()).toEqual([{ type: 'mutated' }]);
   });
 
   it('treats empty AI text as no result', async () => {
@@ -125,7 +133,7 @@ describe('clearStepAiPending', () => {
     expect(step?.description).toBe(FALLBACK);
     expect(step?.descriptionSource).toBeUndefined();
     expect(step?.aiPending).toBe(false);
-    expect(guideEvents()).toEqual([]);
+    expect(guideEvents()).toEqual([{ type: 'mutated' }]);
   });
 
   it('never overwrites a voice narration that landed while the AI call was in flight', async () => {

--- a/src/core/guides/service.ts
+++ b/src/core/guides/service.ts
@@ -229,7 +229,7 @@ export async function clearStepAiPending(stepId: string, description?: string): 
       return true;
     }
     await db.steps.update(stepId, { aiPending: false });
-    return false;
+    return step.aiPending === true;
   });
   if (wrote) notifyGuidesChanged({ type: 'mutated' });
 }

--- a/src/entrypoints/background/__tests__/deferred-descriptions.test.ts
+++ b/src/entrypoints/background/__tests__/deferred-descriptions.test.ts
@@ -5,6 +5,7 @@ import {
   deferDescription,
   discardDeferred,
   shouldQueueAiDescription,
+  takeDeferredDescription,
   takeDeferredDescriptions,
 } from '../deferred-descriptions';
 
@@ -106,5 +107,32 @@ describe('discardDeferred', () => {
 
   it('does nothing for a guide with nothing deferred', () => {
     expect(() => discardDeferred('g1', ['s1'])).not.toThrow();
+  });
+});
+
+describe('takeDeferredDescription', () => {
+  it('hands back the context saved for one step', () => {
+    deferDescription('g1', 's1', ctx('one'));
+
+    expect(takeDeferredDescription('g1', 's1')).toEqual(ctx('one'));
+  });
+
+  it('leaves the other steps waiting for the end of the recording', () => {
+    deferDescription('g1', 's1', ctx('one'));
+    deferDescription('g1', 's2', ctx('two'));
+    takeDeferredDescription('g1', 's1');
+
+    expect(takeDeferredDescriptions('g1', []).map((d) => d.stepId)).toEqual(['s2']);
+  });
+
+  it('hands back nothing for a step that was never deferred', () => {
+    expect(takeDeferredDescription('g1', 'missing')).toBeUndefined();
+  });
+
+  it('hands back nothing the second time the same step is taken', () => {
+    deferDescription('g1', 's1', ctx('one'));
+    takeDeferredDescription('g1', 's1');
+
+    expect(takeDeferredDescription('g1', 's1')).toBeUndefined();
   });
 });

--- a/src/entrypoints/background/__tests__/narration-tally.test.ts
+++ b/src/entrypoints/background/__tests__/narration-tally.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { recordNarrated, takeNarrated } from '../voice';
+
+describe('narration tally', () => {
+  beforeEach(() => {
+    takeNarrated('g1');
+    takeNarrated('g2');
+  });
+
+  it('counts the steps narrated while the recording was still running', () => {
+    recordNarrated('g1', ['s1']);
+    recordNarrated('g1', ['s2']);
+
+    expect(takeNarrated('g1')).toEqual(['s1', 's2']);
+  });
+
+  it('counts a step once when it is narrated again at the end', () => {
+    recordNarrated('g1', ['s1', 's2']);
+    recordNarrated('g1', ['s2']);
+
+    expect(takeNarrated('g1')).toEqual(['s1', 's2']);
+  });
+
+  it('reports nothing for a recording where no step was narrated', () => {
+    expect(takeNarrated('g1')).toEqual([]);
+  });
+
+  it('keeps each recording separate', () => {
+    recordNarrated('g1', ['s1']);
+    recordNarrated('g2', ['s9']);
+
+    expect(takeNarrated('g1')).toEqual(['s1']);
+    expect(takeNarrated('g2')).toEqual(['s9']);
+  });
+
+  it('starts over once a recording has been reported', () => {
+    recordNarrated('g1', ['s1']);
+    takeNarrated('g1');
+
+    expect(takeNarrated('g1')).toEqual([]);
+  });
+});

--- a/src/entrypoints/background/deferred-descriptions.ts
+++ b/src/entrypoints/background/deferred-descriptions.ts
@@ -29,6 +29,14 @@ export function deferDescription(guideId: string, stepId: string, domContext: DO
   deferred.set(guideId, forGuide);
 }
 
+export function takeDeferredDescription(guideId: string, stepId: string): DOMContext | undefined {
+  const forGuide = deferred.get(guideId);
+  if (!forGuide) return undefined;
+  const domContext = forGuide.get(stepId);
+  forGuide.delete(stepId);
+  return domContext;
+}
+
 export function takeDeferredDescriptions(guideId: string, narratedStepIds: readonly string[]): DeferredDescription[] {
   const forGuide = deferred.get(guideId);
   if (!forGuide) return [];

--- a/src/entrypoints/background/describe-unnarrated.ts
+++ b/src/entrypoints/background/describe-unnarrated.ts
@@ -1,13 +1,19 @@
 import { applyAiDescription, clearStepAiPending } from '@/core/guides/service';
+import { logger } from '@/lib/logger';
 import { generateAiDescription } from './ai-description';
 import { takeDeferredDescription, takeDeferredDescriptions } from './deferred-descriptions';
 import { queueDescription } from './description-queue';
 
 export function describeStepNow(guideId: string, stepId: string): void {
   const domContext = takeDeferredDescription(guideId, stepId);
+  logger.info('voice: nothing was said for this step, describing it instead', {
+    stepId,
+    hasDomContext: !!domContext,
+  });
   queueDescription(guideId, async () => {
     const description = domContext ? await generateAiDescription(domContext) : undefined;
     await clearStepAiPending(stepId, description);
+    logger.info('voice: step description settled', { stepId, wroteAi: !!description });
   });
 }
 

--- a/src/entrypoints/background/describe-unnarrated.ts
+++ b/src/entrypoints/background/describe-unnarrated.ts
@@ -1,7 +1,15 @@
-import { applyAiDescription } from '@/core/guides/service';
+import { applyAiDescription, clearStepAiPending } from '@/core/guides/service';
 import { generateAiDescription } from './ai-description';
-import { takeDeferredDescriptions } from './deferred-descriptions';
+import { takeDeferredDescription, takeDeferredDescriptions } from './deferred-descriptions';
 import { queueDescription } from './description-queue';
+
+export function describeStepNow(guideId: string, stepId: string): void {
+  const domContext = takeDeferredDescription(guideId, stepId);
+  queueDescription(guideId, async () => {
+    const description = domContext ? await generateAiDescription(domContext) : undefined;
+    await clearStepAiPending(stepId, description);
+  });
+}
 
 export function describeUnnarratedSteps(guideId: string, narratedStepIds: readonly string[]): void {
   for (const { stepId, domContext } of takeDeferredDescriptions(guideId, narratedStepIds)) {

--- a/src/entrypoints/background/voice.ts
+++ b/src/entrypoints/background/voice.ts
@@ -39,6 +39,20 @@ const START_TIMEOUT_MS = 8000;
 
 let resumeNarration: (() => Promise<unknown>) | null = null;
 
+const narratedSteps = new Map<string, Set<string>>();
+
+export function recordNarrated(guideId: string, stepIds: readonly string[]): void {
+  const seen = narratedSteps.get(guideId) ?? new Set<string>();
+  for (const stepId of stepIds) seen.add(stepId);
+  narratedSteps.set(guideId, seen);
+}
+
+export function takeNarrated(guideId: string): string[] {
+  const seen = narratedSteps.get(guideId);
+  narratedSteps.delete(guideId);
+  return seen ? [...seen] : [];
+}
+
 let phase: PanelVoiceUpdate = { type: 'VOICE_UPDATE', phase: 'idle' };
 
 export function getVoiceUpdate(): PanelVoiceUpdate {
@@ -253,6 +267,7 @@ async function applyNarration(guideId: string, result: VoiceResultEvent['result'
     await applyNarrationToSteps(updates);
     const narratedIds = updates.map((update) => update.stepId);
     discardDeferred(guideId, narratedIds);
+    recordNarrated(guideId, narratedIds);
     logger.info('voice: narration applied', {
       narrated: updates.length,
       of: narrated.length,
@@ -260,8 +275,9 @@ async function applyNarration(guideId: string, result: VoiceResultEvent['result'
       stats: result.stats,
     });
     if (final) {
-      report({ phase: 'idle', narrated: updates.length });
-      describeUnnarratedSteps(guideId, narratedIds);
+      const narratedSoFar = takeNarrated(guideId);
+      report({ phase: 'idle', narrated: narratedSoFar.length });
+      describeUnnarratedSteps(guideId, narratedSoFar);
     }
   } catch (error) {
     logger.error('voice: narration could not be applied', error);

--- a/src/entrypoints/background/voice.ts
+++ b/src/entrypoints/background/voice.ts
@@ -33,7 +33,7 @@ import {
 import { narrateRecording, readTranscriptionSettings, type VoiceRecording } from '@/lib/voice-narration';
 import { handedOffPcm, voiceStopAction } from '@/lib/voice-recovery';
 import { discardDeferred } from './deferred-descriptions';
-import { describeUnnarratedSteps } from './describe-unnarrated';
+import { describeStepNow, describeUnnarratedSteps } from './describe-unnarrated';
 
 const START_TIMEOUT_MS = 8000;
 
@@ -210,9 +210,15 @@ export async function flushNarrationForStep(guideId: string, stepId: string, tim
     const settings = await readTranscriptionSettings();
     if (!settings.apiKey) return;
     const response = await flushVoiceCapture(guideId, { stepId, timestamp }, settings);
-    if (!response.ok) logger.warn('voice: could not narrate the step yet', response);
+    if (!response.ok) {
+      logger.warn('voice: could not narrate the step yet', response);
+      describeStepNow(guideId, stepId);
+      return;
+    }
+    if (!response.flushed) describeStepNow(guideId, stepId);
   } catch (error) {
     logger.warn('voice: narrating the step while recording failed', error);
+    describeStepNow(guideId, stepId);
   }
 }
 


### PR DESCRIPTION
Finishing a recording that was narrated reported that no narration matched the steps, while every step on screen carried the words that were spoken. Each step is transcribed while the recording runs, so by the time you press Finish the only audio left is whatever came after the last click. That is usually under a second of silence, and the count read nothing else.

The count now tallies the distinct steps narrated across the whole session and reports that when the recording ends. The end-of-recording pass that fills unnarrated steps gets the same set, so it cannot claim a step narration already owns.

Stacked on #50. Lint, typecheck, 1075 tests and both builds pass. Coverage fails until #49 lands.
