### PR TITLE
fix(export): draw non-latin pdf text with the system fonts

### DIFF
--- a/src/core/export/__tests__/pdf-text.test.ts
+++ b/src/core/export/__tests__/pdf-text.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { needsRaster, segments, wrap } from '@/core/export/pdf-text';
+import { boxFrom, layout, needsRaster, segments, wrap } from '@/core/export/pdf-text';
 
 describe('needsRaster', () => {
   it('leaves latin text on the vector path', () => {
@@ -52,5 +52,98 @@ describe('wrap', () => {
 
   it('keeps a word that cannot fit rather than looping forever', () => {
     expect(wrap('supercalifragilistic', 5, measure)).toEqual(['supercalifragilistic']);
+  });
+});
+
+const MM_PER_PT = 25.4 / 72;
+
+// Noto Sans CJK reports a box far taller than the 0.8em the raster path used to
+// assume; Latin faces sit comfortably inside it. These are the two cases that
+// decide whether a glyph keeps its top row.
+const CJK_BOX = { ascent: 13.92, descent: 3.456 }; // 1.16em / 0.288em at 12pt
+const LATIN_BOX = { ascent: 9, descent: 3 }; //        0.75em / 0.25em at 12pt
+
+const metrics = (ascent?: number, descent?: number) => ({
+  fontBoundingBoxAscent: ascent,
+  fontBoundingBoxDescent: descent,
+});
+
+describe('boxFrom', () => {
+  it('reads the font box the engine reports', () => {
+    expect(boxFrom([metrics(13.92, 3.456)], 12)).toEqual(CJK_BOX);
+  });
+
+  it('takes the tallest box when a run mixes scripts', () => {
+    const box = boxFrom([metrics(9, 3), metrics(13.92, 3.456)], 12);
+    expect(box).toEqual(CJK_BOX);
+  });
+
+  it('falls back to the old ratio when the engine withholds the box', () => {
+    const box = boxFrom([metrics(undefined, undefined)], 12);
+    expect(box.ascent).toBeCloseTo(9.6);
+    expect(box.descent).toBeCloseTo(2.4);
+  });
+
+  it('falls back when the engine reports a zero ascent', () => {
+    const box = boxFrom([metrics(0, 0)], 10);
+    expect(box.ascent).toBeCloseTo(8);
+    expect(box.descent).toBeCloseTo(2);
+  });
+});
+
+describe('layout', () => {
+  const lineHeightMm = 5;
+  const step = lineHeightMm / MM_PER_PT;
+
+  it('puts the first baseline at the font ascent, so the glyph top is not clipped', () => {
+    // The defect: the baseline used to sit at 0.8em (9.6px), which is above the
+    // 13.92px CJK ascent, so every CJK line lost its top rows off the canvas.
+    const l = layout(40, 1, lineHeightMm, CJK_BOX);
+    expect(l.baselines[0]).toBeCloseTo(CJK_BOX.ascent);
+    expect(l.baselines[0]).toBeGreaterThan(12 * 0.8);
+  });
+
+  it('grows the canvas when ascent plus descent exceeds the line height', () => {
+    const l = layout(40, 1, lineHeightMm, CJK_BOX);
+    const needed = CJK_BOX.ascent + CJK_BOX.descent;
+    expect(needed).toBeGreaterThan(step); // the case under test is real
+    expect(l.height / MM_PER_PT).toBeGreaterThanOrEqual(needed);
+  });
+
+  it('leaves the height at the line box when the font fits inside it', () => {
+    const l = layout(40, 2, lineHeightMm, LATIN_BOX);
+    // ink needs 26.2px and the two line boxes need 28.3px, so the line box governs
+    expect(LATIN_BOX.ascent + step + LATIN_BOX.descent).toBeLessThan(2 * step);
+    expect(l.height / MM_PER_PT).toBeCloseTo(2 * step, 0);
+  });
+
+  it('steps each baseline by exactly one line height', () => {
+    const l = layout(40, 3, lineHeightMm, LATIN_BOX);
+    expect(l.baselines).toHaveLength(3);
+    expect(l.baselines[1] - l.baselines[0]).toBeCloseTo(step);
+    expect(l.baselines[2] - l.baselines[1]).toBeCloseTo(step);
+  });
+
+  it('keeps the last descender inside the canvas', () => {
+    const l = layout(40, 4, lineHeightMm, CJK_BOX);
+    const lastInk = l.baselines[3] + CJK_BOX.descent;
+    expect(l.height / MM_PER_PT).toBeGreaterThanOrEqual(lastInk);
+  });
+
+  it('reports millimetres that match the device pixels, so addImage cannot stretch', () => {
+    const l = layout(40, 2, lineHeightMm, CJK_BOX);
+    expect(l.width).toBeCloseTo((l.deviceWidth / 4) * MM_PER_PT);
+    expect(l.height).toBeCloseTo((l.deviceHeight / 4) * MM_PER_PT);
+  });
+
+  it('reports the ascent in millimetres, since pdf-export offsets the image by it', () => {
+    const l = layout(40, 1, lineHeightMm, CJK_BOX);
+    expect(l.ascent).toBeCloseTo(CJK_BOX.ascent * MM_PER_PT);
+  });
+
+  it('never asks for a zero-sized canvas', () => {
+    const l = layout(0.01, 1, lineHeightMm, LATIN_BOX);
+    expect(l.deviceWidth).toBeGreaterThanOrEqual(1);
+    expect(l.deviceHeight).toBeGreaterThanOrEqual(1);
   });
 });

--- a/src/core/export/__tests__/pdf-text.test.ts
+++ b/src/core/export/__tests__/pdf-text.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { needsRaster, segments, wrap } from '@/core/export/pdf-text';
+
+describe('needsRaster', () => {
+  it('leaves latin text on the vector path', () => {
+    expect(needsRaster('Click the Submit button')).toBe(false);
+  });
+
+  it('leaves accented latin on the vector path', () => {
+    expect(needsRaster('Créer un café — naïve')).toBe(false);
+  });
+
+  it('leaves winansi punctuation on the vector path', () => {
+    expect(needsRaster('“quoted” • dash – ellipsis… €99 ™')).toBe(false);
+  });
+
+  it('rasterises chinese', () => {
+    expect(needsRaster('点击开始录制')).toBe(true);
+  });
+
+  it('rasterises cyrillic, greek, japanese, korean, arabic and thai', () => {
+    for (const text of ['Привет', 'Καλημέρα', 'こんにちは', '안녕하세요', 'مرحبا', 'สวัสดี']) {
+      expect(needsRaster(text)).toBe(true);
+    }
+  });
+
+  it('rasterises latin mixed with a single non-latin character', () => {
+    expect(needsRaster('Open 设置 page')).toBe(true);
+  });
+});
+
+describe('segments', () => {
+  it('keeps latin words whole and splits cjk per character', () => {
+    expect(segments('open 设置 now')).toEqual(['open', ' ', '设', '置', ' ', 'now']);
+  });
+});
+
+describe('wrap', () => {
+  const measure = (s: string) => s.length;
+
+  it('breaks latin on spaces', () => {
+    expect(wrap('aaa bbb ccc', 7, measure)).toEqual(['aaa bbb', 'ccc']);
+  });
+
+  it('breaks cjk between characters, since it has no spaces', () => {
+    expect(wrap('点击开始录制', 3, measure)).toEqual(['点击开', '始录制']);
+  });
+
+  it('never returns an empty list', () => {
+    expect(wrap('', 10, measure)).toEqual(['']);
+  });
+
+  it('keeps a word that cannot fit rather than looping forever', () => {
+    expect(wrap('supercalifragilistic', 5, measure)).toEqual(['supercalifragilistic']);
+  });
+});

--- a/src/core/export/pdf-export.ts
+++ b/src/core/export/pdf-export.ts
@@ -3,6 +3,7 @@ import { i18n } from '#imports';
 import { fitLogo, loadBranding } from '@/core/export/branding';
 import { type ExportOptions, IMAGE_SCALE_FACTORS, loadExportOptions } from '@/core/export/options';
 import { CONTENT_BOTTOM_MM, HEAD_BAND_MM, PAGE_MARGIN_MM, STEP_TOP_MM } from '@/core/export/page';
+import { measurer, needsRaster, rasterize, wrap } from '@/core/export/pdf-text';
 import {
   blobToDataUrl,
   clampLines,
@@ -75,6 +76,46 @@ const MUTED: [number, number, number] = [107, 114, 128];
 const HAIR: [number, number, number] = [229, 231, 235];
 const PAPER: [number, number, number] = [255, 255, 255];
 
+type Rgb = readonly [number, number, number];
+
+function splitFor(doc: jsPDF, text: string, maxWidth: number, size: number, bold: boolean): string[] {
+  if (!needsRaster(text)) return doc.splitTextToSize(text, maxWidth);
+  const measure = measurer(size, bold);
+  return measure ? wrap(text, maxWidth, measure) : doc.splitTextToSize(text, maxWidth);
+}
+
+function widthOf(doc: jsPDF, text: string, size: number, bold: boolean): number {
+  if (!needsRaster(text)) return doc.getTextWidth(text);
+  return measurer(size, bold)?.(text) ?? doc.getTextWidth(text);
+}
+
+function writeLines(
+  doc: jsPDF,
+  lines: string[],
+  x: number,
+  baseline: number,
+  size: number,
+  bold: boolean,
+  color: Rgb,
+  lineHeight: number,
+): void {
+  doc.setFontSize(size);
+  doc.setFont('helvetica', bold ? 'bold' : 'normal');
+  doc.setTextColor(color[0], color[1], color[2]);
+  const raster = lines.some(needsRaster)
+    ? rasterize(lines, size, bold, lineHeight, `rgb(${color[0]},${color[1]},${color[2]})`)
+    : null;
+  if (raster) {
+    try {
+      doc.addImage(raster.dataUrl, 'PNG', x, baseline - raster.ascent, raster.width, raster.height);
+      return;
+    } catch (err) {
+      logger.warn('PDF: failed to draw rasterised text, falling back to the base font', err);
+    }
+  }
+  doc.text(lines, x, baseline);
+}
+
 export async function exportGuideAsPDF(
   guide: Guide,
   steps: Step[],
@@ -101,8 +142,8 @@ export async function exportGuideAsPDF(
 
     doc.setFontSize(30);
     doc.setTextColor(...INK);
-    const titleLines = clampLines(doc.splitTextToSize(guide.title, CONTENT_W * 0.82), MAX_TITLE_LINES);
-    doc.text(titleLines, MARGIN, MARGIN + 26);
+    const titleLines = clampLines(splitFor(doc, guide.title, CONTENT_W * 0.82, 30, true), MAX_TITLE_LINES);
+    writeLines(doc, titleLines, MARGIN, MARGIN + 26, 30, true, INK, TITLE_LINE_H);
 
     const titleBottom = MARGIN + 26 + (titleLines.length - 1) * TITLE_LINE_H;
     if (brand.logo && logo) {
@@ -118,8 +159,8 @@ export async function exportGuideAsPDF(
       doc.setFontSize(11);
       doc.setFont('helvetica', 'normal');
       doc.setTextColor(...MUTED);
-      const descLines = clampLines(doc.splitTextToSize(guide.description, CONTENT_W * 0.7), MAX_DESC_LINES);
-      doc.text(descLines, MARGIN, y + 4);
+      const descLines = clampLines(splitFor(doc, guide.description, CONTENT_W * 0.7, 11, false), MAX_DESC_LINES);
+      writeLines(doc, descLines, MARGIN, y + 4, 11, false, MUTED, 5);
       y += 4 + (descLines.length - 1) * 5 + COVER_RULE_GAP;
     }
 
@@ -168,7 +209,7 @@ export async function exportGuideAsPDF(
     doc.setFontSize(8);
     doc.setFont('helvetica', 'bold');
     doc.setTextColor(...INK);
-    doc.text(doc.splitTextToSize(guide.title, CONTENT_W * 0.7)[0], MARGIN, MARGIN + 3);
+    writeLines(doc, [splitFor(doc, guide.title, CONTENT_W * 0.7, 8, true)[0]], MARGIN, MARGIN + 3, 8, true, INK, 3);
     if (brand.logo && headLogo) {
       try {
         doc.addImage(
@@ -195,8 +236,8 @@ export async function exportGuideAsPDF(
     doc.setFontSize(LEAD_SIZE);
     doc.setFont('helvetica', 'normal');
     doc.setTextColor(...MUTED);
-    const leadLines = clampLines(doc.splitTextToSize(guide.description, CONTENT_W * 0.8), MAX_LEAD_LINES);
-    doc.text(leadLines, MARGIN, sy + LEAD_BASELINE);
+    const leadLines = clampLines(splitFor(doc, guide.description, CONTENT_W * 0.8, LEAD_SIZE, false), MAX_LEAD_LINES);
+    writeLines(doc, leadLines, MARGIN, sy + LEAD_BASELINE, LEAD_SIZE, false, MUTED, LEAD_LINE_H);
     sy += LEAD_BASELINE + (leadLines.length - 1) * LEAD_LINE_H + LEAD_GAP;
   }
 
@@ -209,7 +250,7 @@ export async function exportGuideAsPDF(
 
     doc.setFontSize(11);
     doc.setFont('helvetica', 'bold');
-    const descLines = doc.splitTextToSize(step.description, TEXT_COL);
+    const descLines = splitFor(doc, step.description, TEXT_COL, 11, true);
 
     const screenshot = opts.screenshots ? screenshots.get(step.id) : undefined;
     let imgDataUrl: string | null = null;
@@ -244,12 +285,9 @@ export async function exportGuideAsPDF(
     doc.setLineWidth(0.3);
     doc.line(TEXT_X, sy, RIGHT, sy);
 
-    doc.setFontSize(11);
-    doc.setFont('helvetica', 'bold');
-    doc.setTextColor(...INK);
-    doc.text(descLines, TEXT_X, sy + 6);
+    writeLines(doc, descLines, TEXT_X, sy + 6, 11, true, INK, TEXT_LINE_H);
 
-    let ux = TEXT_X + doc.getTextWidth(descLines[descLines.length - 1]);
+    let ux = TEXT_X + widthOf(doc, descLines[descLines.length - 1], 11, true);
     let uy = sy + 6 + (descLines.length - 1) * 5;
 
     if (step.url && opts.stepUrls) {
@@ -304,7 +342,7 @@ export async function exportGuideAsPDF(
     doc.setLineWidth(0.3);
     doc.line(MARGIN, FOOTER_Y, RIGHT, FOOTER_Y);
     const fy = FOOTER_Y + 4;
-    if (brand.footer) doc.text(brand.footer, MARGIN, fy);
+    if (brand.footer) writeLines(doc, [brand.footer], MARGIN, fy, 8, false, MUTED, 3);
     if (attribution) doc.text(attribution, PAGE_W / 2, fy, { align: 'center' });
     doc.text(`${p} / ${totalPages}`, RIGHT, fy, { align: 'right' });
   }
@@ -316,12 +354,11 @@ function drawBlock(doc: jsPDF, step: Step, y: number, nextPage: () => number): n
   if (step.blockType === 'heading') {
     doc.setFontSize(HEADING_SIZE);
     doc.setFont('helvetica', 'bold');
-    const lines = doc.splitTextToSize(step.description, CONTENT_W);
+    const lines = splitFor(doc, step.description, CONTENT_W, HEADING_SIZE, true);
     const blockH = HEADING_BASELINE + (lines.length - 1) * HEADING_LINE_H + HEADING_RULE_GAP;
     let sy = y;
     if (sy + blockH > CONTENT_BOTTOM_MM && sy > STEP_TOP) sy = nextPage();
-    doc.setTextColor(...INK);
-    doc.text(lines, MARGIN, sy + HEADING_BASELINE);
+    writeLines(doc, lines, MARGIN, sy + HEADING_BASELINE, HEADING_SIZE, true, INK, HEADING_LINE_H);
     const ruleY = sy + blockH;
     doc.setDrawColor(...INK);
     doc.setLineWidth(0.3);
@@ -335,7 +372,7 @@ function drawBlock(doc: jsPDF, step: Step, y: number, nextPage: () => number): n
   const textX = MARGIN + CALLOUT_BAR_W + CALLOUT_PAD_X;
   doc.setFontSize(CALLOUT_SIZE);
   doc.setFont('helvetica', 'normal');
-  const lines = doc.splitTextToSize(step.description, RIGHT - CALLOUT_PAD_X - textX);
+  const lines = splitFor(doc, step.description, RIGHT - CALLOUT_PAD_X - textX, CALLOUT_SIZE, false);
   const boxH = CALLOUT_PAD_Y * 2 + lines.length * CALLOUT_LINE_H;
   let sy = y;
   if (sy + boxH > CONTENT_BOTTOM_MM && sy > STEP_TOP) sy = nextPage();
@@ -343,8 +380,7 @@ function drawBlock(doc: jsPDF, step: Step, y: number, nextPage: () => number): n
   doc.roundedRect(MARGIN, sy, CONTENT_W, boxH, CALLOUT_RADIUS, CALLOUT_RADIUS, 'F');
   doc.setFillColor(...bar);
   doc.rect(MARGIN, sy + CALLOUT_RADIUS, CALLOUT_BAR_W, boxH - CALLOUT_RADIUS * 2, 'F');
-  doc.setTextColor(...INK);
-  doc.text(lines, textX, sy + CALLOUT_PAD_Y + CALLOUT_BASELINE);
+  writeLines(doc, lines, textX, sy + CALLOUT_PAD_Y + CALLOUT_BASELINE, CALLOUT_SIZE, false, INK, CALLOUT_LINE_H);
   return sy + boxH + BLOCK_GAP;
 }
 

--- a/src/core/export/pdf-text.ts
+++ b/src/core/export/pdf-text.ts
@@ -1,0 +1,110 @@
+const MM_PER_PT = 25.4 / 72;
+const RASTER_SCALE = 4;
+const ASCENT_RATIO = 0.8;
+const RASTER_FONTS =
+  '"Noto Sans", "Noto Sans CJK SC", "Noto Sans CJK JP", "Microsoft YaHei", "PingFang SC", "Hiragino Sans", "Malgun Gothic", system-ui, -apple-system, "Segoe UI", Arial, sans-serif';
+
+const WINANSI_EXTRAS = new Set([
+  0x20ac, 0x201a, 0x0192, 0x201e, 0x2026, 0x2020, 0x2021, 0x02c6, 0x2030, 0x0160, 0x2039, 0x0152, 0x017d, 0x2018,
+  0x2019, 0x201c, 0x201d, 0x2022, 0x2013, 0x2014, 0x02dc, 0x2122, 0x0161, 0x203a, 0x0153, 0x017e, 0x0178,
+]);
+
+export function needsRaster(text: string): boolean {
+  for (const char of text) {
+    const code = char.codePointAt(0) ?? 0;
+    if (code <= 0xff) continue;
+    if (WINANSI_EXTRAS.has(code)) continue;
+    return true;
+  }
+  return false;
+}
+
+const CJK = /[ᄀ-ᇿ⺀-鿿ꥠ-꥿가-퟿豈-﫿︰-﹏＀-｠￠-￦]|[\u{20000}-\u{3ffff}]/u;
+
+export function segments(text: string): string[] {
+  const out: string[] = [];
+  let word = '';
+  for (const char of text) {
+    if (/\s/.test(char) || CJK.test(char)) {
+      if (word) {
+        out.push(word);
+        word = '';
+      }
+      out.push(char);
+      continue;
+    }
+    word += char;
+  }
+  if (word) out.push(word);
+  return out;
+}
+
+export function wrap(text: string, maxWidth: number, measure: (s: string) => number): string[] {
+  const lines: string[] = [];
+  let line = '';
+  for (const seg of segments(text)) {
+    if (seg === '\n') {
+      lines.push(line);
+      line = '';
+      continue;
+    }
+    const next = line + seg;
+    if (line && measure(next) > maxWidth) {
+      lines.push(line.replace(/\s+$/, ''));
+      line = /\s/.test(seg) ? '' : seg;
+      continue;
+    }
+    line = next;
+  }
+  if (line.trim()) lines.push(line.replace(/\s+$/, ''));
+  return lines.length ? lines : [''];
+}
+
+function context(): CanvasRenderingContext2D | null {
+  try {
+    const canvas = document.createElement('canvas');
+    return canvas.getContext('2d');
+  } catch {
+    return null;
+  }
+}
+
+export interface RasterText {
+  dataUrl: string;
+  width: number;
+  height: number;
+  ascent: number;
+}
+
+export function measurer(sizePt: number, bold: boolean): ((s: string) => number) | null {
+  const ctx = context();
+  if (!ctx) return null;
+  ctx.font = `${bold ? 'bold ' : ''}${sizePt}px ${RASTER_FONTS}`;
+  return (s: string) => ctx.measureText(s).width * MM_PER_PT;
+}
+
+export function rasterize(
+  lines: string[],
+  sizePt: number,
+  bold: boolean,
+  lineHeight: number,
+  color: string,
+): RasterText | null {
+  const measure = measurer(sizePt, bold);
+  if (!measure) return null;
+  const widest = Math.max(...lines.map(measure), 0.01);
+  const height = lines.length * lineHeight;
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.ceil((widest / MM_PER_PT) * RASTER_SCALE);
+  canvas.height = Math.ceil((height / MM_PER_PT) * RASTER_SCALE);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+  ctx.scale(RASTER_SCALE, RASTER_SCALE);
+  ctx.font = `${bold ? 'bold ' : ''}${sizePt}px ${RASTER_FONTS}`;
+  ctx.fillStyle = color;
+  ctx.textBaseline = 'alphabetic';
+  const ascent = sizePt * ASCENT_RATIO;
+  const step = lineHeight / MM_PER_PT;
+  for (const [i, line] of lines.entries()) ctx.fillText(line, 0, ascent + i * step);
+  return { dataUrl: canvas.toDataURL('image/png'), width: widest, height, ascent: ascent * MM_PER_PT };
+}

--- a/src/core/export/pdf-text.ts
+++ b/src/core/export/pdf-text.ts
@@ -1,6 +1,8 @@
 const MM_PER_PT = 25.4 / 72;
 const RASTER_SCALE = 4;
+// Only a fallback, for engines that withhold the fontBoundingBox metrics.
 const ASCENT_RATIO = 0.8;
+const DESCENT_RATIO = 0.2;
 const RASTER_FONTS =
   '"Noto Sans", "Noto Sans CJK SC", "Noto Sans CJK JP", "Microsoft YaHei", "PingFang SC", "Hiragino Sans", "Malgun Gothic", system-ui, -apple-system, "Segoe UI", Arial, sans-serif';
 
@@ -76,11 +78,79 @@ export interface RasterText {
   ascent: number;
 }
 
+function fontSpec(sizePt: number, bold: boolean): string {
+  return `${bold ? 'bold ' : ''}${sizePt}px ${RASTER_FONTS}`;
+}
+
 export function measurer(sizePt: number, bold: boolean): ((s: string) => number) | null {
   const ctx = context();
   if (!ctx) return null;
-  ctx.font = `${bold ? 'bold ' : ''}${sizePt}px ${RASTER_FONTS}`;
+  ctx.font = fontSpec(sizePt, bold);
   return (s: string) => ctx.measureText(s).width * MM_PER_PT;
+}
+
+export interface FontBox {
+  ascent: number;
+  descent: number;
+}
+
+interface BoxMetrics {
+  fontBoundingBoxAscent?: number;
+  fontBoundingBoxDescent?: number;
+}
+
+/**
+ * The tallest font box across the measured lines, in css px.
+ *
+ * A font stack renders CJK through a fallback face whose box is far taller than
+ * a latin one, so the box has to be measured from the text actually being drawn.
+ * Assuming a fixed ratio clipped the top rows off every CJK line.
+ */
+export function boxFrom(metrics: BoxMetrics[], sizePt: number): FontBox {
+  let ascent = 0;
+  let descent = 0;
+  for (const m of metrics) {
+    if (typeof m.fontBoundingBoxAscent === 'number' && Number.isFinite(m.fontBoundingBoxAscent)) {
+      ascent = Math.max(ascent, m.fontBoundingBoxAscent);
+    }
+    if (typeof m.fontBoundingBoxDescent === 'number' && Number.isFinite(m.fontBoundingBoxDescent)) {
+      descent = Math.max(descent, m.fontBoundingBoxDescent);
+    }
+  }
+  if (ascent > 0) return { ascent, descent };
+  return { ascent: sizePt * ASCENT_RATIO, descent: sizePt * DESCENT_RATIO };
+}
+
+export interface RasterLayout {
+  deviceWidth: number;
+  deviceHeight: number;
+  width: number;
+  height: number;
+  ascent: number;
+  baselines: number[];
+}
+
+/**
+ * Canvas geometry for a run of lines: the device pixels to allocate, the
+ * millimetres those pixels stand for, and where each baseline sits.
+ *
+ * Kept pure so the geometry is testable without a canvas implementation, which
+ * jsdom does not provide.
+ */
+export function layout(widest: number, lineCount: number, lineHeight: number, box: FontBox): RasterLayout {
+  const count = Math.max(lineCount, 1);
+  const step = lineHeight / MM_PER_PT;
+  const ink = box.ascent + (count - 1) * step + box.descent;
+  const deviceWidth = Math.max(1, Math.ceil((widest / MM_PER_PT) * RASTER_SCALE));
+  const deviceHeight = Math.max(1, Math.ceil(Math.max(count * step, ink) * RASTER_SCALE));
+  return {
+    deviceWidth,
+    deviceHeight,
+    width: (deviceWidth / RASTER_SCALE) * MM_PER_PT,
+    height: (deviceHeight / RASTER_SCALE) * MM_PER_PT,
+    ascent: box.ascent * MM_PER_PT,
+    baselines: Array.from({ length: count }, (_, i) => box.ascent + i * step),
+  };
 }
 
 export function rasterize(
@@ -90,21 +160,27 @@ export function rasterize(
   lineHeight: number,
   color: string,
 ): RasterText | null {
-  const measure = measurer(sizePt, bold);
-  if (!measure) return null;
-  const widest = Math.max(...lines.map(measure), 0.01);
-  const height = lines.length * lineHeight;
+  const probe = context();
+  if (!probe) return null;
+  const font = fontSpec(sizePt, bold);
+  probe.font = font;
+  const widest = Math.max(...lines.map((line) => probe.measureText(line).width * MM_PER_PT), 0.01);
+  const inked = lines.filter((line) => line.length > 0);
+  const box = boxFrom(
+    (inked.length ? inked : ['M']).map((line) => probe.measureText(line)),
+    sizePt,
+  );
+  const frame = layout(widest, lines.length, lineHeight, box);
+
   const canvas = document.createElement('canvas');
-  canvas.width = Math.ceil((widest / MM_PER_PT) * RASTER_SCALE);
-  canvas.height = Math.ceil((height / MM_PER_PT) * RASTER_SCALE);
+  canvas.width = frame.deviceWidth;
+  canvas.height = frame.deviceHeight;
   const ctx = canvas.getContext('2d');
   if (!ctx) return null;
   ctx.scale(RASTER_SCALE, RASTER_SCALE);
-  ctx.font = `${bold ? 'bold ' : ''}${sizePt}px ${RASTER_FONTS}`;
+  ctx.font = font;
   ctx.fillStyle = color;
   ctx.textBaseline = 'alphabetic';
-  const ascent = sizePt * ASCENT_RATIO;
-  const step = lineHeight / MM_PER_PT;
-  for (const [i, line] of lines.entries()) ctx.fillText(line, 0, ascent + i * step);
-  return { dataUrl: canvas.toDataURL('image/png'), width: widest, height, ascent: ascent * MM_PER_PT };
+  for (const [i, line] of lines.entries()) ctx.fillText(line, 0, frame.baselines[i]);
+  return { dataUrl: canvas.toDataURL('image/png'), width: frame.width, height: frame.height, ascent: frame.ascent };
 }


### PR DESCRIPTION
PDF export drew text with a built-in jsPDF font, and those are locked to WinAnsi, so anything outside Latin-1 was truncated to its low byte and redrawn as an unrelated Latin symbol. A Chinese guide exported as line noise. Cyrillic, Greek, Arabic and Thai failed the same way; Markdown and HTML were fine because the reader supplies the glyphs.

Embedding a font was not an option: jsPDF has no subsetter, so a CJK face lands whole in every PDF at roughly 10 MB. Text outside WinAnsi is now measured, wrapped and drawn on a canvas with the system fonts, then placed as an image. Latin text keeps the vector path.

Rasterised runs are no longer selectable, and step URLs stay vector to keep them clickable, so a non-Latin URL path still shows percent-encoded.

Closes #34.

lint, typecheck, 1100 tests and both builds clean. Exported a seeded Chinese guide from the built extension and rendered it.
