### PR TITLE
fix(voice): describe a step right away when there was nothing to transcribe

### DIFF
--- a/src/core/guides/__tests__/ai-pending.test.ts
+++ b/src/core/guides/__tests__/ai-pending.test.ts
@@ -104,6 +104,14 @@ describe('clearStepAiPending', () => {
     expect(step?.descriptionSource).toBe('ai');
   });
 
+  it('says nothing when the step was not spinning in the first place', async () => {
+    await db.steps.add(makeStep({ id: 's1', aiPending: false }));
+
+    await clearStepAiPending('s1');
+
+    expect(guideEvents()).toEqual([]);
+  });
+
   it('clears the flag and leaves the description alone when no AI text arrives', async () => {
     await seedPendingStep('s1');
 
@@ -113,7 +121,7 @@ describe('clearStepAiPending', () => {
     expect(step?.description).toBe(FALLBACK);
     expect(step?.descriptionSource).toBeUndefined();
     expect(step?.aiPending).toBe(false);
-    expect(guideEvents()).toEqual([]);
+    expect(guideEvents()).toEqual([{ type: 'mutated' }]);
   });
 
   it('treats empty AI text as no result', async () => {
@@ -125,7 +133,7 @@ describe('clearStepAiPending', () => {
     expect(step?.description).toBe(FALLBACK);
     expect(step?.descriptionSource).toBeUndefined();
     expect(step?.aiPending).toBe(false);
-    expect(guideEvents()).toEqual([]);
+    expect(guideEvents()).toEqual([{ type: 'mutated' }]);
   });
 
   it('never overwrites a voice narration that landed while the AI call was in flight', async () => {

--- a/src/core/guides/service.ts
+++ b/src/core/guides/service.ts
@@ -229,7 +229,7 @@ export async function clearStepAiPending(stepId: string, description?: string): 
       return true;
     }
     await db.steps.update(stepId, { aiPending: false });
-    return false;
+    return step.aiPending === true;
   });
   if (wrote) notifyGuidesChanged({ type: 'mutated' });
 }

--- a/src/entrypoints/background/__tests__/deferred-descriptions.test.ts
+++ b/src/entrypoints/background/__tests__/deferred-descriptions.test.ts
@@ -5,6 +5,7 @@ import {
   deferDescription,
   discardDeferred,
   shouldQueueAiDescription,
+  takeDeferredDescription,
   takeDeferredDescriptions,
 } from '../deferred-descriptions';
 
@@ -106,5 +107,32 @@ describe('discardDeferred', () => {
 
   it('does nothing for a guide with nothing deferred', () => {
     expect(() => discardDeferred('g1', ['s1'])).not.toThrow();
+  });
+});
+
+describe('takeDeferredDescription', () => {
+  it('hands back the context saved for one step', () => {
+    deferDescription('g1', 's1', ctx('one'));
+
+    expect(takeDeferredDescription('g1', 's1')).toEqual(ctx('one'));
+  });
+
+  it('leaves the other steps waiting for the end of the recording', () => {
+    deferDescription('g1', 's1', ctx('one'));
+    deferDescription('g1', 's2', ctx('two'));
+    takeDeferredDescription('g1', 's1');
+
+    expect(takeDeferredDescriptions('g1', []).map((d) => d.stepId)).toEqual(['s2']);
+  });
+
+  it('hands back nothing for a step that was never deferred', () => {
+    expect(takeDeferredDescription('g1', 'missing')).toBeUndefined();
+  });
+
+  it('hands back nothing the second time the same step is taken', () => {
+    deferDescription('g1', 's1', ctx('one'));
+    takeDeferredDescription('g1', 's1');
+
+    expect(takeDeferredDescription('g1', 's1')).toBeUndefined();
   });
 });

--- a/src/entrypoints/background/deferred-descriptions.ts
+++ b/src/entrypoints/background/deferred-descriptions.ts
@@ -29,6 +29,14 @@ export function deferDescription(guideId: string, stepId: string, domContext: DO
   deferred.set(guideId, forGuide);
 }
 
+export function takeDeferredDescription(guideId: string, stepId: string): DOMContext | undefined {
+  const forGuide = deferred.get(guideId);
+  if (!forGuide) return undefined;
+  const domContext = forGuide.get(stepId);
+  forGuide.delete(stepId);
+  return domContext;
+}
+
 export function takeDeferredDescriptions(guideId: string, narratedStepIds: readonly string[]): DeferredDescription[] {
   const forGuide = deferred.get(guideId);
   if (!forGuide) return [];

--- a/src/entrypoints/background/describe-unnarrated.ts
+++ b/src/entrypoints/background/describe-unnarrated.ts
@@ -1,13 +1,19 @@
 import { applyAiDescription, clearStepAiPending } from '@/core/guides/service';
+import { logger } from '@/lib/logger';
 import { generateAiDescription } from './ai-description';
 import { takeDeferredDescription, takeDeferredDescriptions } from './deferred-descriptions';
 import { queueDescription } from './description-queue';
 
 export function describeStepNow(guideId: string, stepId: string): void {
   const domContext = takeDeferredDescription(guideId, stepId);
+  logger.info('voice: nothing was said for this step, describing it instead', {
+    stepId,
+    hasDomContext: !!domContext,
+  });
   queueDescription(guideId, async () => {
     const description = domContext ? await generateAiDescription(domContext) : undefined;
     await clearStepAiPending(stepId, description);
+    logger.info('voice: step description settled', { stepId, wroteAi: !!description });
   });
 }
 

--- a/src/entrypoints/background/describe-unnarrated.ts
+++ b/src/entrypoints/background/describe-unnarrated.ts
@@ -1,7 +1,15 @@
-import { applyAiDescription } from '@/core/guides/service';
+import { applyAiDescription, clearStepAiPending } from '@/core/guides/service';
 import { generateAiDescription } from './ai-description';
-import { takeDeferredDescriptions } from './deferred-descriptions';
+import { takeDeferredDescription, takeDeferredDescriptions } from './deferred-descriptions';
 import { queueDescription } from './description-queue';
+
+export function describeStepNow(guideId: string, stepId: string): void {
+  const domContext = takeDeferredDescription(guideId, stepId);
+  queueDescription(guideId, async () => {
+    const description = domContext ? await generateAiDescription(domContext) : undefined;
+    await clearStepAiPending(stepId, description);
+  });
+}
 
 export function describeUnnarratedSteps(guideId: string, narratedStepIds: readonly string[]): void {
   for (const { stepId, domContext } of takeDeferredDescriptions(guideId, narratedStepIds)) {

--- a/src/entrypoints/background/voice.ts
+++ b/src/entrypoints/background/voice.ts
@@ -33,7 +33,7 @@ import {
 import { narrateRecording, readTranscriptionSettings, type VoiceRecording } from '@/lib/voice-narration';
 import { handedOffPcm, voiceStopAction } from '@/lib/voice-recovery';
 import { discardDeferred } from './deferred-descriptions';
-import { describeUnnarratedSteps } from './describe-unnarrated';
+import { describeStepNow, describeUnnarratedSteps } from './describe-unnarrated';
 
 const START_TIMEOUT_MS = 8000;
 
@@ -210,9 +210,15 @@ export async function flushNarrationForStep(guideId: string, stepId: string, tim
     const settings = await readTranscriptionSettings();
     if (!settings.apiKey) return;
     const response = await flushVoiceCapture(guideId, { stepId, timestamp }, settings);
-    if (!response.ok) logger.warn('voice: could not narrate the step yet', response);
+    if (!response.ok) {
+      logger.warn('voice: could not narrate the step yet', response);
+      describeStepNow(guideId, stepId);
+      return;
+    }
+    if (!response.flushed) describeStepNow(guideId, stepId);
   } catch (error) {
     logger.warn('voice: narrating the step while recording failed', error);
+    describeStepNow(guideId, stepId);
   }
 }
 


### PR DESCRIPTION
A step you did not narrate showed a spinner saying it was transcribing for the rest of the recording. Nothing was being transcribed: silence is filtered out locally before any audio is sent, so the step waited on a result that would never arrive, and its written description only appeared once the recording ended.

The microphone host already reported that it had nothing to transcribe. That answer is now acted on, so the step takes its AI description straight away, or keeps the rule-based text where no key is configured. Clearing that spinner also tells the views, which it never did, so any step whose description came back empty was stranded the same way.

Stacked on #51. Lint, typecheck, 1080 tests and both builds pass. Coverage fails until #49 lands.
