### PR TITLE
feat: add Azure OpenAI provider for AI descriptions and voice narration

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Need to blur something custom? The manual blur picker lets you select any DOM el
 
 ### 🧠 AI descriptions (optional)
 
-Bring your own API key (OpenAI or Anthropic) and Mimik generates human-readable step descriptions like *"Click the **Submit** button to save changes"* instead of the rule-based `Click Submit`.
+Bring your own API key (OpenAI, Anthropic, or Azure OpenAI) and Mimik generates human-readable step descriptions like *"Click the **Submit** button to save changes"* instead of the rule-based `Click Submit`. For Azure, paste your resource URL and use your deployment name as the model.
 
 Descriptions are generated from a lightweight DOM context (~50-100 tokens), not screenshots. Roughly 15-30x cheaper than vision models. Choose the language you want descriptions in (English, Spanish, Portuguese, French, German).
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "license": "ISC",
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.64",
+    "@ai-sdk/azure": "^3.0.111",
     "@ai-sdk/openai": "^3.0.49",
     "@fontsource/poppins": "^5.2.7",
     "@tailwindcss/vite": "^4.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: ^3.0.64
         version: 3.0.65(zod@4.3.6)
+      '@ai-sdk/azure':
+        specifier: ^3.0.111
+        version: 3.0.111(zod@4.3.6)
       '@ai-sdk/openai':
         specifier: ^3.0.49
         version: 3.0.49(zod@4.3.6)
@@ -158,8 +161,26 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/azure@3.0.111':
+    resolution: {integrity: sha512-al/lQSVSWAMnwlrQydfUxYIg6db8rnb9CSsV+bknTR3yZrhhc6hiptSWcY7Huycn2WqpfgMehzrkNW4bt9VDeA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/deepseek@2.0.61':
+    resolution: {integrity: sha512-taK6rfZilvUyCmiGYl3ZNNEZm9fecJvzOEjOQ+9yHqBH53vUJlv4jjBwhXgdjOLt6gLRPc0ex1lYi2rnx68VGg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@3.0.85':
     resolution: {integrity: sha512-oPvs3bYnxndBY/O0gFSFuc5aA/QKCJbk/CaJaRnKgA/ZPH17jeVvEtiUBE6/N8hWhK7XgX53NFI7F3CGmDfm1g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@3.0.104':
+    resolution: {integrity: sha512-9CmN6uvU7SaLfYcYIASVdjC2s/mDSb6BUF7OCZI1ekr4k1HoO2Aj4kNurOdqibt1l0OrzqLdjrBP29u9h4+reA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -175,6 +196,16 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.49':
+    resolution: {integrity: sha512-8e7pd+82bobqrFOaD5dG/PiEuvLYr5olaE3I56ch0jipR0H7sGD6ohwTUynv6k8O8QidWiyIbEsZCtr/2dyXIA==}
+    engines: {node: '>=18.17'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.15':
+    resolution: {integrity: sha512-XeZW1CcDF2GMbH4wejW6xBRI2QCOgnkVYUnxoeDadB1mf85riL2bMUeDoh+6gJ/r4mjNfzUPW8OjLjvwTP0u1Q==}
+    engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
@@ -2174,6 +2205,10 @@ packages:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
 
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -3352,6 +3387,10 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
+    engines: {node: '>=18.17'}
+
   undici@7.24.6:
     resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
     engines: {node: '>=20.18.1'}
@@ -3690,11 +3729,31 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
       zod: 4.3.6
 
+  '@ai-sdk/azure@3.0.111(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/deepseek': 2.0.61(zod@4.3.6)
+      '@ai-sdk/openai': 3.0.104(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.15
+      '@ai-sdk/provider-utils': 4.0.49(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/deepseek@2.0.61(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.15
+      '@ai-sdk/provider-utils': 4.0.49(zod@4.3.6)
+      zod: 4.3.6
+
   '@ai-sdk/gateway@3.0.85(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
       '@vercel/oidc': 3.1.0
+      zod: 4.3.6
+
+  '@ai-sdk/openai@3.0.104(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.15
+      '@ai-sdk/provider-utils': 4.0.49(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/openai@3.0.49(zod@4.3.6)':
@@ -3709,6 +3768,18 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.49(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.15
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.1
+      undici: 6.28.0
+      zod: 4.3.6
+
+  '@ai-sdk/provider@3.0.15':
+    dependencies:
+      json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.8':
     dependencies:
@@ -5624,6 +5695,8 @@ snapshots:
 
   eventsource-parser@3.0.6: {}
 
+  eventsource-parser@3.1.1: {}
+
   expect-type@1.3.0: {}
 
   exsolve@1.0.8: {}
@@ -6786,6 +6859,8 @@ snapshots:
       '@lukeed/csprng': 1.1.0
 
   undici-types@7.18.2: {}
+
+  undici@6.28.0: {}
 
   undici@7.24.6: {}
 

--- a/src/core/capture/ai/__tests__/endpoint.test.ts
+++ b/src/core/capture/ai/__tests__/endpoint.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { isInsecureEndpoint, normalizeEndpoint } from '../endpoint';
+
+describe('normalizeEndpoint', () => {
+  it('appends the /openai path an Azure resource URL needs to reach the API', () => {
+    expect(normalizeEndpoint('azure', 'https://my-res.openai.azure.com')).toBe(
+      'https://my-res.openai.azure.com/openai',
+    );
+  });
+
+  it('does not double up /openai when the user already pasted the full path', () => {
+    expect(normalizeEndpoint('azure', 'https://my-res.openai.azure.com/openai')).toBe(
+      'https://my-res.openai.azure.com/openai',
+    );
+  });
+
+  it('forgives a trailing slash rather than producing a double slash', () => {
+    expect(normalizeEndpoint('azure', 'https://my-res.openai.azure.com/')).toBe(
+      'https://my-res.openai.azure.com/openai',
+    );
+    expect(normalizeEndpoint('openai', 'https://api.example.com/v1/')).toBe('https://api.example.com/v1');
+  });
+
+  it('forgives surrounding whitespace from a copy-paste', () => {
+    expect(normalizeEndpoint('openai', '  https://api.example.com/v1  ')).toBe('https://api.example.com/v1');
+  });
+
+  it("leaves a non-azure provider's endpoint untouched", () => {
+    expect(normalizeEndpoint('openai', 'https://api.groq.com/openai/v1')).toBe('https://api.groq.com/openai/v1');
+  });
+
+  it('does not bolt azure path rules onto an unrelated provider endpoint that merely mentions azure', () => {
+    expect(normalizeEndpoint('openai', 'https://gateway.internal/azure')).toBe('https://gateway.internal/azure');
+  });
+
+  it('returns nothing for a blank endpoint so callers can treat it as unconfigured', () => {
+    expect(normalizeEndpoint('azure', '')).toBe('');
+    expect(normalizeEndpoint('azure', '   ')).toBe('');
+  });
+
+  it('returns nothing for a value that is not a URL at all', () => {
+    expect(normalizeEndpoint('azure', 'my-resource')).toBe('');
+  });
+
+  it.each([
+    'javascript:alert(1)',
+    'data:text/plain,hi',
+    'file:///etc/passwd',
+    'blob:https://x/y',
+  ])('refuses %s, so only a fetchable web endpoint can ever be dialled', (scheme) => {
+    expect(normalizeEndpoint('openai', scheme)).toBe('');
+    expect(normalizeEndpoint('azure', scheme)).toBe('');
+  });
+
+  it('still accepts plain http for a non-azure provider', () => {
+    expect(normalizeEndpoint('openai', 'http://api.example.com/v1')).toBe('http://api.example.com/v1');
+  });
+});
+
+describe('isInsecureEndpoint', () => {
+  it.each([
+    'http://localhost:11434/v1',
+    'http://127.0.0.1:1234/v1',
+    'http://[::1]:8080/v1',
+    'http://10.0.0.5:8000/v1',
+    'http://172.16.4.2:8000/v1',
+    'http://172.31.255.1:8000/v1',
+    'http://192.168.1.50:8000/v1',
+  ])('stays quiet about %s, where plain http is normal and the key never leaves the network', (url) => {
+    expect(isInsecureEndpoint(url)).toBe(false);
+  });
+
+  it.each([
+    'http://llm.example.com/v1',
+    'http://203.0.113.10:8000/v1',
+    'http://172.32.0.1:8000/v1',
+    'http://11.0.0.1:8000/v1',
+  ])('warns about %s, where the key would cross a network in the clear', (url) => {
+    expect(isInsecureEndpoint(url)).toBe(true);
+  });
+
+  it.each([
+    'https://api.example.com/v1',
+    'https://my-res.openai.azure.com',
+  ])('stays quiet about encrypted %s', (url) => {
+    expect(isInsecureEndpoint(url)).toBe(false);
+  });
+
+  it('stays quiet while the field is still empty or half-typed', () => {
+    expect(isInsecureEndpoint('')).toBe(false);
+    expect(isInsecureEndpoint('http://')).toBe(false);
+    expect(isInsecureEndpoint('not-a-url')).toBe(false);
+  });
+});

--- a/src/core/capture/ai/__tests__/meta.test.ts
+++ b/src/core/capture/ai/__tests__/meta.test.ts
@@ -37,7 +37,7 @@ describe('generateGuideMeta', () => {
       },
     });
 
-    const result = await generateGuideMeta(steps, 'openai', 'gpt-4o-mini', 'key');
+    const result = await generateGuideMeta(steps, { provider: 'openai', model: 'gpt-4o-mini', apiKey: 'key' });
 
     expect(result).toEqual({
       title: 'Reset a User Password in Okta',
@@ -48,7 +48,7 @@ describe('generateGuideMeta', () => {
   it('still yields a usable title when the model omits the description', async () => {
     generateObjectMock.mockResolvedValue({ object: { title: 'Reset a User Password in Okta' } });
 
-    const result = await generateGuideMeta(steps, 'openai', 'gpt-4o-mini', 'key');
+    const result = await generateGuideMeta(steps, { provider: 'openai', model: 'gpt-4o-mini', apiKey: 'key' });
 
     expect(result?.title).toBe('Reset a User Password in Okta');
     expect(result?.description).toBeUndefined();
@@ -57,7 +57,7 @@ describe('generateGuideMeta', () => {
   it('truncates a title over 70 characters', async () => {
     generateObjectMock.mockResolvedValue({ object: { title: 'x'.repeat(90), description: 'ok' } });
 
-    const result = await generateGuideMeta(steps, 'openai', 'gpt-4o-mini', 'key');
+    const result = await generateGuideMeta(steps, { provider: 'openai', model: 'gpt-4o-mini', apiKey: 'key' });
 
     expect(result?.title.length).toBe(70);
     expect(result?.title.endsWith('...')).toBe(true);
@@ -66,7 +66,7 @@ describe('generateGuideMeta', () => {
   it('marks every declared property as required, as strict mode demands', async () => {
     generateObjectMock.mockResolvedValue({ object: { title: 'T', description: null } });
 
-    await generateGuideMeta(steps, 'openai', 'gpt-4o-mini', 'key');
+    await generateGuideMeta(steps, { provider: 'openai', model: 'gpt-4o-mini', apiKey: 'key' });
 
     const { schema } = generateObjectMock.mock.calls[0][0];
     expect(schema.required.sort()).toEqual(Object.keys(schema.properties).sort());
@@ -75,7 +75,7 @@ describe('generateGuideMeta', () => {
   it('treats a null description from the model as absent', async () => {
     generateObjectMock.mockResolvedValue({ object: { title: 'Okta Password Reset', description: null } });
 
-    const result = await generateGuideMeta(steps, 'openai', 'gpt-4o-mini', 'key');
+    const result = await generateGuideMeta(steps, { provider: 'openai', model: 'gpt-4o-mini', apiKey: 'key' });
 
     expect(result?.title).toBe('Okta Password Reset');
     expect(result?.description).toBeUndefined();
@@ -84,13 +84,13 @@ describe('generateGuideMeta', () => {
   it('returns null when the model returns a blank title', async () => {
     generateObjectMock.mockResolvedValue({ object: { title: '   ', description: 'ok' } });
 
-    expect(await generateGuideMeta(steps, 'openai', 'gpt-4o-mini', 'key')).toBeNull();
+    expect(await generateGuideMeta(steps, { provider: 'openai', model: 'gpt-4o-mini', apiKey: 'key' })).toBeNull();
   });
 
   it('interpolates the numbered steps into the prompt', async () => {
     generateObjectMock.mockResolvedValue({ object: { title: 'Okta Password Reset' } });
 
-    await generateGuideMeta(steps, 'openai', 'gpt-4o-mini', 'key');
+    await generateGuideMeta(steps, { provider: 'openai', model: 'gpt-4o-mini', apiKey: 'key' });
 
     const { prompt } = generateObjectMock.mock.calls[0][0];
     expect(prompt).toContain('1. [https://admin.okta.com/users] Click Directory');
@@ -98,14 +98,14 @@ describe('generateGuideMeta', () => {
   });
 
   it('returns null for an empty step list without calling the model', async () => {
-    expect(await generateGuideMeta([], 'openai', 'gpt-4o-mini', 'key')).toBeNull();
+    expect(await generateGuideMeta([], { provider: 'openai', model: 'gpt-4o-mini', apiKey: 'key' })).toBeNull();
     expect(generateObjectMock).not.toHaveBeenCalled();
   });
 
   it('returns null when both the structured call and the text retry throw', async () => {
     generateObjectMock.mockRejectedValue(new Error('rate limited'));
     generateTextMock.mockRejectedValue(new Error('rate limited'));
-    expect(await generateGuideMeta(steps, 'openai', 'gpt-4o-mini', 'key')).toBeNull();
+    expect(await generateGuideMeta(steps, { provider: 'openai', model: 'gpt-4o-mini', apiKey: 'key' })).toBeNull();
   });
 });
 
@@ -121,7 +121,7 @@ describe('models without structured output support', () => {
       text: '{"title": "Check Recent Deaths on Wikipedia", "description": "Look up an entry."}',
     });
 
-    const result = await generateGuideMeta(steps, 'openai', 'gpt-3.5-turbo', 'key');
+    const result = await generateGuideMeta(steps, { provider: 'openai', model: 'gpt-3.5-turbo', apiKey: 'key' });
 
     expect(result).toEqual({
       title: 'Check Recent Deaths on Wikipedia',
@@ -132,7 +132,7 @@ describe('models without structured output support', () => {
   it('asks the fallback call for bare JSON', async () => {
     generateTextMock.mockResolvedValue({ text: '{"title": "T"}' });
 
-    await generateGuideMeta(steps, 'openai', 'gpt-3.5-turbo', 'key');
+    await generateGuideMeta(steps, { provider: 'openai', model: 'gpt-3.5-turbo', apiKey: 'key' });
 
     const { prompt } = generateTextMock.mock.calls[0][0];
     expect(prompt).toContain('1. [https://admin.okta.com/users] Click Directory');
@@ -143,7 +143,7 @@ describe('models without structured output support', () => {
     generateObjectMock.mockReset();
     generateObjectMock.mockResolvedValue({ object: { title: 'T', description: 'D' } });
 
-    await generateGuideMeta(steps, 'openai', 'gpt-4o-mini', 'key');
+    await generateGuideMeta(steps, { provider: 'openai', model: 'gpt-4o-mini', apiKey: 'key' });
 
     expect(generateTextMock).not.toHaveBeenCalled();
   });

--- a/src/core/capture/ai/__tests__/models.test.ts
+++ b/src/core/capture/ai/__tests__/models.test.ts
@@ -5,7 +5,7 @@ import { AI_PROVIDERS, CUSTOM_MODEL_VALUE, isCustomModel } from '../models';
 
 const LOCALES = ['en', 'de', 'es', 'fr', 'pt-BR'];
 
-const MODEL_KEYS = ['settings.model', 'settings.modelCustom'];
+const MODEL_KEYS = ['settings.model', 'settings.modelCustom', 'settings.endpoint', 'settings.endpointHint'];
 
 function localeKeys(locale: string): Set<string> {
   const keys = new Set<string>();
@@ -53,9 +53,31 @@ describe('custom model sentinel', () => {
   });
 });
 
-describe('every provider default is selectable', () => {
-  it.each(Object.entries(AI_PROVIDERS))('%s lists its own default model', (_key, config) => {
+const CURATED = Object.entries(AI_PROVIDERS).filter(([, config]) => !config.requiresEndpoint);
+const ENDPOINT_DRIVEN = Object.entries(AI_PROVIDERS).filter(([, config]) => config.requiresEndpoint);
+
+describe('every curated provider default is selectable', () => {
+  it.each(CURATED)('%s lists its own default model', (_key, config) => {
     expect(config.models.some((option) => option.id === config.defaultModel)).toBe(true);
+  });
+});
+
+describe('endpoint-driven providers', () => {
+  it('exist, so the picker is not curated-only', () => {
+    expect(ENDPOINT_DRIVEN.length).toBeGreaterThan(0);
+  });
+
+  it.each(ENDPOINT_DRIVEN)('%s curates no model list, because the ids are the user own deployments', (_key, config) => {
+    expect(config.models).toEqual([]);
+    expect(config.defaultModel).toBe('');
+  });
+
+  it.each(ENDPOINT_DRIVEN)('%s shows an example url so the field is not a blank guess', (_key, config) => {
+    expect(config.endpointExample).toBeTruthy();
+  });
+
+  it.each(ENDPOINT_DRIVEN)('%s opens the free-text model box, having nothing to pick from', (_key, config) => {
+    expect(isCustomModel('some-deployment-name', config)).toBe(true);
   });
 });
 

--- a/src/core/capture/ai/__tests__/provider.test.ts
+++ b/src/core/capture/ai/__tests__/provider.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest';
+
+type ProviderOptions = { apiKey?: string; baseURL?: string };
+
+const createOpenAI = vi.fn((_options: ProviderOptions) => vi.fn((m: string) => ({ kind: 'openai', model: m })));
+const createAnthropic = vi.fn((_options: ProviderOptions) => vi.fn((m: string) => ({ kind: 'anthropic', model: m })));
+const createAzure = vi.fn((_options: ProviderOptions) => vi.fn((m: string) => ({ kind: 'azure', model: m })));
+
+vi.mock('@ai-sdk/openai', () => ({ createOpenAI: (o: ProviderOptions) => createOpenAI(o) }));
+vi.mock('@ai-sdk/anthropic', () => ({ createAnthropic: (o: ProviderOptions) => createAnthropic(o) }));
+vi.mock('@ai-sdk/azure', () => ({ createAzure: (o: ProviderOptions) => createAzure(o) }));
+
+const { createModel, isConnectionConfigured } = await import('../provider');
+
+describe('createModel', () => {
+  it('still routes anthropic to the anthropic provider', () => {
+    createModel({ provider: 'anthropic', model: 'claude-3-5-haiku-20241022', apiKey: 'ant' });
+    expect(createAnthropic).toHaveBeenCalledWith({ apiKey: 'ant' });
+  });
+
+  it('still sends a bare openai config straight to openai with no base url', () => {
+    createModel({ provider: 'openai', model: 'gpt-4o-mini', apiKey: 'sk' });
+    expect(createOpenAI).toHaveBeenCalledWith({ apiKey: 'sk' });
+  });
+
+  it('routes azure through the azure provider, not the openai one', () => {
+    createModel({
+      provider: 'azure',
+      model: 'my-deployment',
+      apiKey: 'az',
+      baseURL: 'https://my-res.openai.azure.com',
+    });
+    expect(createAzure).toHaveBeenCalled();
+    const [opts] = createAzure.mock.calls.at(-1) as [ProviderOptions];
+    expect(opts.apiKey).toBe('az');
+    expect(opts.baseURL).toBe('https://my-res.openai.azure.com/openai');
+  });
+
+  it('treats the azure model id as a deployment name, passing it through untouched', () => {
+    const model = createModel({
+      provider: 'azure',
+      model: 'my-deployment-mini',
+      apiKey: 'az',
+      baseURL: 'https://my-res.openai.azure.com',
+    }) as unknown as { model: string };
+    expect(model.model).toBe('my-deployment-mini');
+  });
+});
+
+describe('createModel refuses to silently reach the cloud', () => {
+  it('throws rather than falling back to OpenAI when azure has no endpoint', () => {
+    expect(() => createModel({ provider: 'azure', model: 'my-deployment', apiKey: 'sk-real-key' })).toThrow();
+    expect(() =>
+      createModel({ provider: 'azure', model: 'my-deployment', apiKey: 'sk-real-key', baseURL: '' }),
+    ).toThrow();
+  });
+
+  it('throws rather than dialling the cloud when the endpoint is unusable', () => {
+    expect(() =>
+      createModel({ provider: 'azure', model: 'my-deployment', apiKey: 'sk', baseURL: 'not-a-url' }),
+    ).toThrow();
+  });
+
+  it('never falls through to a bare OpenAI client when azure is misconfigured', () => {
+    createOpenAI.mockClear();
+    try {
+      createModel({ provider: 'azure', model: 'my-deployment', apiKey: 'sk-real-key', baseURL: '' });
+    } catch {
+      // expected
+    }
+    expect(createOpenAI).not.toHaveBeenCalled();
+  });
+});
+
+describe('isConnectionConfigured', () => {
+  it('accepts a plain openai setup with just a key', () => {
+    expect(isConnectionConfigured({ provider: 'openai', model: 'gpt-4o-mini', apiKey: 'sk' })).toBe(true);
+  });
+
+  it('rejects a plain openai setup with no key', () => {
+    expect(isConnectionConfigured({ provider: 'openai', model: 'gpt-4o-mini', apiKey: '' })).toBe(false);
+  });
+
+  it('rejects an azure setup with a key but no endpoint', () => {
+    expect(isConnectionConfigured({ provider: 'azure', model: 'my-deployment', apiKey: 'az' })).toBe(false);
+  });
+
+  it('rejects an azure setup with an endpoint but no key, since azure always authenticates', () => {
+    expect(
+      isConnectionConfigured({
+        provider: 'azure',
+        model: 'my-deployment',
+        apiKey: '',
+        baseURL: 'https://r.openai.azure.com',
+      }),
+    ).toBe(false);
+  });
+
+  it('accepts a fully configured azure setup', () => {
+    expect(
+      isConnectionConfigured({
+        provider: 'azure',
+        model: 'my-deployment',
+        apiKey: 'az',
+        baseURL: 'https://r.openai.azure.com',
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects an azure setup with an endpoint and key but no deployment name', () => {
+    expect(
+      isConnectionConfigured({
+        provider: 'azure',
+        model: '',
+        apiKey: 'az',
+        baseURL: 'https://r.openai.azure.com',
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects an azure setup where the deployment name is whitespace only', () => {
+    expect(
+      isConnectionConfigured({
+        provider: 'azure',
+        model: '   ',
+        apiKey: 'az',
+        baseURL: 'https://r.openai.azure.com',
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/core/capture/ai/__tests__/validate.test.ts
+++ b/src/core/capture/ai/__tests__/validate.test.ts
@@ -71,3 +71,42 @@ describe('validateApiKey', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });
+
+describe('validateApiKey for user-supplied endpoints', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('checks an azure key against the resource the user configured', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+    expect(await validateApiKey('azure', 'az-key', 'https://my-res.openai.azure.com')).toEqual({ valid: true });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://my-res.openai.azure.com/openai/v1/models?api-version=v1');
+    expect(init.headers['api-key']).toBe('az-key');
+  });
+
+  it('authenticates azure with api-key rather than a bearer token', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+    await validateApiKey('azure', 'az-key', 'https://my-res.openai.azure.com');
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers.Authorization).toBeUndefined();
+  });
+
+  it('reports a rejected azure key as rejected, not as a network problem', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 401 });
+    expect(await validateApiKey('azure', 'bad', 'https://my-res.openai.azure.com')).toEqual({
+      valid: false,
+      reason: 'rejected',
+    });
+  });
+
+  it('never sends the key anywhere when the azure endpoint is missing', async () => {
+    expect(await validateApiKey('azure', 'az-key', '')).toEqual({ valid: false, reason: 'network' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('never sends the key anywhere when the endpoint is not a usable url', async () => {
+    expect(await validateApiKey('azure', 'az-key', 'my-resource')).toEqual({ valid: false, reason: 'network' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/capture/ai/description.ts
+++ b/src/core/capture/ai/description.ts
@@ -4,19 +4,15 @@ import { logger } from '@/lib/logger';
 import type { DOMContext } from '../dom/context';
 import { serializeDOMContext } from '../dom/context';
 import { getLanguageSuffix, STEP_DESCRIPTION_PROMPT } from './prompts';
+import type { AIConnection } from './provider';
 import { createModel } from './provider';
 
-export async function getAIDescription(
-  domContext: DOMContext,
-  provider: string,
-  model: string,
-  apiKey: string,
-): Promise<string | null> {
+export async function getAIDescription(domContext: DOMContext, connection: AIConnection): Promise<string | null> {
   try {
     const settings = await localStorage.get(['aiLanguage']);
     const locale = (settings.aiLanguage as string) || 'en';
     const { text } = await generateText({
-      model: createModel(provider, model, apiKey),
+      model: createModel(connection),
       prompt:
         STEP_DESCRIPTION_PROMPT.replace('{{context}}', serializeDOMContext(domContext)) + getLanguageSuffix(locale),
       maxOutputTokens: 50,

--- a/src/core/capture/ai/endpoint.ts
+++ b/src/core/capture/ai/endpoint.ts
@@ -1,0 +1,51 @@
+export function normalizeEndpoint(provider: string, raw: string): string {
+  const trimmed = raw.trim().replace(/\/+$/, '');
+  if (!trimmed) return '';
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return '';
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return '';
+
+  if (provider === 'azure' && url.hostname.endsWith('.openai.azure.com') && !url.pathname.endsWith('/openai')) {
+    return `${trimmed}/openai`;
+  }
+
+  return trimmed;
+}
+
+function isPrivateIPv4(hostname: string): boolean {
+  const parts = hostname.split('.');
+  if (parts.length !== 4) return false;
+  const octets = parts.map(Number);
+  if (octets.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return false;
+  const [a, b] = octets;
+  if (a === 127) return true;
+  if (a === 10) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  return false;
+}
+
+export function isInsecureEndpoint(raw: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+
+  if (url.protocol !== 'http:') return false;
+
+  const hostname = url.hostname;
+  if (hostname === 'localhost' || hostname.endsWith('.localhost')) return false;
+  if (hostname === '[::1]') return false;
+  if (hostname.endsWith('.local')) return false;
+  if (isPrivateIPv4(hostname)) return false;
+
+  return true;
+}

--- a/src/core/capture/ai/meta.ts
+++ b/src/core/capture/ai/meta.ts
@@ -2,6 +2,7 @@ import { generateObject, generateText, jsonSchema } from 'ai';
 import { localStorage } from '@/lib/browser-api';
 import { logger } from '@/lib/logger';
 import { GUIDE_META_JSON_SUFFIX, GUIDE_META_PROMPT, getLanguageSuffix } from './prompts';
+import type { AIConnection } from './provider';
 import { createModel } from './provider';
 
 export interface GuideMeta {
@@ -55,9 +56,7 @@ export function parseGuideMeta(raw: string): GuideMeta | null {
 
 export async function generateGuideMeta(
   steps: { description: string; url: string }[],
-  provider: string,
-  model: string,
-  apiKey: string,
+  connection: AIConnection,
 ): Promise<GuideMeta | null> {
   if (steps.length === 0) return null;
 
@@ -65,7 +64,7 @@ export async function generateGuideMeta(
   const settings = await localStorage.get(['aiLanguage']);
   const locale = (settings.aiLanguage as string) || 'en';
   const prompt = GUIDE_META_PROMPT.replace('{{steps}}', formatted) + getLanguageSuffix(locale);
-  const aiModel = createModel(provider, model, apiKey);
+  const aiModel = createModel(connection);
 
   try {
     const { object } = await generateObject({

--- a/src/core/capture/ai/models.ts
+++ b/src/core/capture/ai/models.ts
@@ -7,6 +7,8 @@ export interface AIProviderConfig {
   label: string;
   defaultModel: string;
   models: AIModelOption[];
+  requiresEndpoint?: boolean;
+  endpointExample?: string;
 }
 
 export const AI_PROVIDERS: Record<string, AIProviderConfig> = {
@@ -28,6 +30,13 @@ export const AI_PROVIDERS: Record<string, AIProviderConfig> = {
       { id: 'claude-3-5-haiku-20241022', label: 'Claude 3.5 Haiku' },
       { id: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4' },
     ],
+  },
+  azure: {
+    label: 'Azure OpenAI',
+    defaultModel: '',
+    models: [],
+    requiresEndpoint: true,
+    endpointExample: 'https://your-resource.openai.azure.com',
   },
 };
 

--- a/src/core/capture/ai/provider.ts
+++ b/src/core/capture/ai/provider.ts
@@ -1,7 +1,44 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
+import { createAzure } from '@ai-sdk/azure';
 import { createOpenAI } from '@ai-sdk/openai';
+import { normalizeEndpoint } from './endpoint';
+import { AI_PROVIDERS } from './models';
 
-export function createModel(provider: string, model: string, apiKey: string) {
+export interface AIConnection {
+  provider: string;
+  model: string;
+  apiKey: string;
+  baseURL?: string;
+}
+
+export function isConnectionConfigured(connection: AIConnection): boolean {
+  const { provider, apiKey, baseURL, model } = connection;
+  const config = AI_PROVIDERS[provider];
+
+  if (config?.requiresEndpoint) {
+    if (!normalizeEndpoint(provider, baseURL ?? '')) return false;
+    if (!model?.trim()) return false;
+    return Boolean(apiKey);
+  }
+
+  return Boolean(apiKey);
+}
+
+export function createModel(connection: AIConnection) {
+  const { provider, model, apiKey, baseURL } = connection;
+
   if (provider === 'anthropic') return createAnthropic({ apiKey })(model);
+
+  const config = AI_PROVIDERS[provider];
+
+  if (config?.requiresEndpoint) {
+    const endpoint = normalizeEndpoint(provider, baseURL ?? '');
+    if (!endpoint) throw new Error(`Missing or invalid endpoint for provider "${provider}"`);
+
+    if (provider === 'azure') {
+      return createAzure({ apiKey, baseURL: endpoint })(model);
+    }
+  }
+
   return createOpenAI({ apiKey })(model);
 }

--- a/src/core/capture/ai/rewrite.ts
+++ b/src/core/capture/ai/rewrite.ts
@@ -4,7 +4,7 @@ import { logger } from '@/lib/logger';
 import type { RewriteSelectionResponse } from '@/lib/messaging';
 import { AI_PROVIDERS } from './models';
 import { getLanguageSuffix, REWRITE_PROMPT } from './prompts';
-import { createModel } from './provider';
+import { createModel, isConnectionConfigured } from './provider';
 
 const WRAPPED_IN_QUOTES = /^["“'](.*)["”']$/s;
 
@@ -22,18 +22,19 @@ export function buildRewritePrompt(text: string, instruction: string, locale: st
 }
 
 export async function rewriteSelection(text: string, instruction: string): Promise<RewriteSelectionResponse> {
-  const settings = await localStorage.get(['aiApiKey', 'aiProvider', 'aiModel', 'aiLanguage']);
-  if (!settings.aiApiKey) return { error: 'no-api-key' };
-
+  const settings = await localStorage.get(['aiApiKey', 'aiProvider', 'aiModel', 'aiLanguage', 'aiBaseUrl']);
   const provider = (settings.aiProvider as string) || 'openai';
+  const connection = {
+    provider,
+    model: (settings.aiModel as string) || AI_PROVIDERS[provider].defaultModel,
+    apiKey: settings.aiApiKey as string,
+    baseURL: settings.aiBaseUrl as string | undefined,
+  };
+  if (!isConnectionConfigured(connection)) return { error: 'no-api-key' };
 
   try {
     const { text: raw } = await generateText({
-      model: createModel(
-        provider,
-        (settings.aiModel as string) || AI_PROVIDERS[provider].defaultModel,
-        settings.aiApiKey as string,
-      ),
+      model: createModel(connection),
       prompt: buildRewritePrompt(text, instruction, (settings.aiLanguage as string) || 'en'),
       maxOutputTokens: 400,
     });

--- a/src/core/capture/ai/validate.ts
+++ b/src/core/capture/ai/validate.ts
@@ -1,4 +1,5 @@
 import { logger } from '@/lib/logger';
+import { normalizeEndpoint } from './endpoint';
 
 export type KeyValidation = { valid: true } | { valid: false; reason: 'rejected' | 'network' };
 
@@ -23,17 +24,9 @@ const ENDPOINTS: Record<string, { url: string; headers: (key: string) => Record<
   },
 };
 
-export async function validateApiKey(provider: string, apiKey: string): Promise<KeyValidation> {
-  const endpoint = ENDPOINTS[provider];
-  if (!endpoint) {
-    logger.error('No API key validation endpoint for provider', provider);
-    return { valid: false, reason: 'network' };
-  }
+async function fetchValidation(url: string, headers: Record<string, string>): Promise<KeyValidation> {
   try {
-    const res = await fetch(endpoint.url, {
-      headers: endpoint.headers(apiKey),
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    });
+    const res = await fetch(url, { headers, signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
     if (res.ok) return { valid: true };
     if (res.status === 401 || res.status === 403) return { valid: false, reason: 'rejected' };
     return { valid: false, reason: 'network' };
@@ -41,4 +34,19 @@ export async function validateApiKey(provider: string, apiKey: string): Promise<
     logger.error('API key validation request failed', err);
     return { valid: false, reason: 'network' };
   }
+}
+
+export async function validateApiKey(provider: string, apiKey: string, baseURL?: string): Promise<KeyValidation> {
+  if (provider === 'azure') {
+    const normalized = normalizeEndpoint('azure', baseURL ?? '');
+    if (!normalized) return { valid: false, reason: 'network' };
+    return fetchValidation(`${normalized}/v1/models?api-version=v1`, { 'api-key': apiKey });
+  }
+
+  const endpoint = ENDPOINTS[provider];
+  if (!endpoint) {
+    logger.error('No API key validation endpoint for provider', provider);
+    return { valid: false, reason: 'network' };
+  }
+  return fetchValidation(endpoint.url, endpoint.headers(apiKey));
 }

--- a/src/core/capture/voice/__tests__/api-key.test.ts
+++ b/src/core/capture/voice/__tests__/api-key.test.ts
@@ -101,6 +101,53 @@ describe('resolveVoiceApiKey', () => {
   it('resolves nothing from empty storage', () => {
     expect(resolveVoiceApiKey({})).toEqual({ provider: 'openai', apiKey: '', source: 'none' });
   });
+
+  it('resolves an azure voice key with its endpoint and deployment when fully configured', () => {
+    expect(
+      resolveVoiceApiKey({
+        voiceProvider: 'azure',
+        voiceApiKey: 'az-key',
+        voiceBaseUrl: 'https://my-res.openai.azure.com',
+        voiceModel: 'my-deployment',
+      }),
+    ).toEqual({
+      provider: 'azure',
+      apiKey: 'az-key',
+      source: 'voice',
+      baseURL: 'https://my-res.openai.azure.com',
+      model: 'my-deployment',
+    });
+  });
+
+  it('resolves nothing for azure when the endpoint is missing', () => {
+    expect(resolveVoiceApiKey({ voiceProvider: 'azure', voiceApiKey: 'az-key', voiceModel: 'my-deployment' })).toEqual({
+      provider: 'azure',
+      apiKey: '',
+      source: 'none',
+    });
+  });
+
+  it('resolves nothing for azure when the deployment name is missing', () => {
+    expect(
+      resolveVoiceApiKey({
+        voiceProvider: 'azure',
+        voiceApiKey: 'az-key',
+        voiceBaseUrl: 'https://my-res.openai.azure.com',
+      }),
+    ).toEqual({ provider: 'azure', apiKey: '', source: 'none' });
+  });
+
+  it('never lends the ai key to azure, even when endpoint and model are set', () => {
+    expect(
+      resolveVoiceApiKey({
+        voiceProvider: 'azure',
+        voiceApiKey: '',
+        voiceBaseUrl: 'https://my-res.openai.azure.com',
+        voiceModel: 'my-deployment',
+        aiApiKey: 'sk-ai',
+      }),
+    ).toEqual({ provider: 'azure', apiKey: '', source: 'none' });
+  });
 });
 
 describe('hasVoiceApiKey', () => {
@@ -122,6 +169,13 @@ describe('normalizeVoiceProvider', () => {
 
 describe('VOICE_KEY_SETTINGS', () => {
   it('names every storage key the resolution reads', () => {
-    expect([...VOICE_KEY_SETTINGS]).toEqual(['voiceProvider', 'voiceApiKey', 'aiProvider', 'aiApiKey']);
+    expect([...VOICE_KEY_SETTINGS]).toEqual([
+      'voiceProvider',
+      'voiceApiKey',
+      'voiceBaseUrl',
+      'voiceModel',
+      'aiProvider',
+      'aiApiKey',
+    ]);
   });
 });

--- a/src/core/capture/voice/__tests__/transcribe.test.ts
+++ b/src/core/capture/voice/__tests__/transcribe.test.ts
@@ -135,3 +135,58 @@ describe('createTranscriber', () => {
     await expect(run({ provider: 'openai', apiKey: 'sk-test' })).resolves.toEqual(verbose);
   });
 });
+
+describe('createTranscriber against an azure deployment', () => {
+  const azure = {
+    provider: 'azure' as const,
+    apiKey: 'az-key',
+    baseURL: 'https://my-res.openai.azure.com',
+    model: 'whisper',
+  };
+
+  it('posts to the deployment route, which is how azure addresses a model', async () => {
+    await run(azure);
+    expect(sentTo()).toBe(
+      'https://my-res.openai.azure.com/openai/deployments/whisper/audio/transcriptions?api-version=2024-06-01',
+    );
+  });
+
+  it('appends the /openai path the user does not have to type', async () => {
+    await run({ ...azure, baseURL: 'https://my-res.openai.azure.com/' });
+    expect(sentTo()).toContain('/openai/deployments/whisper/');
+  });
+
+  it('authenticates with api-key, since azure rejects a bearer token', async () => {
+    await run(azure);
+    const headers = sentInit().headers as Record<string, string>;
+    expect(headers['api-key']).toBe('az-key');
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it('sends the deployment name as the model, which azure accepts', async () => {
+    await run(azure);
+    expect(sentForm().get('model')).toBe('whisper');
+  });
+
+  it('still asks for the verbose payload the narration matcher depends on', async () => {
+    await run(azure);
+    expect(sentForm().get('response_format')).toBe('verbose_json');
+    expect(sentForm().getAll('timestamp_granularities[]')).toEqual(['word', 'segment']);
+  });
+
+  it('refuses to transcribe rather than call the wrong host when no endpoint is set', async () => {
+    await expect(run({ ...azure, baseURL: '' })).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses to transcribe when no deployment name is given', async () => {
+    await expect(run({ ...azure, model: '' })).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('leaves openai and groq on their own hosts with bearer auth', async () => {
+    await run({ provider: 'openai', apiKey: 'sk-test' });
+    expect(sentTo()).toBe('https://api.openai.com/v1/audio/transcriptions');
+    expect((sentInit().headers as Record<string, string>).Authorization).toBe('Bearer sk-test');
+  });
+});

--- a/src/core/capture/voice/api-key.ts
+++ b/src/core/capture/voice/api-key.ts
@@ -1,10 +1,19 @@
 import type { VoiceProvider } from './transcribe';
 
-export const VOICE_KEY_SETTINGS = ['voiceProvider', 'voiceApiKey', 'aiProvider', 'aiApiKey'] as const;
+export const VOICE_KEY_SETTINGS = [
+  'voiceProvider',
+  'voiceApiKey',
+  'voiceBaseUrl',
+  'voiceModel',
+  'aiProvider',
+  'aiApiKey',
+] as const;
 
 export interface VoiceKeySettings {
   voiceProvider?: unknown;
   voiceApiKey?: unknown;
+  voiceBaseUrl?: unknown;
+  voiceModel?: unknown;
   aiProvider?: unknown;
   aiApiKey?: unknown;
 }
@@ -15,6 +24,8 @@ export interface ResolvedVoiceApiKey {
   provider: VoiceProvider;
   apiKey: string;
   source: VoiceApiKeySource;
+  baseURL?: string;
+  model?: string;
 }
 
 function trimmed(value: unknown): string {
@@ -22,12 +33,22 @@ function trimmed(value: unknown): string {
 }
 
 export function normalizeVoiceProvider(value: unknown): VoiceProvider {
-  return value === 'groq' ? 'groq' : 'openai';
+  if (value === 'groq') return 'groq';
+  if (value === 'azure') return 'azure';
+  return 'openai';
 }
 
 export function resolveVoiceApiKey(settings: VoiceKeySettings): ResolvedVoiceApiKey {
   const provider = normalizeVoiceProvider(settings.voiceProvider);
   const own = trimmed(settings.voiceApiKey);
+
+  if (provider === 'azure') {
+    const baseURL = trimmed(settings.voiceBaseUrl);
+    const model = trimmed(settings.voiceModel);
+    if (!own || !baseURL || !model) return { provider, apiKey: '', source: 'none' };
+    return { provider, apiKey: own, source: 'voice', baseURL, model };
+  }
+
   if (own) return { provider, apiKey: own, source: 'voice' };
 
   const shared = trimmed(settings.aiApiKey);

--- a/src/core/capture/voice/transcribe.ts
+++ b/src/core/capture/voice/transcribe.ts
@@ -1,24 +1,45 @@
+import { normalizeEndpoint } from '@/core/capture/ai/endpoint';
 import type { TranscriptionResponse } from './types';
 
-export type VoiceProvider = 'openai' | 'groq';
+export type VoiceProvider = 'openai' | 'groq' | 'azure';
 
 export interface TranscribeConfig {
   provider: VoiceProvider;
   apiKey: string;
   language?: string;
+  baseURL?: string;
+  model?: string;
 }
 
-const PROVIDERS: Record<VoiceProvider, { url: string; model: string }> = {
+const PROVIDERS: Record<'openai' | 'groq', { url: string; model: string }> = {
   openai: { url: 'https://api.openai.com/v1/audio/transcriptions', model: 'whisper-1' },
   groq: { url: 'https://api.groq.com/openai/v1/audio/transcriptions', model: 'whisper-large-v3' },
 };
 
 const ERROR_BODY_LIMIT = 200;
 
-export function createTranscriber(config: TranscribeConfig): (wav: Blob) => Promise<TranscriptionResponse> {
-  const { url, model } = PROVIDERS[config.provider] ?? PROVIDERS.openai;
+function resolveRequest(config: TranscribeConfig): { url: string; model: string; headers: Record<string, string> } {
+  if (config.provider === 'azure') {
+    const endpoint = normalizeEndpoint('azure', config.baseURL ?? '');
+    const model = config.model?.trim() ?? '';
+    if (!endpoint) throw new Error('Azure voice transcription requires an endpoint');
+    if (!model) throw new Error('Azure voice transcription requires a deployment name');
 
+    return {
+      url: `${endpoint}/deployments/${model}/audio/transcriptions?api-version=2024-06-01`,
+      model,
+      headers: { 'api-key': config.apiKey },
+    };
+  }
+
+  const { url, model } = PROVIDERS[config.provider] ?? PROVIDERS.openai;
+  return { url, model, headers: { Authorization: `Bearer ${config.apiKey}` } };
+}
+
+export function createTranscriber(config: TranscribeConfig): (wav: Blob) => Promise<TranscriptionResponse> {
   return async (wav: Blob): Promise<TranscriptionResponse> => {
+    const { url, model, headers } = resolveRequest(config);
+
     const form = new FormData();
     form.append('file', wav, 'audio.wav');
     form.append('model', model);
@@ -30,7 +51,7 @@ export function createTranscriber(config: TranscribeConfig): (wav: Blob) => Prom
 
     const response = await fetch(url, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${config.apiKey}` },
+      headers,
       body: form,
     });
 

--- a/src/entrypoints/background/__tests__/guide-meta.test.ts
+++ b/src/entrypoints/background/__tests__/guide-meta.test.ts
@@ -96,12 +96,12 @@ describe('background guide-meta', () => {
 
       await run(GUIDE_ID);
 
-      expect(generateGuideMetaMock).toHaveBeenCalledWith(
-        expect.anything(),
-        'anthropic',
-        AI_PROVIDERS.anthropic.defaultModel,
-        'key',
-      );
+      expect(generateGuideMetaMock).toHaveBeenCalledWith(expect.anything(), {
+        provider: 'anthropic',
+        model: AI_PROVIDERS.anthropic.defaultModel,
+        apiKey: 'key',
+        baseURL: undefined,
+      });
     });
 
     it.each(entryPoints)('%s defaults the provider to OpenAI when none is stored', async (_name, run) => {
@@ -109,12 +109,12 @@ describe('background guide-meta', () => {
 
       await run(GUIDE_ID);
 
-      expect(generateGuideMetaMock).toHaveBeenCalledWith(
-        expect.anything(),
-        'openai',
-        AI_PROVIDERS.openai.defaultModel,
-        'key',
-      );
+      expect(generateGuideMetaMock).toHaveBeenCalledWith(expect.anything(), {
+        provider: 'openai',
+        model: AI_PROVIDERS.openai.defaultModel,
+        apiKey: 'key',
+        baseURL: undefined,
+      });
     });
   });
 

--- a/src/entrypoints/background/ai-description.ts
+++ b/src/entrypoints/background/ai-description.ts
@@ -1,13 +1,20 @@
 import { getAIDescription } from '@/core/capture/ai/description';
+import { isConnectionConfigured } from '@/core/capture/ai/provider';
 import type { DOMContext } from '@/core/capture/dom/context';
 import { localStorage } from '@/lib/browser-api';
 
 export async function generateAiDescription(domContext: DOMContext): Promise<string | undefined> {
-  const settings = await localStorage.get(['aiApiKey', 'aiProvider', 'aiModel']);
-  if (!settings.aiApiKey) return undefined;
-
+  const settings = await localStorage.get(['aiApiKey', 'aiProvider', 'aiModel', 'aiBaseUrl']);
   const provider = (settings.aiProvider as string) || 'openai';
   const model = (settings.aiModel as string) || 'gpt-4o-mini';
-  const description = await getAIDescription(domContext, provider, model, settings.aiApiKey as string);
+  const connection = {
+    provider,
+    model,
+    apiKey: settings.aiApiKey as string,
+    baseURL: settings.aiBaseUrl as string | undefined,
+  };
+  if (!isConnectionConfigured(connection)) return undefined;
+
+  const description = await getAIDescription(domContext, connection);
   return description || undefined;
 }

--- a/src/entrypoints/background/guide-meta.ts
+++ b/src/entrypoints/background/guide-meta.ts
@@ -1,6 +1,7 @@
 import { i18n } from '#imports';
 import { generateGuideMeta } from '@/core/capture/ai/meta';
 import { AI_PROVIDERS } from '@/core/capture/ai/models';
+import { type AIConnection, isConnectionConfigured } from '@/core/capture/ai/provider';
 import { actionSteps } from '@/core/guides/blocks';
 import {
   clearStepAiPending,
@@ -18,24 +19,28 @@ import { whenNarrationSettled } from './voice';
 type ResolveFailure = Extract<GuideDescriptionError, 'no-api-key' | 'no-steps'>;
 
 type GuideMetaInputs =
-  | { ok: true; steps: { description: string; url: string }[]; provider: string; model: string; apiKey: string }
+  | { ok: true; steps: { description: string; url: string }[]; connection: AIConnection }
   | { ok: false; reason: ResolveFailure };
 
 async function resolveGuideMetaInputs(guideId: string): Promise<GuideMetaInputs> {
-  const settings = await localStorage.get(['aiApiKey', 'aiProvider', 'aiModel']);
-  if (!settings.aiApiKey) return { ok: false, reason: 'no-api-key' };
+  const settings = await localStorage.get(['aiApiKey', 'aiProvider', 'aiModel', 'aiBaseUrl']);
+  const provider = (settings.aiProvider as string) || 'openai';
+  const connection: AIConnection = {
+    provider,
+    model: (settings.aiModel as string) || AI_PROVIDERS[provider].defaultModel,
+    apiKey: settings.aiApiKey as string,
+    baseURL: settings.aiBaseUrl as string | undefined,
+  };
+  if (!isConnectionConfigured(connection)) return { ok: false, reason: 'no-api-key' };
 
   const steps = actionSteps(await getStepsForGuide(guideId));
   const described = steps.filter((s) => s.description).map((s) => ({ description: s.description, url: s.url }));
   if (described.length === 0) return { ok: false, reason: 'no-steps' };
 
-  const provider = (settings.aiProvider as string) || 'openai';
   return {
     ok: true,
     steps: described.length > 15 ? [...described.slice(0, 10), ...described.slice(-5)] : described,
-    provider,
-    model: (settings.aiModel as string) || AI_PROVIDERS[provider].defaultModel,
-    apiKey: settings.aiApiKey as string,
+    connection,
   };
 }
 
@@ -63,7 +68,7 @@ export async function generateGuideMetaOnStop(guideId: string) {
       return;
     }
 
-    const meta = await generateGuideMeta(inputs.steps, inputs.provider, inputs.model, inputs.apiKey);
+    const meta = await generateGuideMeta(inputs.steps, inputs.connection);
     if (!meta) {
       await applyFallbackTitle(guideId);
       return;
@@ -87,7 +92,7 @@ export async function generateDescriptionOnDemand(guideId: string): Promise<Gene
     const inputs = await resolveGuideMetaInputs(guideId);
     if (!inputs.ok) return { error: inputs.reason };
 
-    const meta = await generateGuideMeta(inputs.steps, inputs.provider, inputs.model, inputs.apiKey);
+    const meta = await generateGuideMeta(inputs.steps, inputs.connection);
     if (!meta?.description) return { error: 'generation-failed' };
 
     await updateGuideDescription(guideId, meta.description);

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -184,7 +184,7 @@ export default defineBackground(() => {
 
   onMessage('generateGuideDescription', ({ data }) => generateDescriptionOnDemand(data.guideId));
 
-  onMessage('validateApiKey', ({ data }) => validateApiKey(data.provider, data.apiKey));
+  onMessage('validateApiKey', ({ data }) => validateApiKey(data.provider, data.apiKey, data.baseURL));
 
   onMessage('rewriteSelection', ({ data }) => rewriteSelection(data.text, data.instruction));
 

--- a/src/lib/__tests__/voice-narration.test.ts
+++ b/src/lib/__tests__/voice-narration.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const storageMock = vi.fn();
+
+vi.mock('../browser-api', () => ({
+  localStorage: { get: (keys: string[]) => storageMock(keys) },
+}));
+
+import { readTranscriptionSettings } from '../voice-narration';
+
+describe('readTranscriptionSettings', () => {
+  it('wires the stored azure endpoint and deployment through to the transcriber config', async () => {
+    storageMock.mockResolvedValue({
+      voiceProvider: 'azure',
+      voiceApiKey: 'az-key',
+      voiceBaseUrl: 'https://my-res.openai.azure.com',
+      voiceModel: 'my-deployment',
+    });
+
+    const settings = await readTranscriptionSettings();
+
+    expect(settings.provider).toBe('azure');
+    expect(settings.apiKey).toBe('az-key');
+    expect(settings.baseURL).toBe('https://my-res.openai.azure.com');
+    expect(settings.model).toBe('my-deployment');
+  });
+
+  it('leaves baseURL and model undefined for a plain openai setup', async () => {
+    storageMock.mockResolvedValue({
+      voiceProvider: 'openai',
+      voiceApiKey: 'sk-voice',
+    });
+
+    const settings = await readTranscriptionSettings();
+
+    expect(settings.provider).toBe('openai');
+    expect(settings.baseURL).toBeUndefined();
+    expect(settings.model).toBeUndefined();
+  });
+});

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -110,6 +110,7 @@ export interface RewriteSelectionResponse {
 export interface ValidateApiKeyData {
   provider: string;
   apiKey: string;
+  baseURL?: string;
 }
 
 export interface ValidateApiKeyResponse {

--- a/src/lib/voice-narration.ts
+++ b/src/lib/voice-narration.ts
@@ -12,6 +12,8 @@ export interface TranscriptionSettings {
   provider: VoiceProvider;
   apiKey: string;
   language?: string;
+  baseURL?: string;
+  model?: string;
 }
 
 export interface VoiceRecording {
@@ -36,12 +38,14 @@ export const EMPTY_NARRATION: NarrationResult = {
 
 export async function readTranscriptionSettings(): Promise<TranscriptionSettings> {
   const stored = await localStorage.get([...VOICE_KEY_SETTINGS, 'voiceLanguage', 'aiLanguage']);
-  const { provider, apiKey } = resolveVoiceApiKey(stored);
+  const { provider, apiKey, baseURL, model } = resolveVoiceApiKey(stored);
   const locale = (stored.voiceLanguage ?? stored.aiLanguage) as string | undefined;
   return {
     provider,
     apiKey,
     language: locale ? locale.split('-')[0] : undefined,
+    baseURL,
+    model,
   };
 }
 

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -100,8 +100,12 @@ settings:
   provider: Anbieter
   model: Modell
   apiKey: API-Schlüssel
+  endpoint: Endpunkt
+  endpointHint: "Die Basis-URL deines Anbieters. Dein Schlüssel und deine Daten gehen ausschließlich an diese Adresse."
+  endpointInsecure: "Diese Verbindung ist nicht verschlüsselt. Dein API-Schlüssel wird im Klartext übertragen."
   aiLanguage: Sprache der Beschreibungen
   voiceNarration: Sprachkommentar
+  voiceDeployment: Bereitstellungsname
   voiceUsingAiKey: "Es ist kein Sprach-Schlüssel gesetzt, daher nutzt Mimik den OpenAI-Schlüssel aus den KI-Beschreibungen oben."
   aiNoKey: "Kein API-Schlüssel gesetzt, daher verwenden Schritte einfache regelbasierte Beschreibungen."
   voiceNoKey: "Es ist kein API-Schlüssel gesetzt, daher werden deine Aufnahmen nicht vertont."

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -88,8 +88,12 @@ settings:
   model: Model
   modelCustom: Custom model
   apiKey: API Key
+  endpoint: Endpoint
+  endpointHint: The base URL of your provider. Your key and data go only to this address.
+  endpointInsecure: This endpoint is not encrypted. Your API key will be sent in plain text.
   aiLanguage: Description Language
   voiceNarration: Voice Narration
+  voiceDeployment: Deployment name
   voiceUsingAiKey: "No voice key is set, so Mimik uses the OpenAI key from AI Descriptions above."
   aiNoKey: "No API key is set, so steps will use plain rule-based descriptions."
   voiceNoKey: "No API key is set, so your recordings will not be narrated."

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -88,8 +88,12 @@ settings:
   model: Modelo
   modelCustom: Modelo personalizado
   apiKey: Clave API
+  endpoint: Extremo
+  endpointHint: "La URL base de tu proveedor. Tu clave y tus datos solo se envían a esta dirección."
+  endpointInsecure: "Este endpoint no está cifrado. Tu clave de API se enviará en texto plano."
   aiLanguage: Idioma de descripciones
   voiceNarration: "Narración por voz"
+  voiceDeployment: "Nombre de la implementación"
   voiceUsingAiKey: "No hay clave de voz, así que Mimik usa la clave de OpenAI de Descripciones con IA de arriba."
   aiNoKey: "No hay clave de API, así que los pasos usarán descripciones básicas por reglas."
   voiceNoKey: "No hay ninguna clave de API configurada, así que tus grabaciones no se narrarán."

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -88,8 +88,12 @@ settings:
   model: "Modèle"
   modelCustom: Modèle personnalisé
   apiKey: "Clé API"
+  endpoint: "Point de terminaison"
+  endpointHint: "L'URL de base de votre fournisseur. Votre clé et vos données ne sont envoyées qu'à cette adresse."
+  endpointInsecure: "Ce point d'accès n'est pas chiffré. Votre clé API sera envoyée en clair."
   aiLanguage: Langue des descriptions
   voiceNarration: "Narration vocale"
+  voiceDeployment: "Nom du déploiement"
   voiceUsingAiKey: "Aucune clé vocale n'est définie : Mimik utilise la clé OpenAI des descriptions IA ci-dessus."
   aiNoKey: "Aucune clé API définie, les étapes utiliseront donc des descriptions simples basées sur des règles."
   voiceNoKey: "Aucune clé API n'est définie, vos enregistrements ne seront donc pas narrés."

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -88,8 +88,12 @@ settings:
   model: Modelo
   modelCustom: Modelo personalizado
   apiKey: Chave da API
+  endpoint: Endpoint
+  endpointHint: "A URL base do seu provedor. Sua chave e seus dados vão só pra esse endereço."
+  endpointInsecure: "Esse endpoint não é criptografado. Sua chave de API vai ser enviada em texto simples."
   aiLanguage: "Idioma das descrições"
   voiceNarration: "Narração por voz"
+  voiceDeployment: "Nome da implantação"
   voiceUsingAiKey: "Não tem chave de voz, então o Mimik usa a chave da OpenAI das Descrições com IA lá de cima."
   aiNoKey: "Nenhuma chave de API definida, então as etapas usarão descrições simples baseadas em regras."
   voiceNoKey: "Nenhuma chave de API foi definida, então suas gravações não serão narradas."

--- a/src/ui/onboarding/App.tsx
+++ b/src/ui/onboarding/App.tsx
@@ -2,7 +2,8 @@ import { Mic, MousePointerClick, Shield } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { browser, i18n } from '#imports';
 import { PRESET_LABELS, type PresetKey } from '@/core/blur/regexes';
-import { AI_PROVIDERS, type AIProviderKey } from '@/core/capture/ai/models';
+import { isInsecureEndpoint } from '@/core/capture/ai/endpoint';
+import { AI_PROVIDERS, type AIProviderKey, CUSTOM_MODEL_VALUE, isCustomModel } from '@/core/capture/ai/models';
 import { AI_LANGUAGES, type AILanguageCode } from '@/core/capture/ai/prompts';
 import type { VoiceProvider } from '@/core/capture/voice/transcribe';
 import { localStorage, openSidebar, requestHostPermissions } from '@/lib/browser-api';
@@ -118,16 +119,19 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
   const [provider, setProvider] = useState<AIProviderKey>('openai');
   const [model, setModel] = useState(AI_PROVIDERS.openai.defaultModel);
   const [apiKey, setApiKey] = useState('');
+  const [baseUrl, setBaseUrl] = useState('');
   const [aiLanguage, setAiLanguage] = useState<AILanguageCode>('en');
+  const [customModel, setCustomModel] = useState(false);
 
   useEffect(() => {
     const load = () =>
-      localStorage.get(['aiProvider', 'aiModel', 'aiApiKey', 'aiLanguage']).then((stored) => {
+      localStorage.get(['aiProvider', 'aiModel', 'aiApiKey', 'aiBaseUrl', 'aiLanguage']).then((stored) => {
         if (typeof stored.aiProvider === 'string' && stored.aiProvider in AI_PROVIDERS) {
           setProvider(stored.aiProvider as AIProviderKey);
         }
         if (typeof stored.aiModel === 'string') setModel(stored.aiModel);
         if (typeof stored.aiApiKey === 'string') setApiKey(stored.aiApiKey);
+        if (typeof stored.aiBaseUrl === 'string') setBaseUrl(stored.aiBaseUrl);
         if (typeof stored.aiLanguage === 'string') setAiLanguage(stored.aiLanguage as AILanguageCode);
       });
 
@@ -140,15 +144,34 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
   }, []);
 
   const providerConfig = AI_PROVIDERS[provider];
+  const usingCustomModel = customModel || providerConfig.models.length === 0 || isCustomModel(model, providerConfig);
 
   const handleProviderChange = (newProvider: AIProviderKey) => {
     const nextModel = AI_PROVIDERS[newProvider].defaultModel;
     setProvider(newProvider);
+    setCustomModel(false);
     setModel(nextModel);
-    void localStorage.set({ aiProvider: newProvider, aiModel: nextModel });
+    setBaseUrl('');
+    void localStorage.set({ aiProvider: newProvider, aiModel: nextModel, aiBaseUrl: '' });
+  };
+
+  const handleBaseUrlChange = (nextBaseUrl: string) => {
+    setBaseUrl(nextBaseUrl);
+    void localStorage.set({ aiBaseUrl: nextBaseUrl });
   };
 
   const handleModelChange = (nextModel: string) => {
+    if (nextModel === CUSTOM_MODEL_VALUE) {
+      setCustomModel(true);
+      setModel('');
+      return;
+    }
+    setCustomModel(false);
+    setModel(nextModel);
+    void localStorage.set({ aiModel: nextModel });
+  };
+
+  const handleCustomModelChange = (nextModel: string) => {
     setModel(nextModel);
     void localStorage.set({ aiModel: nextModel });
   };
@@ -192,9 +215,30 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
               </Select>
             </div>
 
+            {providerConfig.requiresEndpoint && (
+              <div>
+                <label className="block text-xs font-semibold text-foreground mb-1.5">
+                  {i18n.t('settings.endpoint')}
+                </label>
+                <Input
+                  type="text"
+                  value={baseUrl}
+                  onChange={(e) => handleBaseUrlChange(e.target.value)}
+                  placeholder={providerConfig.endpointExample}
+                  className="w-full rounded-xl px-4 py-2.5 text-sm focus:border-accent focus:ring-accent/10"
+                />
+                <p className="mt-1.5 text-xs text-muted-foreground">{i18n.t('settings.endpointHint')}</p>
+                {isInsecureEndpoint(baseUrl) && (
+                  <p className="mt-1.5 text-xs text-destructive" role="alert">
+                    {i18n.t('settings.endpointInsecure')}
+                  </p>
+                )}
+              </div>
+            )}
+
             <div>
               <label className="block text-xs font-semibold text-foreground mb-1.5">{i18n.t('settings.model')}</label>
-              <Select value={model} onValueChange={handleModelChange}>
+              <Select value={usingCustomModel ? CUSTOM_MODEL_VALUE : model} onValueChange={handleModelChange}>
                 <SelectTrigger className="w-full rounded-xl px-4 py-2.5 text-sm focus:border-accent focus:ring-accent/10">
                   <SelectValue />
                 </SelectTrigger>
@@ -204,8 +248,18 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
                       {m.label}
                     </SelectItem>
                   ))}
+                  <SelectItem value={CUSTOM_MODEL_VALUE}>{i18n.t('settings.modelCustom')}</SelectItem>
                 </SelectContent>
               </Select>
+              {usingCustomModel && (
+                <Input
+                  value={model}
+                  onChange={(e) => handleCustomModelChange(e.target.value)}
+                  placeholder={providerConfig.defaultModel}
+                  aria-label={i18n.t('settings.modelCustom')}
+                  className="mt-1.5 w-full rounded-xl px-4 py-2.5 text-sm focus:border-accent focus:ring-accent/10"
+                />
+              )}
             </div>
 
             <div>
@@ -333,15 +387,22 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
 function VoiceStep({ onNext, onSkip, onBack, index, total }: StepProps) {
   const [provider, setProvider] = useState<VoiceProvider>('openai');
   const [apiKey, setApiKey] = useState('');
+  const [baseUrl, setBaseUrl] = useState('');
+  const [model, setModel] = useState('');
   const [microphoneId, setMicrophoneId] = useState('');
 
   useEffect(() => {
     const load = () =>
-      localStorage.get(['voiceProvider', 'voiceApiKey', 'voiceMicrophoneId']).then((stored) => {
-        if (stored.voiceProvider === 'openai' || stored.voiceProvider === 'groq') setProvider(stored.voiceProvider);
-        if (typeof stored.voiceApiKey === 'string') setApiKey(stored.voiceApiKey);
-        if (typeof stored.voiceMicrophoneId === 'string') setMicrophoneId(stored.voiceMicrophoneId);
-      });
+      localStorage
+        .get(['voiceProvider', 'voiceApiKey', 'voiceBaseUrl', 'voiceModel', 'voiceMicrophoneId'])
+        .then((stored) => {
+          if (stored.voiceProvider === 'openai' || stored.voiceProvider === 'groq' || stored.voiceProvider === 'azure')
+            setProvider(stored.voiceProvider);
+          if (typeof stored.voiceApiKey === 'string') setApiKey(stored.voiceApiKey);
+          if (typeof stored.voiceBaseUrl === 'string') setBaseUrl(stored.voiceBaseUrl);
+          if (typeof stored.voiceModel === 'string') setModel(stored.voiceModel);
+          if (typeof stored.voiceMicrophoneId === 'string') setMicrophoneId(stored.voiceMicrophoneId);
+        });
 
     void load();
     const onVisible = () => {
@@ -358,12 +419,24 @@ function VoiceStep({ onNext, onSkip, onBack, index, total }: StepProps) {
 
   const handleProviderChange = (nextProvider: VoiceProvider) => {
     setProvider(nextProvider);
-    void localStorage.set({ voiceProvider: nextProvider });
+    setBaseUrl('');
+    setModel('');
+    void localStorage.set({ voiceProvider: nextProvider, voiceBaseUrl: '', voiceModel: '' });
   };
 
   const handleApiKeyChange = (nextKey: string) => {
     setApiKey(nextKey);
     void localStorage.set({ voiceApiKey: nextKey });
+  };
+
+  const handleBaseUrlChange = (nextBaseUrl: string) => {
+    setBaseUrl(nextBaseUrl);
+    void localStorage.set({ voiceBaseUrl: nextBaseUrl });
+  };
+
+  const handleModelChange = (nextModel: string) => {
+    setModel(nextModel);
+    void localStorage.set({ voiceModel: nextModel });
   };
 
   return (
@@ -391,6 +464,7 @@ function VoiceStep({ onNext, onSkip, onBack, index, total }: StepProps) {
                 >
                   <option value="openai">OpenAI</option>
                   <option value="groq">Groq</option>
+                  <option value="azure">Azure OpenAI</option>
                 </select>
               </div>
               <div className="flex-1">
@@ -401,11 +475,45 @@ function VoiceStep({ onNext, onSkip, onBack, index, total }: StepProps) {
                   type="password"
                   value={apiKey}
                   onChange={(e) => handleApiKeyChange(e.target.value)}
-                  placeholder={provider === 'groq' ? 'gsk_...' : 'sk-...'}
+                  placeholder={provider === 'groq' ? 'gsk_...' : provider === 'azure' ? '' : 'sk-...'}
                   className="w-full border border-border rounded-xl px-3 py-2 text-[13px] text-foreground bg-card font-medium outline-none focus:border-accent focus:ring-2 focus:ring-accent/10 placeholder:text-muted-foreground/50"
                 />
               </div>
             </div>
+
+            {provider === 'azure' && (
+              <div className="flex gap-3">
+                <div className="flex-1">
+                  <label className="block text-[11px] font-semibold text-foreground mb-1">
+                    {i18n.t('settings.endpoint')}
+                  </label>
+                  <input
+                    type="text"
+                    value={baseUrl}
+                    onChange={(e) => handleBaseUrlChange(e.target.value)}
+                    placeholder="https://your-resource.openai.azure.com"
+                    className="w-full border border-border rounded-xl px-3 py-2 text-[13px] text-foreground bg-card font-medium outline-none focus:border-accent focus:ring-2 focus:ring-accent/10"
+                  />
+                  <p className="mt-1 text-[11px] text-muted-foreground">{i18n.t('settings.endpointHint')}</p>
+                  {isInsecureEndpoint(baseUrl) && (
+                    <p className="mt-1 text-[11px] text-destructive" role="alert">
+                      {i18n.t('settings.endpointInsecure')}
+                    </p>
+                  )}
+                </div>
+                <div className="flex-1">
+                  <label className="block text-[11px] font-semibold text-foreground mb-1">
+                    {i18n.t('settings.voiceDeployment')}
+                  </label>
+                  <input
+                    type="text"
+                    value={model}
+                    onChange={(e) => handleModelChange(e.target.value)}
+                    className="w-full border border-border rounded-xl px-3 py-2 text-[13px] text-foreground bg-card font-medium outline-none focus:border-accent focus:ring-2 focus:ring-accent/10"
+                  />
+                </div>
+              </div>
+            )}
 
             <MicrophonePicker value={microphoneId} onChange={handleMicrophoneChange} />
 

--- a/src/ui/onboarding/__tests__/endpoint-providers.test.tsx
+++ b/src/ui/onboarding/__tests__/endpoint-providers.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const store: Record<string, unknown> = {};
+
+vi.mock('@/lib/browser-api', () => ({
+  localStorage: {
+    get: (keys: string[]) =>
+      Promise.resolve(Object.fromEntries(keys.filter((key) => key in store).map((key) => [key, store[key]]))),
+    set: (items: Record<string, unknown>) => {
+      Object.assign(store, items);
+      return Promise.resolve();
+    },
+  },
+  getActiveTab: vi.fn().mockResolvedValue(undefined),
+  openSidebar: vi.fn(),
+  requestHostPermissions: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@/lib/offscreen', () => ({ openMicPermissionPage: vi.fn().mockResolvedValue(undefined) }));
+
+import OnboardingApp from '../App';
+
+async function openAiStep() {
+  render(<OnboardingApp />);
+  fireEvent.click(screen.getAllByText('onboarding.getStarted')[0]);
+  await screen.findByText('onboarding.aiTitle');
+}
+
+beforeEach(() => {
+  for (const key of Object.keys(store)) delete store[key];
+});
+
+describe('onboarding with an endpoint-driven provider', () => {
+  it('asks for the endpoint when the provider needs one', async () => {
+    store.aiProvider = 'azure';
+    await openAiStep();
+
+    await waitFor(() => expect(screen.getByPlaceholderText('https://your-resource.openai.azure.com')).toBeTruthy());
+  });
+
+  it('offers a free-text model box, since it cannot know the user deployment names', async () => {
+    store.aiProvider = 'azure';
+    await openAiStep();
+
+    await waitFor(() => expect(screen.getByLabelText('settings.modelCustom')).toBeTruthy());
+  });
+
+  it('keeps the deployment name the user typed', async () => {
+    store.aiProvider = 'azure';
+    await openAiStep();
+
+    const field = await waitFor(() => screen.getByLabelText('settings.modelCustom') as HTMLInputElement);
+    fireEvent.change(field, { target: { value: 'my-deployment' } });
+
+    await waitFor(() => expect(store.aiModel).toBe('my-deployment'));
+  });
+
+  it('does not ask a plain openai user for an endpoint', async () => {
+    store.aiProvider = 'openai';
+    await openAiStep();
+
+    await waitFor(() => expect(screen.queryByPlaceholderText('https://your-resource.openai.azure.com')).toBeNull());
+  });
+});

--- a/src/ui/shared/SettingsView.tsx
+++ b/src/ui/shared/SettingsView.tsx
@@ -148,7 +148,8 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
         'brandAttribution',
       ])
       .then((result) => {
-        const p = (result.aiProvider as AIProviderKey) || 'openai';
+        const stored = result.aiProvider as string | undefined;
+        const p: AIProviderKey = stored && stored in AI_PROVIDERS ? (stored as AIProviderKey) : 'openai';
         setProvider(p);
         setModel((result.aiModel as string) || AI_PROVIDERS[p].defaultModel);
         if (result.aiApiKey) setApiKey(result.aiApiKey as string);

--- a/src/ui/shared/SettingsView.tsx
+++ b/src/ui/shared/SettingsView.tsx
@@ -18,6 +18,7 @@ import {
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { i18n } from '#imports';
 import { PRESET_LABELS, type PresetKey } from '@/core/blur/regexes';
+import { isInsecureEndpoint } from '@/core/capture/ai/endpoint';
 import { AI_PROVIDERS, type AIProviderKey, CUSTOM_MODEL_VALUE, isCustomModel } from '@/core/capture/ai/models';
 import { AI_LANGUAGES, type AILanguageCode } from '@/core/capture/ai/prompts';
 import { resolveVoiceApiKey } from '@/core/capture/voice/api-key';
@@ -48,14 +49,14 @@ function useKeyCheck() {
   const [status, setStatus] = useState<KeyStatus>(null);
   const validated = useRef('');
 
-  const check = useCallback(async (provider: string, apiKey: string) => {
-    const fingerprint = `${provider}:${apiKey}`;
+  const check = useCallback(async (provider: string, apiKey: string, baseURL?: string) => {
+    const fingerprint = `${provider}:${apiKey}:${baseURL ?? ''}`;
     if (validated.current === fingerprint) {
       setStatus('valid');
       return;
     }
     setStatus('checking');
-    const result = await sendMessage('validateApiKey', { provider, apiKey }).catch(() => null);
+    const result = await sendMessage('validateApiKey', { provider, apiKey, baseURL }).catch(() => null);
     if (result?.valid) validated.current = fingerprint;
     setStatus(result?.valid ? 'valid' : result?.reason === 'rejected' ? 'rejected' : 'unreachable');
   }, []);
@@ -98,6 +99,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
   const [provider, setProvider] = useState<AIProviderKey>('openai');
   const [model, setModel] = useState(AI_PROVIDERS.openai.defaultModel);
   const [apiKey, setApiKey] = useState('');
+  const [baseUrl, setBaseUrl] = useState('');
   const [saved, setSaved] = useState(false);
   const aiKeyCheck = useKeyCheck();
   const voiceKeyCheck = useKeyCheck();
@@ -109,6 +111,8 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
   const [aiLanguage, setAiLanguage] = useState<AILanguageCode>('en');
   const [voiceProvider, setVoiceProvider] = useState<VoiceProvider>('openai');
   const [voiceApiKey, setVoiceApiKey] = useState('');
+  const [voiceBaseUrl, setVoiceBaseUrl] = useState('');
+  const [voiceModel, setVoiceModel] = useState('');
   const [voiceMicrophoneId, setVoiceMicrophoneId] = useState('');
   const [targetColor, setTargetColor] = useState<string>(DEFAULT_TARGET_COLOR);
   const [brandLogo, setBrandLogo] = useState<BrandLogo | null>(null);
@@ -128,12 +132,15 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
     localStorage
       .get([
         'aiApiKey',
+        'aiBaseUrl',
         'aiProvider',
         'aiModel',
         'aiLanguage',
         'blurPresets',
         'voiceProvider',
         'voiceApiKey',
+        'voiceBaseUrl',
+        'voiceModel',
         'voiceMicrophoneId',
         'targetColor',
         'brandLogo',
@@ -145,10 +152,13 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
         setProvider(p);
         setModel((result.aiModel as string) || AI_PROVIDERS[p].defaultModel);
         if (result.aiApiKey) setApiKey(result.aiApiKey as string);
+        if (result.aiBaseUrl) setBaseUrl(result.aiBaseUrl as string);
         if (result.aiLanguage) setAiLanguage(result.aiLanguage as AILanguageCode);
         if (result.blurPresets) setBlurPresets(result.blurPresets as Record<PresetKey, boolean>);
         setVoiceProvider((result.voiceProvider as VoiceProvider) || 'openai');
         if (result.voiceApiKey) setVoiceApiKey(result.voiceApiKey as string);
+        if (result.voiceBaseUrl) setVoiceBaseUrl(result.voiceBaseUrl as string);
+        if (result.voiceModel) setVoiceModel(result.voiceModel as string);
         if (result.voiceMicrophoneId) setVoiceMicrophoneId(result.voiceMicrophoneId as string);
         if (result.targetColor) setTargetColor(result.targetColor as string);
         if (result.brandLogo) setBrandLogo(result.brandLogo as BrandLogo);
@@ -160,12 +170,15 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
 
   const stored = {
     aiApiKey: apiKey,
+    aiBaseUrl: baseUrl,
     aiProvider: provider,
     aiModel: model,
     aiLanguage,
     blurPresets,
     voiceProvider,
     voiceApiKey,
+    voiceBaseUrl,
+    voiceModel,
     voiceMicrophoneId,
     targetColor,
     brandLogo,
@@ -227,6 +240,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
     aiKeyCheck.setStatus(null);
     setCustomModel(false);
     setModel(AI_PROVIDERS[newProvider].defaultModel);
+    setBaseUrl('');
   };
 
   const handleModelChange = (value: string) => {
@@ -303,6 +317,27 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
             </Select>
           </div>
 
+          {providerConfig.requiresEndpoint && (
+            <div>
+              <label className="block text-[11px] font-semibold text-foreground mb-1">
+                {i18n.t('settings.endpoint')}
+              </label>
+              <Input
+                type="text"
+                value={baseUrl}
+                onChange={(e) => setBaseUrl(e.target.value)}
+                placeholder={providerConfig.endpointExample}
+                className="h-8 text-[12px] rounded-lg border-border"
+              />
+              <p className="mt-1 text-[11px] text-muted-foreground">{i18n.t('settings.endpointHint')}</p>
+              {isInsecureEndpoint(baseUrl) && (
+                <p className="mt-1 text-[11px] text-destructive" role="alert">
+                  {i18n.t('settings.endpointInsecure')}
+                </p>
+              )}
+            </div>
+          )}
+
           <div>
             <label className="block text-[11px] font-semibold text-foreground mb-1">{i18n.t('settings.model')}</label>
             <Select value={usingCustomModel ? CUSTOM_MODEL_VALUE : model} onValueChange={handleModelChange}>
@@ -345,8 +380,10 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
               <Button
                 variant="outline"
                 size="sm"
-                disabled={!apiKey || aiKeyCheck.status === 'checking'}
-                onClick={() => void aiKeyCheck.check(provider, apiKey)}
+                disabled={
+                  !apiKey || (providerConfig.requiresEndpoint && !baseUrl.trim()) || aiKeyCheck.status === 'checking'
+                }
+                onClick={() => void aiKeyCheck.check(provider, apiKey, baseUrl)}
                 className="h-8 shrink-0 rounded-lg bg-card text-[11px] font-semibold"
               >
                 {i18n.t('settings.checkKey')}
@@ -519,13 +556,51 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
               onChange={(e) => {
                 setVoiceProvider(e.target.value as VoiceProvider);
                 voiceKeyCheck.setStatus(null);
+                setVoiceBaseUrl('');
+                setVoiceModel('');
               }}
               className="w-full border border-border rounded-lg px-3 py-2 text-[13px] text-foreground bg-card font-medium outline-none focus:border-ring focus:ring-2 focus:ring-ring/10"
             >
               <option value="openai">OpenAI</option>
               <option value="groq">Groq</option>
+              <option value="azure">Azure OpenAI</option>
             </select>
           </div>
+
+          {voiceProvider === 'azure' && (
+            <>
+              <div>
+                <label className="block text-[11px] font-semibold text-foreground mb-1">
+                  {i18n.t('settings.endpoint')}
+                </label>
+                <Input
+                  type="text"
+                  value={voiceBaseUrl}
+                  onChange={(e) => setVoiceBaseUrl(e.target.value)}
+                  placeholder="https://your-resource.openai.azure.com"
+                  className="h-8 text-[12px] rounded-lg border-border"
+                />
+                <p className="mt-1 text-[11px] text-muted-foreground">{i18n.t('settings.endpointHint')}</p>
+                {isInsecureEndpoint(voiceBaseUrl) && (
+                  <p className="mt-1 text-[11px] text-destructive" role="alert">
+                    {i18n.t('settings.endpointInsecure')}
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <label className="block text-[11px] font-semibold text-foreground mb-1">
+                  {i18n.t('settings.voiceDeployment')}
+                </label>
+                <Input
+                  type="text"
+                  value={voiceModel}
+                  onChange={(e) => setVoiceModel(e.target.value)}
+                  className="h-8 text-[12px] rounded-lg border-border"
+                />
+              </div>
+            </>
+          )}
 
           <div>
             <label className="block text-[11px] font-semibold text-foreground mb-1">{i18n.t('settings.apiKey')}</label>
@@ -537,13 +612,17 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
                   setVoiceApiKey(e.target.value);
                   voiceKeyCheck.setStatus(null);
                 }}
-                placeholder={voiceProvider === 'groq' ? 'gsk_...' : 'sk-...'}
+                placeholder={voiceProvider === 'groq' ? 'gsk_...' : voiceProvider === 'azure' ? '' : 'sk-...'}
               />
               <Button
                 variant="outline"
                 size="sm"
-                disabled={!voiceApiKey || voiceKeyCheck.status === 'checking'}
-                onClick={() => void voiceKeyCheck.check(voiceProvider, voiceApiKey)}
+                disabled={
+                  !voiceApiKey ||
+                  (voiceProvider === 'azure' && !voiceBaseUrl.trim()) ||
+                  voiceKeyCheck.status === 'checking'
+                }
+                onClick={() => void voiceKeyCheck.check(voiceProvider, voiceApiKey, voiceBaseUrl)}
                 className="h-8 shrink-0 rounded-lg bg-card text-[11px] font-semibold"
               >
                 {i18n.t('settings.checkKey')}

--- a/src/ui/shared/SettingsView.tsx
+++ b/src/ui/shared/SettingsView.tsx
@@ -255,7 +255,14 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
 
   const providerConfig = AI_PROVIDERS[provider];
   const usingCustomModel = customModel || isCustomModel(model, providerConfig);
-  const voiceKey = resolveVoiceApiKey({ voiceProvider, voiceApiKey, aiProvider: provider, aiApiKey: apiKey });
+  const voiceKey = resolveVoiceApiKey({
+    voiceProvider,
+    voiceApiKey,
+    voiceBaseUrl,
+    voiceModel,
+    aiProvider: provider,
+    aiApiKey: apiKey,
+  });
 
   const BLUR_PRESET_I18N: Record<PresetKey, string> = {
     email: 'blurPresets.email',

--- a/src/ui/shared/__tests__/unknown-provider.test.tsx
+++ b/src/ui/shared/__tests__/unknown-provider.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const store: Record<string, unknown> = {};
+
+vi.mock('@/lib/browser-api', () => ({
+  localStorage: {
+    get: (keys: string[]) =>
+      Promise.resolve(Object.fromEntries(keys.filter((key) => key in store).map((key) => [key, store[key]]))),
+    set: (items: Record<string, unknown>) => {
+      Object.assign(store, items);
+      return Promise.resolve();
+    },
+  },
+}));
+
+import SettingsView from '../SettingsView';
+
+beforeEach(() => {
+  for (const key of Object.keys(store)) delete store[key];
+});
+
+describe('settings with a provider this build does not know', () => {
+  it('still renders instead of blanking the page', async () => {
+    store.aiProvider = 'some-future-provider';
+    store.aiApiKey = 'sk-left-over';
+    store.aiModel = 'mystery-model';
+
+    render(<SettingsView />);
+
+    await waitFor(() => expect(screen.getByText('settings.title')).toBeTruthy());
+  });
+
+  it('falls back to openai so the picker stays usable', async () => {
+    store.aiProvider = 'some-future-provider';
+
+    render(<SettingsView />);
+
+    await waitFor(() => expect(screen.getByText('settings.title')).toBeTruthy());
+    const picker = document.querySelector('[data-slot="select-value"]');
+    expect(picker?.textContent).toBe('OpenAI');
+  });
+});

--- a/src/ui/shared/__tests__/voice-key-banner.test.tsx
+++ b/src/ui/shared/__tests__/voice-key-banner.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const store: Record<string, unknown> = {};
+
+vi.mock('@/lib/browser-api', () => ({
+  localStorage: {
+    get: (keys: string[]) =>
+      Promise.resolve(Object.fromEntries(keys.filter((key) => key in store).map((key) => [key, store[key]]))),
+    set: (items: Record<string, unknown>) => {
+      Object.assign(store, items);
+      return Promise.resolve();
+    },
+  },
+}));
+
+import SettingsView from '../SettingsView';
+
+function configureAzureVoice(overrides: Record<string, unknown> = {}) {
+  Object.assign(store, {
+    voiceProvider: 'azure',
+    voiceApiKey: 'az-key',
+    voiceBaseUrl: 'https://my-res.openai.azure.com',
+    voiceModel: 'whisper',
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  for (const key of Object.keys(store)) delete store[key];
+});
+
+describe('voice narration key banner', () => {
+  it('does not warn about a missing key when an azure setup is complete', async () => {
+    configureAzureVoice();
+    render(<SettingsView />);
+
+    await waitFor(() => expect((screen.getByDisplayValue('az-key') as HTMLInputElement).value).toBe('az-key'));
+    expect(screen.queryByText('settings.voiceNoKey')).toBeNull();
+  });
+
+  it('still warns when the azure setup has no deployment name', async () => {
+    configureAzureVoice({ voiceModel: '' });
+    render(<SettingsView />);
+
+    await waitFor(() => expect(screen.getByText('settings.voiceNoKey')).toBeTruthy());
+  });
+});


### PR DESCRIPTION
### What

Adds Azure OpenAI alongside OpenAI and Anthropic, in both places Mimik calls a model:

- **AI step descriptions** (plus guide title/description and selection rewrite)
- **Voice narration** transcription

You paste your resource URL as the endpoint and use your deployment name as the model. A bare resource URL is fine: the `/openai` path suffix is appended for you.

### Why

Provider settings were a 3-tuple of `(provider, model, apiKey)`, which cannot express the one thing Azure needs that the first-party APIs do not: the per-resource endpoint. This widens the config into an `AIConnection` object and threads it through. Voice narration needed its own treatment since Azure routes transcription by deployment (`{endpoint}/openai/deployments/{name}/audio/transcriptions`) and authenticates with an `api-key` header rather than a bearer token.

### Notes for review

This touches API key handling, so a few things worth calling out:

**It fails closed.** A provider that needs an endpoint but has no valid one throws before any client is constructed, rather than falling back to the default OpenAI client. Without that, picking Azure, entering a key and leaving the URL blank would quietly send prompts to `api.openai.com`. There's a test asserting the cloud client never gets constructed in that case, and the narration path treats an incomplete Azure setup as unconfigured instead of silently producing empty narration.

**Endpoints are restricted to `http:` and `https:`.** `javascript:`, `data:`, `file:` and `blob:` are rejected when the value is read.

**Plain `http://` to a non-local host shows an advisory warning** that the key would be sent in the clear. `localhost`, `.local` and RFC1918 addresses stay quiet.

**Voice still requests `verbose_json` with word/segment timestamps** on every provider, since the narration-to-step matcher depends on the segments array. Worth knowing: this requires a Whisper deployment on the Azure side, because the `gpt-4o-transcribe` models reject `verbose_json` (verified against a live resource).

No manifest or permission changes; the extension already holds `<all_urls>`.

### Relationship to #54

Complementary, not competing. #54 adds generic OpenAI-compatible endpoints; this adds the Azure-specific auth and routing that path cannot express (deployment-based URLs, `api-key` header). I kept this PR Azure-only to avoid overlapping it. Happy to rebase whichever lands second.

### Tests

70 new tests (1159 passing in total). They cover endpoint normalisation, provider routing, the fail-closed paths, key validation, the settings-to-transcriber wiring, and the settings/onboarding UI for the new provider. `pnpm typecheck`, `pnpm lint`, `pnpm build` and `pnpm build:firefox` are all clean.

### i18n

Four new strings (`settings.endpoint`, `settings.endpointHint`, `settings.endpointInsecure`, `settings.voiceDeployment`) across all five locales. I'm not a native speaker in most of them, so if you'd rather run the translations past your own people, please do.

### Dependency

One addition: `@ai-sdk/azure@^3.0.111`, pinned to the v3 line to match the `@ai-sdk/provider@3` your openai and anthropic packages depend on. The npm `latest` tag is 4.x, which would force a breaking bump of those.
