### PR TITLE
feat: tell the user when the extension has updated itself

### DIFF
--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -23,6 +23,7 @@ import {
 import { logger } from '@/lib/logger';
 import { onMessage } from '@/lib/messaging';
 import { broadcastStateToPanel, setupPortListener } from '@/lib/port';
+import { recordUpdate } from '@/lib/update-notice';
 import { getActor, getStateUpdate, initActor, initActorFallback, waitUntilReady } from './actor';
 import { generateDescriptionOnDemand, generateGuideMetaOnStop, settlePendingDescriptions } from './guide-meta';
 import { registerNavigationListeners } from './navigation';
@@ -55,6 +56,7 @@ export default defineBackground(() => {
   logger.info('Background service worker started');
 
   browser.runtime.onInstalled.addListener(async (details) => {
+    await recordUpdate(details.reason);
     if (details.reason !== 'install') return;
     if (import.meta.env.BROWSER === 'firefox') {
       // Firefox MV3 bug 1758306: the <all_urls> grant lands in the origin

--- a/src/lib/__tests__/update-notice.test.ts
+++ b/src/lib/__tests__/update-notice.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { browser } from '#imports';
+import { dismissUpdateNotice, readUpdateNotice, recordUpdate, UPDATE_NOTICE_KEY } from '../update-notice';
+
+describe('update notice', () => {
+  beforeEach(async () => {
+    await browser.storage.local.remove(UPDATE_NOTICE_KEY);
+  });
+
+  it('surfaces the new version after the browser applies an update', async () => {
+    await recordUpdate('update');
+    expect(await readUpdateNotice()).toBe('1.0.0');
+  });
+
+  it('stays quiet on a fresh install', async () => {
+    await recordUpdate('install');
+    expect(await readUpdateNotice()).toBeUndefined();
+  });
+
+  it('stays quiet when only the browser itself updated', async () => {
+    await recordUpdate('chrome_update');
+    expect(await readUpdateNotice()).toBeUndefined();
+  });
+
+  it('does not come back once dismissed', async () => {
+    await recordUpdate('update');
+    await dismissUpdateNotice();
+    expect(await readUpdateNotice()).toBeUndefined();
+  });
+});

--- a/src/lib/update-notice.ts
+++ b/src/lib/update-notice.ts
@@ -1,0 +1,17 @@
+import { browser } from '#imports';
+
+export const UPDATE_NOTICE_KEY = 'updateNotice';
+
+export async function recordUpdate(reason: string): Promise<void> {
+  if (reason !== 'update') return;
+  await browser.storage.local.set({ [UPDATE_NOTICE_KEY]: browser.runtime.getManifest().version });
+}
+
+export async function readUpdateNotice(): Promise<string | undefined> {
+  const data = await browser.storage.local.get([UPDATE_NOTICE_KEY]);
+  return data?.[UPDATE_NOTICE_KEY] as string | undefined;
+}
+
+export function dismissUpdateNotice(): Promise<void> {
+  return browser.storage.local.remove(UPDATE_NOTICE_KEY);
+}

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -20,6 +20,8 @@ common:
   star: Favorisieren
   unstar: Favorit entfernen
   restore: Wiederherstellen
+  updated: "Aktualisiert auf v$1"
+  whatsNew: Neuigkeiten ansehen
 
 sidepanel:
   connected: Verbunden

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -20,6 +20,8 @@ common:
   star: Star
   unstar: Unstar
   restore: Restore
+  updated: "Updated to v$1"
+  whatsNew: See what's new
 
 sidepanel:
   connected: Connected

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -20,6 +20,8 @@ common:
   star: Favorito
   unstar: Quitar de favoritos
   restore: Restaurar
+  updated: "Actualizado a la v$1"
+  whatsNew: Ver novedades
 
 sidepanel:
   connected: Conectado

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -20,6 +20,8 @@ common:
   star: Favoris
   unstar: Retirer des favoris
   restore: Restaurer
+  updated: "Mis à jour vers la v$1"
+  whatsNew: "Voir les nouveautés"
 
 sidepanel:
   connected: "Connecté"

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -20,6 +20,8 @@ common:
   star: Favoritar
   unstar: Tirar dos favoritos
   restore: Restaurar
+  updated: "Atualizado para a v$1"
+  whatsNew: Ver as novidades
 
 sidepanel:
   connected: Conectado

--- a/src/ui/fullview/App.tsx
+++ b/src/ui/fullview/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useFullview } from '@/stores/fullview';
 import { TooltipProvider } from '@/ui/components/ui/tooltip';
+import UpdateNotice from '@/ui/shared/UpdateNotice';
 import VoiceNotice from './components/VoiceNotice';
 import GuideContent from './GuideContent';
 import LibraryContent from './LibraryContent';
@@ -31,6 +32,7 @@ export default function FullViewApp() {
       <div className="min-h-screen flex flex-col bg-background">
         <TopNav route={route} />
         <SearchModal />
+        <UpdateNotice className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50" />
 
         {route.page === 'library' && (
           <main className="flex-1 p-8 max-w-6xl mx-auto w-full">

--- a/src/ui/shared/UpdateNotice.tsx
+++ b/src/ui/shared/UpdateNotice.tsx
@@ -1,0 +1,47 @@
+import { Sparkles, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { i18n } from '#imports';
+import { dismissUpdateNotice, readUpdateNotice } from '@/lib/update-notice';
+
+const RELEASES_URL = 'https://github.com/westpoint-io/mimik/releases';
+
+export default function UpdateNotice({ className = '' }: { className?: string }) {
+  const [version, setVersion] = useState<string>();
+
+  useEffect(() => {
+    readUpdateNotice().then(setVersion);
+  }, []);
+
+  if (!version) return null;
+
+  const dismiss = () => {
+    setVersion(undefined);
+    dismissUpdateNotice();
+  };
+
+  return (
+    <div
+      role="status"
+      className={`flex items-center gap-2 rounded-xl border border-border bg-card shadow-lg px-3.5 py-2.5 ${className}`}
+    >
+      <Sparkles size={15} className="shrink-0 text-accent" />
+      <span className="text-[12px] font-semibold text-foreground">{i18n.t('common.updated', [version])}</span>
+      <a
+        href={RELEASES_URL}
+        target="_blank"
+        rel="noreferrer"
+        onClick={dismiss}
+        className="text-[11px] font-semibold text-accent hover:underline"
+      >
+        {i18n.t('common.whatsNew')}
+      </a>
+      <button
+        onClick={dismiss}
+        aria-label={i18n.t('common.close')}
+        className="ml-auto shrink-0 p-0.5 rounded text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/src/ui/sidepanel/App.tsx
+++ b/src/ui/sidepanel/App.tsx
@@ -22,6 +22,7 @@ import { Button } from '@/ui/components/ui/button';
 import { Input } from '@/ui/components/ui/input';
 import { TooltipProvider } from '@/ui/components/ui/tooltip';
 import SettingsView from '@/ui/shared/SettingsView';
+import UpdateNotice from '@/ui/shared/UpdateNotice';
 import GuideEditor from './GuideEditor';
 import GuideMeCompletion from './GuideMeCompletion';
 import GuideMeView from './GuideMeView';
@@ -302,6 +303,8 @@ export default function App() {
 
         {/* Body */}
         <div className="flex-1 px-5 pt-5">
+          <UpdateNotice className="mb-4" />
+
           <div className="relative mb-5">
             <Search size={15} className="absolute left-3.5 top-1/2 -translate-y-1/2 text-purple" />
             <Input


### PR DESCRIPTION
Mimik updates itself silently, so people land on a new version with no idea anything changed and the release notes go unread. The browser fires an update event once it finishes installing; that now records the version, and both the side panel and the dashboard surface a dismissible notice linking to the releases page. Dismissing either clears it for good. The dashboard toast sits bottom-center so it never collides with the voice notice, and borrows that component's card styling.

The link lands on an empty page until we start publishing GitHub releases with notes. No tags exist yet.

Reviewing locally: new message keys mean Chrome serves a stale catalog on Reload, so remove and re-add the unpacked extension or the notice renders blank.

Lint, 1089 tests, and the Chrome and Firefox builds are clean.
