### PR TITLE
feat(ai): add OpenAI-compatible custom provider (multislot, baseUrl o…

### DIFF
--- a/src/core/capture/ai/description.ts
+++ b/src/core/capture/ai/description.ts
@@ -11,12 +11,13 @@ export async function getAIDescription(
   provider: string,
   model: string,
   apiKey: string,
+  baseUrl?: string,
 ): Promise<string | null> {
   try {
     const settings = await localStorage.get(['aiLanguage']);
     const locale = (settings.aiLanguage as string) || 'en';
     const { text } = await generateText({
-      model: createModel(provider, model, apiKey),
+      model: createModel(provider, model, apiKey, baseUrl),
       prompt:
         STEP_DESCRIPTION_PROMPT.replace('{{context}}', serializeDOMContext(domContext)) + getLanguageSuffix(locale),
       maxOutputTokens: 50,

--- a/src/core/capture/ai/meta.ts
+++ b/src/core/capture/ai/meta.ts
@@ -58,6 +58,7 @@ export async function generateGuideMeta(
   provider: string,
   model: string,
   apiKey: string,
+  baseUrl?: string,
 ): Promise<GuideMeta | null> {
   if (steps.length === 0) return null;
 
@@ -65,7 +66,7 @@ export async function generateGuideMeta(
   const settings = await localStorage.get(['aiLanguage']);
   const locale = (settings.aiLanguage as string) || 'en';
   const prompt = GUIDE_META_PROMPT.replace('{{steps}}', formatted) + getLanguageSuffix(locale);
-  const aiModel = createModel(provider, model, apiKey);
+  const aiModel = createModel(provider, model, apiKey, baseUrl);
 
   try {
     const { object } = await generateObject({

--- a/src/core/capture/ai/models.ts
+++ b/src/core/capture/ai/models.ts
@@ -3,6 +3,11 @@ export interface AIModelOption {
   label: string;
 }
 
+export interface AIModelOption {
+  id: string;
+  label: string;
+}
+
 export interface AIProviderConfig {
   label: string;
   defaultModel: string;
@@ -38,4 +43,49 @@ export const CUSTOM_MODEL_VALUE = 'mimik-custom-model';
 export function isCustomModel(model: string, provider: AIProviderConfig): boolean {
   const id = model.trim();
   return id.length > 0 && !provider.models.some((option) => option.id === id);
+}
+
+// OpenAI-compatible custom profiles (multislot)
+export const PROFILE_PREFIX = 'profile:';
+
+export interface AIProfile {
+  id: string;
+  name: string;
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+}
+
+export function isProfileProvider(provider: string): boolean {
+  return provider.startsWith(PROFILE_PREFIX);
+}
+
+export function getProfileId(provider: string): string {
+  return provider.slice(PROFILE_PREFIX.length);
+}
+
+export function profileProviderId(id: string): string {
+  return `${PROFILE_PREFIX}${id}`;
+}
+
+export function normalizeBaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, '');
+}
+
+export function isLocalBaseUrl(url: string): boolean {
+  const u = url.trim().toLowerCase();
+  return (
+    u.includes('localhost') ||
+    u.includes('127.0.0.1') ||
+    u.includes('192.168.') ||
+    u.includes('10.') ||
+    u.startsWith('http://')
+  );
+}
+
+export function makeProfileId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return (crypto.randomUUID() as string).slice(0, 8);
+  }
+  return Math.random().toString(36).slice(2, 10);
 }

--- a/src/core/capture/ai/provider.ts
+++ b/src/core/capture/ai/provider.ts
@@ -1,7 +1,10 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
+import { normalizeBaseUrl } from './models';
 
-export function createModel(provider: string, model: string, apiKey: string) {
+export function createModel(provider: string, model: string, apiKey: string, baseUrl?: string) {
   if (provider === 'anthropic') return createAnthropic({ apiKey })(model);
+  const trimmed = baseUrl ? normalizeBaseUrl(baseUrl) : '';
+  if (trimmed) return createOpenAI({ apiKey, baseURL: trimmed })(model);
   return createOpenAI({ apiKey })(model);
 }

--- a/src/core/capture/ai/resolve.ts
+++ b/src/core/capture/ai/resolve.ts
@@ -1,0 +1,99 @@
+import { AI_PROVIDERS, type AIProfile, getProfileId, isProfileProvider, profileProviderId } from './models';
+
+export interface ResolvedAIConfig {
+  providerSdk: 'openai' | 'anthropic';
+  model: string;
+  apiKey: string;
+  baseUrl?: string;
+  label: string;
+  profileId?: string;
+}
+
+type StorageLike = Record<string, unknown>;
+
+function asString(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+function asProfiles(v: unknown): AIProfile[] {
+  if (!Array.isArray(v)) return [];
+  return v.filter(
+    (p): p is AIProfile =>
+      p !== null &&
+      typeof p === 'object' &&
+      typeof (p as AIProfile).id === 'string' &&
+      typeof (p as AIProfile).baseUrl === 'string' &&
+      typeof (p as AIProfile).model === 'string',
+  ) as AIProfile[];
+}
+
+export function resolveAIConfig(settings: StorageLike): ResolvedAIConfig | null {
+  const rawProvider = asString(settings.aiProvider) || 'openai';
+  const profiles = asProfiles(settings.aiProfiles);
+
+  if (isProfileProvider(rawProvider)) {
+    const id = getProfileId(rawProvider);
+    const profile = profiles.find((p) => p.id === id);
+    if (!profile) return null;
+    return {
+      providerSdk: 'openai',
+      model: profile.model.trim(),
+      apiKey: profile.apiKey ?? '',
+      baseUrl: profile.baseUrl.trim(),
+      label: profile.name || profile.baseUrl,
+      profileId: id,
+    };
+  }
+
+  if (rawProvider === 'anthropic') {
+    return {
+      providerSdk: 'anthropic',
+      model: asString(settings.aiModel) || AI_PROVIDERS.anthropic.defaultModel,
+      apiKey: asString(settings.aiApiKey),
+      label: AI_PROVIDERS.anthropic.label,
+    };
+  }
+
+  // openai (with optional baseUrl override)
+  const baseUrl = asString(settings.aiBaseUrl) || asString(settings.aiEndpoint);
+  return {
+    providerSdk: 'openai',
+    model: asString(settings.aiModel) || AI_PROVIDERS.openai.defaultModel,
+    apiKey: asString(settings.aiApiKey),
+    baseUrl: baseUrl.trim() || undefined,
+    label: AI_PROVIDERS.openai.label,
+  };
+}
+
+export function hasAIKey(settings: StorageLike): boolean {
+  const c = resolveAIConfig(settings);
+  if (!c) return false;
+  // keyless allowed for local/custom baseUrls; otherwise require key
+  if (c.baseUrl && c.providerSdk === 'openai' && c.apiKey.trim() === '') {
+    const lu = c.baseUrl.toLowerCase();
+    if (lu.includes('localhost') || lu.includes('127.0.0.1') || lu.startsWith('http://')) return true;
+  }
+  return c.apiKey.trim().length > 0;
+}
+
+export function migrateLegacyToProfiles(settings: StorageLike): { aiProfiles: AIProfile[]; aiProvider: string } | null {
+  const profiles = asProfiles(settings.aiProfiles);
+  if (profiles.length > 0) return null;
+  // Legacy single custom stored as aiProvider = 'openai-compatible' / 'custom' with aiBaseUrl
+  const legacyProvider = asString(settings.aiProvider);
+  const legacyBase = asString(settings.aiBaseUrl) || asString(settings.aiEndpoint);
+  const legacyModel = asString(settings.aiModel);
+  const legacyKey = asString(settings.aiApiKey);
+  if ((legacyProvider === 'openai-compatible' || legacyProvider === 'custom') && legacyBase) {
+    const id = Math.random().toString(36).slice(2, 10);
+    const profile: AIProfile = {
+      id,
+      name: 'Custom',
+      baseUrl: legacyBase,
+      apiKey: legacyKey,
+      model: legacyModel,
+    };
+    return { aiProfiles: [profile], aiProvider: profileProviderId(id) };
+  }
+  return null;
+}

--- a/src/core/capture/ai/rewrite.ts
+++ b/src/core/capture/ai/rewrite.ts
@@ -2,9 +2,9 @@ import { generateText } from 'ai';
 import { localStorage } from '@/lib/browser-api';
 import { logger } from '@/lib/logger';
 import type { RewriteSelectionResponse } from '@/lib/messaging';
-import { AI_PROVIDERS } from './models';
 import { getLanguageSuffix, REWRITE_PROMPT } from './prompts';
 import { createModel } from './provider';
+import { resolveAIConfig } from './resolve';
 
 const WRAPPED_IN_QUOTES = /^["“'](.*)["”']$/s;
 
@@ -22,18 +22,28 @@ export function buildRewritePrompt(text: string, instruction: string, locale: st
 }
 
 export async function rewriteSelection(text: string, instruction: string): Promise<RewriteSelectionResponse> {
-  const settings = await localStorage.get(['aiApiKey', 'aiProvider', 'aiModel', 'aiLanguage']);
-  if (!settings.aiApiKey) return { error: 'no-api-key' };
-
-  const provider = (settings.aiProvider as string) || 'openai';
+  const settings = await localStorage.get([
+    'aiApiKey',
+    'aiProvider',
+    'aiModel',
+    'aiBaseUrl',
+    'aiEndpoint',
+    'aiProfiles',
+    'aiLanguage',
+  ]);
+  const cfg = resolveAIConfig(settings);
+  if (!cfg) return { error: 'no-api-key' };
+  const hasKey = cfg.apiKey.trim().length > 0;
+  const isLocal = cfg.baseUrl
+    ? cfg.baseUrl.toLowerCase().includes('localhost') ||
+      cfg.baseUrl.includes('127.0.0.1') ||
+      cfg.baseUrl.startsWith('http://')
+    : false;
+  if (!hasKey && !isLocal) return { error: 'no-api-key' };
 
   try {
     const { text: raw } = await generateText({
-      model: createModel(
-        provider,
-        (settings.aiModel as string) || AI_PROVIDERS[provider].defaultModel,
-        settings.aiApiKey as string,
-      ),
+      model: createModel(cfg.providerSdk, cfg.model, cfg.apiKey, cfg.baseUrl),
       prompt: buildRewritePrompt(text, instruction, (settings.aiLanguage as string) || 'en'),
       maxOutputTokens: 400,
     });

--- a/src/core/capture/ai/validate.ts
+++ b/src/core/capture/ai/validate.ts
@@ -1,4 +1,5 @@
 import { logger } from '@/lib/logger';
+import { normalizeBaseUrl } from './models';
 
 export type KeyValidation = { valid: true } | { valid: false; reason: 'rejected' | 'network' };
 
@@ -23,7 +24,41 @@ const ENDPOINTS: Record<string, { url: string; headers: (key: string) => Record<
   },
 };
 
-export async function validateApiKey(provider: string, apiKey: string): Promise<KeyValidation> {
+function buildModelsUrl(baseUrl: string): string {
+  const trimmed = normalizeBaseUrl(baseUrl);
+  if (!trimmed) return '';
+  try {
+    return new URL('/v1/models', trimmed.endsWith('/') ? trimmed : `${trimmed}/`).toString();
+  } catch {
+    // fallback simple join if URL constructor fails (e.g. missing scheme during test)
+    const sep = trimmed.endsWith('/') ? '' : '/';
+    // if baseUrl already ends with /v1 or /v1/, just append /models
+    if (trimmed.endsWith('/v1')) return `${trimmed}/models`;
+    if (trimmed.endsWith('/v1/')) return `${trimmed}models`;
+    // heuristic: if trimmed contains /v1 already, append /models
+    if (trimmed.includes('/v1')) return `${trimmed}${sep}models`;
+    return `${trimmed}${sep}v1/models`;
+  }
+}
+
+export async function validateApiKey(provider: string, apiKey: string, baseUrl?: string): Promise<KeyValidation> {
+  const trimmedBase = baseUrl ? normalizeBaseUrl(baseUrl) : '';
+
+  // Custom / profile providers or openai with explicit baseUrl override use OpenAI-spec /models
+  if (provider.startsWith('profile:') || provider === 'openai-compatible' || provider === 'custom') {
+    if (!trimmedBase) {
+      logger.error('No baseUrl for custom provider', provider);
+      return { valid: false, reason: 'network' };
+    }
+    const url = buildModelsUrl(trimmedBase);
+    return fetchWithAuth(url, apiKey);
+  }
+
+  if (provider === 'openai' && trimmedBase) {
+    const url = buildModelsUrl(trimmedBase);
+    return fetchWithAuth(url, apiKey);
+  }
+
   const endpoint = ENDPOINTS[provider];
   if (!endpoint) {
     logger.error('No API key validation endpoint for provider', provider);
@@ -32,6 +67,22 @@ export async function validateApiKey(provider: string, apiKey: string): Promise<
   try {
     const res = await fetch(endpoint.url, {
       headers: endpoint.headers(apiKey),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    if (res.ok) return { valid: true };
+    if (res.status === 401 || res.status === 403) return { valid: false, reason: 'rejected' };
+    return { valid: false, reason: 'network' };
+  } catch (err) {
+    logger.error('API key validation request failed', err);
+    return { valid: false, reason: 'network' };
+  }
+}
+
+async function fetchWithAuth(url: string, apiKey: string): Promise<KeyValidation> {
+  try {
+    const headers: Record<string, string> = apiKey ? { Authorization: `Bearer ${apiKey}` } : {};
+    const res = await fetch(url, {
+      headers,
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
     if (res.ok) return { valid: true };

--- a/src/core/capture/voice/__tests__/api-key.test.ts
+++ b/src/core/capture/voice/__tests__/api-key.test.ts
@@ -122,6 +122,15 @@ describe('normalizeVoiceProvider', () => {
 
 describe('VOICE_KEY_SETTINGS', () => {
   it('names every storage key the resolution reads', () => {
-    expect([...VOICE_KEY_SETTINGS]).toEqual(['voiceProvider', 'voiceApiKey', 'aiProvider', 'aiApiKey']);
+    expect([...VOICE_KEY_SETTINGS]).toEqual([
+      'voiceProvider',
+      'voiceApiKey',
+      'voiceBaseUrl',
+      'voiceModel',
+      'aiProvider',
+      'aiApiKey',
+      'aiProfiles',
+      'aiBaseUrl',
+    ]);
   });
 });

--- a/src/core/capture/voice/api-key.ts
+++ b/src/core/capture/voice/api-key.ts
@@ -1,12 +1,25 @@
 import type { VoiceProvider } from './transcribe';
 
-export const VOICE_KEY_SETTINGS = ['voiceProvider', 'voiceApiKey', 'aiProvider', 'aiApiKey'] as const;
+export const VOICE_KEY_SETTINGS = [
+  'voiceProvider',
+  'voiceApiKey',
+  'voiceBaseUrl',
+  'voiceModel',
+  'aiProvider',
+  'aiApiKey',
+  'aiProfiles',
+  'aiBaseUrl',
+] as const;
 
 export interface VoiceKeySettings {
   voiceProvider?: unknown;
   voiceApiKey?: unknown;
+  voiceBaseUrl?: unknown;
+  voiceModel?: unknown;
   aiProvider?: unknown;
   aiApiKey?: unknown;
+  aiProfiles?: unknown;
+  aiBaseUrl?: unknown;
 }
 
 export type VoiceApiKeySource = 'voice' | 'ai' | 'none';
@@ -15,6 +28,8 @@ export interface ResolvedVoiceApiKey {
   provider: VoiceProvider;
   apiKey: string;
   source: VoiceApiKeySource;
+  baseUrl?: string;
+  model?: string;
 }
 
 function trimmed(value: unknown): string {
@@ -22,23 +37,68 @@ function trimmed(value: unknown): string {
 }
 
 export function normalizeVoiceProvider(value: unknown): VoiceProvider {
-  return value === 'groq' ? 'groq' : 'openai';
+  if (value === 'groq') return 'groq';
+  if (typeof value === 'string' && value.startsWith('profile:')) return 'openai';
+  return 'openai';
+}
+
+export function isVoiceProfileProvider(value: unknown): boolean {
+  return typeof value === 'string' && value.startsWith('profile:');
+}
+
+export function getVoiceProfileId(value: string): string {
+  return value.slice('profile:'.length);
 }
 
 export function resolveVoiceApiKey(settings: VoiceKeySettings): ResolvedVoiceApiKey {
-  const provider = normalizeVoiceProvider(settings.voiceProvider);
+  const rawProvider = typeof settings.voiceProvider === 'string' ? settings.voiceProvider : 'openai';
+  const baseUrl = trimmed(settings.voiceBaseUrl);
+  const model = trimmed(settings.voiceModel);
+
+  // Profile-backed voice provider reuses AI profile
+  if (typeof rawProvider === 'string' && rawProvider.startsWith('profile:')) {
+    const id = getVoiceProfileId(rawProvider);
+    const profiles = Array.isArray(settings.aiProfiles) ? (settings.aiProfiles as Array<Record<string, unknown>>) : [];
+    const p = profiles.find((x) => x.id === id) as { baseUrl?: string; apiKey?: string; model?: string } | undefined;
+    if (p) {
+      const own = trimmed(settings.voiceApiKey) || trimmed(p.apiKey);
+      const r: ResolvedVoiceApiKey = { provider: 'openai', apiKey: own, source: 'voice' as const };
+      if (p.baseUrl) r.baseUrl = p.baseUrl;
+      if (p.model) r.model = p.model;
+      return r;
+    }
+  }
+
+  const provider = normalizeVoiceProvider(rawProvider);
   const own = trimmed(settings.voiceApiKey);
-  if (own) return { provider, apiKey: own, source: 'voice' };
+  if (own) {
+    const r: ResolvedVoiceApiKey = { provider, apiKey: own, source: 'voice' };
+    if (baseUrl) r.baseUrl = baseUrl;
+    if (model) r.model = model;
+    return r;
+  }
 
   const shared = trimmed(settings.aiApiKey);
   const aiProvider = trimmed(settings.aiProvider) || 'openai';
   if (provider !== 'openai' || aiProvider !== 'openai' || !shared) {
-    return { provider, apiKey: '', source: 'none' };
+    const r: ResolvedVoiceApiKey = { provider, apiKey: '', source: 'none' };
+    if (baseUrl) r.baseUrl = baseUrl;
+    if (model) r.model = model;
+    return r;
   }
 
-  return { provider, apiKey: shared, source: 'ai' };
+  const r: ResolvedVoiceApiKey = { provider, apiKey: shared, source: 'ai' };
+  if (baseUrl) r.baseUrl = baseUrl;
+  if (model) r.model = model;
+  return r;
 }
 
 export function hasVoiceApiKey(settings: VoiceKeySettings): boolean {
-  return resolveVoiceApiKey(settings).apiKey.length > 0;
+  const r = resolveVoiceApiKey(settings);
+  // keyless allowed for local/custom baseUrls
+  if (!r.apiKey && r.baseUrl) {
+    const lu = r.baseUrl.toLowerCase();
+    if (lu.includes('localhost') || lu.includes('127.0.0.1') || lu.startsWith('http://')) return true;
+  }
+  return r.apiKey.length > 0;
 }

--- a/src/core/capture/voice/transcribe.ts
+++ b/src/core/capture/voice/transcribe.ts
@@ -6,6 +6,8 @@ export interface TranscribeConfig {
   provider: VoiceProvider;
   apiKey: string;
   language?: string;
+  baseUrl?: string;
+  model?: string;
 }
 
 const PROVIDERS: Record<VoiceProvider, { url: string; model: string }> = {
@@ -13,10 +15,24 @@ const PROVIDERS: Record<VoiceProvider, { url: string; model: string }> = {
   groq: { url: 'https://api.groq.com/openai/v1/audio/transcriptions', model: 'whisper-large-v3' },
 };
 
+function buildTranscriptionUrl(baseUrl: string): string {
+  const trimmed = baseUrl.trim().replace(/\/+$/, '');
+  if (!trimmed) return '';
+  try {
+    return new URL('/v1/audio/transcriptions', trimmed.endsWith('/') ? trimmed : `${trimmed}/`).toString();
+  } catch {
+    if (trimmed.endsWith('/v1')) return `${trimmed}/audio/transcriptions`;
+    if (trimmed.includes('/v1')) return `${trimmed.replace(/\/+$/, '')}/audio/transcriptions`;
+    return `${trimmed}/v1/audio/transcriptions`;
+  }
+}
+
 const ERROR_BODY_LIMIT = 200;
 
 export function createTranscriber(config: TranscribeConfig): (wav: Blob) => Promise<TranscriptionResponse> {
-  const { url, model } = PROVIDERS[config.provider] ?? PROVIDERS.openai;
+  const fallback = PROVIDERS[config.provider] ?? PROVIDERS.openai;
+  const url = config.baseUrl ? buildTranscriptionUrl(config.baseUrl) : fallback.url;
+  const model = config.model?.trim() ? config.model.trim() : fallback.model;
 
   return async (wav: Blob): Promise<TranscriptionResponse> => {
     const form = new FormData();

--- a/src/entrypoints/background/__tests__/guide-meta.test.ts
+++ b/src/entrypoints/background/__tests__/guide-meta.test.ts
@@ -101,6 +101,7 @@ describe('background guide-meta', () => {
         'anthropic',
         AI_PROVIDERS.anthropic.defaultModel,
         'key',
+        undefined,
       );
     });
 
@@ -114,6 +115,7 @@ describe('background guide-meta', () => {
         'openai',
         AI_PROVIDERS.openai.defaultModel,
         'key',
+        undefined,
       );
     });
   });

--- a/src/entrypoints/background/ai-description.ts
+++ b/src/entrypoints/background/ai-description.ts
@@ -1,13 +1,27 @@
 import { getAIDescription } from '@/core/capture/ai/description';
+import { resolveAIConfig } from '@/core/capture/ai/resolve';
 import type { DOMContext } from '@/core/capture/dom/context';
 import { localStorage } from '@/lib/browser-api';
 
 export async function generateAiDescription(domContext: DOMContext): Promise<string | undefined> {
-  const settings = await localStorage.get(['aiApiKey', 'aiProvider', 'aiModel']);
-  if (!settings.aiApiKey) return undefined;
+  const settings = await localStorage.get([
+    'aiApiKey',
+    'aiProvider',
+    'aiModel',
+    'aiBaseUrl',
+    'aiEndpoint',
+    'aiProfiles',
+  ]);
+  const cfg = resolveAIConfig(settings);
+  if (!cfg) return undefined;
+  const hasKey = cfg.apiKey.trim().length > 0;
+  const isLocal = cfg.baseUrl
+    ? cfg.baseUrl.toLowerCase().includes('localhost') ||
+      cfg.baseUrl.includes('127.0.0.1') ||
+      cfg.baseUrl.startsWith('http://')
+    : false;
+  if (!hasKey && !isLocal) return undefined;
 
-  const provider = (settings.aiProvider as string) || 'openai';
-  const model = (settings.aiModel as string) || 'gpt-4o-mini';
-  const description = await getAIDescription(domContext, provider, model, settings.aiApiKey as string);
+  const description = await getAIDescription(domContext, cfg.providerSdk, cfg.model, cfg.apiKey, cfg.baseUrl);
   return description || undefined;
 }

--- a/src/entrypoints/background/guide-meta.ts
+++ b/src/entrypoints/background/guide-meta.ts
@@ -1,6 +1,6 @@
 import { i18n } from '#imports';
 import { generateGuideMeta } from '@/core/capture/ai/meta';
-import { AI_PROVIDERS } from '@/core/capture/ai/models';
+import { resolveAIConfig } from '@/core/capture/ai/resolve';
 import { actionSteps } from '@/core/guides/blocks';
 import {
   clearStepAiPending,
@@ -18,24 +18,46 @@ import { whenNarrationSettled } from './voice';
 type ResolveFailure = Extract<GuideDescriptionError, 'no-api-key' | 'no-steps'>;
 
 type GuideMetaInputs =
-  | { ok: true; steps: { description: string; url: string }[]; provider: string; model: string; apiKey: string }
+  | {
+      ok: true;
+      steps: { description: string; url: string }[];
+      provider: string;
+      model: string;
+      apiKey: string;
+      baseUrl?: string;
+    }
   | { ok: false; reason: ResolveFailure };
 
 async function resolveGuideMetaInputs(guideId: string): Promise<GuideMetaInputs> {
-  const settings = await localStorage.get(['aiApiKey', 'aiProvider', 'aiModel']);
-  if (!settings.aiApiKey) return { ok: false, reason: 'no-api-key' };
+  const settings = await localStorage.get([
+    'aiApiKey',
+    'aiProvider',
+    'aiModel',
+    'aiBaseUrl',
+    'aiEndpoint',
+    'aiProfiles',
+  ]);
+  const cfg = resolveAIConfig(settings);
+  if (!cfg) return { ok: false, reason: 'no-api-key' };
+  const hasKey = cfg.apiKey.trim().length > 0;
+  const isLocal = cfg.baseUrl
+    ? cfg.baseUrl.toLowerCase().includes('localhost') ||
+      cfg.baseUrl.includes('127.0.0.1') ||
+      cfg.baseUrl.startsWith('http://')
+    : false;
+  if (!hasKey && !isLocal) return { ok: false, reason: 'no-api-key' };
 
   const steps = actionSteps(await getStepsForGuide(guideId));
   const described = steps.filter((s) => s.description).map((s) => ({ description: s.description, url: s.url }));
   if (described.length === 0) return { ok: false, reason: 'no-steps' };
 
-  const provider = (settings.aiProvider as string) || 'openai';
   return {
     ok: true,
     steps: described.length > 15 ? [...described.slice(0, 10), ...described.slice(-5)] : described,
-    provider,
-    model: (settings.aiModel as string) || AI_PROVIDERS[provider].defaultModel,
-    apiKey: settings.aiApiKey as string,
+    provider: cfg.providerSdk,
+    model: cfg.model,
+    apiKey: cfg.apiKey,
+    baseUrl: cfg.baseUrl,
   };
 }
 
@@ -63,7 +85,7 @@ export async function generateGuideMetaOnStop(guideId: string) {
       return;
     }
 
-    const meta = await generateGuideMeta(inputs.steps, inputs.provider, inputs.model, inputs.apiKey);
+    const meta = await generateGuideMeta(inputs.steps, inputs.provider, inputs.model, inputs.apiKey, inputs.baseUrl);
     if (!meta) {
       await applyFallbackTitle(guideId);
       return;
@@ -87,7 +109,7 @@ export async function generateDescriptionOnDemand(guideId: string): Promise<Gene
     const inputs = await resolveGuideMetaInputs(guideId);
     if (!inputs.ok) return { error: inputs.reason };
 
-    const meta = await generateGuideMeta(inputs.steps, inputs.provider, inputs.model, inputs.apiKey);
+    const meta = await generateGuideMeta(inputs.steps, inputs.provider, inputs.model, inputs.apiKey, inputs.baseUrl);
     if (!meta?.description) return { error: 'generation-failed' };
 
     await updateGuideDescription(guideId, meta.description);

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -184,7 +184,7 @@ export default defineBackground(() => {
 
   onMessage('generateGuideDescription', ({ data }) => generateDescriptionOnDemand(data.guideId));
 
-  onMessage('validateApiKey', ({ data }) => validateApiKey(data.provider, data.apiKey));
+  onMessage('validateApiKey', ({ data }) => validateApiKey(data.provider, data.apiKey, data.baseUrl));
 
   onMessage('rewriteSelection', ({ data }) => rewriteSelection(data.text, data.instruction));
 

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -110,6 +110,7 @@ export interface RewriteSelectionResponse {
 export interface ValidateApiKeyData {
   provider: string;
   apiKey: string;
+  baseUrl?: string;
 }
 
 export interface ValidateApiKeyResponse {

--- a/src/lib/voice-narration.ts
+++ b/src/lib/voice-narration.ts
@@ -11,6 +11,8 @@ import type { VoiceStepMark } from './voice-messages';
 export interface TranscriptionSettings {
   provider: VoiceProvider;
   apiKey: string;
+  baseUrl?: string;
+  model?: string;
   language?: string;
 }
 
@@ -36,11 +38,13 @@ export const EMPTY_NARRATION: NarrationResult = {
 
 export async function readTranscriptionSettings(): Promise<TranscriptionSettings> {
   const stored = await localStorage.get([...VOICE_KEY_SETTINGS, 'voiceLanguage', 'aiLanguage']);
-  const { provider, apiKey } = resolveVoiceApiKey(stored);
+  const { provider, apiKey, baseUrl, model } = resolveVoiceApiKey(stored);
   const locale = (stored.voiceLanguage ?? stored.aiLanguage) as string | undefined;
   return {
     provider,
     apiKey,
+    baseUrl,
+    model,
     language: locale ? locale.split('-')[0] : undefined,
   };
 }

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -100,6 +100,17 @@ settings:
   provider: Anbieter
   model: Modell
   apiKey: API-Schlüssel
+  baseUrl: Base URL
+  baseUrlOptional: optional
+  baseUrlHint: "OpenAI-compatible endpoint, e.g. https://api.example.com/v1"
+  baseUrlRequired: Base URL is required
+  profileName: Name
+  addProfile: Add Custom Provider
+  editProfile: Edit
+  deleteProfile: Delete
+  profilesHint: Custom providers speak the OpenAI API
+  voiceProfileHint: Using custom provider endpoint for voice.
+  modelRequired: Model is required
   aiLanguage: Sprache der Beschreibungen
   voiceNarration: Sprachkommentar
   voiceUsingAiKey: "Es ist kein Sprach-Schlüssel gesetzt, daher nutzt Mimik den OpenAI-Schlüssel aus den KI-Beschreibungen oben."

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -88,6 +88,17 @@ settings:
   model: Model
   modelCustom: Custom model
   apiKey: API Key
+  baseUrl: Base URL
+  baseUrlOptional: optional
+  baseUrlHint: "OpenAI-compatible endpoint, e.g. https://api.example.com/v1 or http://localhost:11434/v1 (leave empty for default)"
+  baseUrlRequired: Base URL is required for custom providers
+  profileName: Name
+  addProfile: Add Custom Provider
+  editProfile: Edit
+  deleteProfile: Delete
+  profilesHint: Custom providers speak the OpenAI API
+  voiceProfileHint: Using the custom provider's endpoint and model for voice.
+  modelRequired: Model is required
   aiLanguage: Description Language
   voiceNarration: Voice Narration
   voiceUsingAiKey: "No voice key is set, so Mimik uses the OpenAI key from AI Descriptions above."

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -88,6 +88,17 @@ settings:
   model: Modelo
   modelCustom: Modelo personalizado
   apiKey: Clave API
+  baseUrl: Base URL
+  baseUrlOptional: optional
+  baseUrlHint: "OpenAI-compatible endpoint, e.g. https://api.example.com/v1"
+  baseUrlRequired: Base URL is required
+  profileName: Name
+  addProfile: Add Custom Provider
+  editProfile: Edit
+  deleteProfile: Delete
+  profilesHint: Custom providers speak the OpenAI API
+  voiceProfileHint: Using custom provider endpoint for voice.
+  modelRequired: Model is required
   aiLanguage: Idioma de descripciones
   voiceNarration: "Narración por voz"
   voiceUsingAiKey: "No hay clave de voz, así que Mimik usa la clave de OpenAI de Descripciones con IA de arriba."

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -88,6 +88,17 @@ settings:
   model: "Modèle"
   modelCustom: Modèle personnalisé
   apiKey: "Clé API"
+  baseUrl: Base URL
+  baseUrlOptional: optional
+  baseUrlHint: "OpenAI-compatible endpoint, e.g. https://api.example.com/v1"
+  baseUrlRequired: Base URL is required
+  profileName: Name
+  addProfile: Add Custom Provider
+  editProfile: Edit
+  deleteProfile: Delete
+  profilesHint: Custom providers speak the OpenAI API
+  voiceProfileHint: Using custom provider endpoint for voice.
+  modelRequired: Model is required
   aiLanguage: Langue des descriptions
   voiceNarration: "Narration vocale"
   voiceUsingAiKey: "Aucune clé vocale n'est définie : Mimik utilise la clé OpenAI des descriptions IA ci-dessus."

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -88,6 +88,17 @@ settings:
   model: Modelo
   modelCustom: Modelo personalizado
   apiKey: Chave da API
+  baseUrl: Base URL
+  baseUrlOptional: optional
+  baseUrlHint: "OpenAI-compatible endpoint, e.g. https://api.example.com/v1"
+  baseUrlRequired: Base URL is required
+  profileName: Name
+  addProfile: Add Custom Provider
+  editProfile: Edit
+  deleteProfile: Delete
+  profilesHint: Custom providers speak the OpenAI API
+  voiceProfileHint: Using custom provider endpoint for voice.
+  modelRequired: Model is required
   aiLanguage: "Idioma das descrições"
   voiceNarration: "Narração por voz"
   voiceUsingAiKey: "Não tem chave de voz, então o Mimik usa a chave da OpenAI das Descrições com IA lá de cima."

--- a/src/ui/onboarding/App.tsx
+++ b/src/ui/onboarding/App.tsx
@@ -2,9 +2,8 @@ import { Mic, MousePointerClick, Shield } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { browser, i18n } from '#imports';
 import { PRESET_LABELS, type PresetKey } from '@/core/blur/regexes';
-import { AI_PROVIDERS, type AIProviderKey } from '@/core/capture/ai/models';
+import { AI_PROVIDERS, type AIProfile, PROFILE_PREFIX, profileProviderId } from '@/core/capture/ai/models';
 import { AI_LANGUAGES, type AILanguageCode } from '@/core/capture/ai/prompts';
-import type { VoiceProvider } from '@/core/capture/voice/transcribe';
 import { localStorage, openSidebar, requestHostPermissions } from '@/lib/browser-api';
 import { Input } from '@/ui/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/ui/components/ui/select';
@@ -115,21 +114,36 @@ function WelcomeStep({ onNext }: { onNext: () => void }) {
 }
 
 function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
-  const [provider, setProvider] = useState<AIProviderKey>('openai');
+  const [provider, setProvider] = useState<string>('openai');
   const [model, setModel] = useState(AI_PROVIDERS.openai.defaultModel);
   const [apiKey, setApiKey] = useState('');
+  const [baseUrl, setBaseUrl] = useState('');
+  const [profiles, setProfiles] = useState<AIProfile[]>([]);
   const [aiLanguage, setAiLanguage] = useState<AILanguageCode>('en');
 
   useEffect(() => {
     const load = () =>
-      localStorage.get(['aiProvider', 'aiModel', 'aiApiKey', 'aiLanguage']).then((stored) => {
-        if (typeof stored.aiProvider === 'string' && stored.aiProvider in AI_PROVIDERS) {
-          setProvider(stored.aiProvider as AIProviderKey);
-        }
-        if (typeof stored.aiModel === 'string') setModel(stored.aiModel);
-        if (typeof stored.aiApiKey === 'string') setApiKey(stored.aiApiKey);
-        if (typeof stored.aiLanguage === 'string') setAiLanguage(stored.aiLanguage as AILanguageCode);
-      });
+      localStorage
+        .get(['aiProvider', 'aiModel', 'aiApiKey', 'aiBaseUrl', 'aiEndpoint', 'aiProfiles', 'aiLanguage'])
+        .then((stored) => {
+          if (Array.isArray(stored.aiProfiles)) setProfiles(stored.aiProfiles as AIProfile[]);
+          const p = typeof stored.aiProvider === 'string' ? stored.aiProvider : 'openai';
+          if (p in AI_PROVIDERS || p.startsWith(PROFILE_PREFIX)) setProvider(p);
+          if (typeof stored.aiModel === 'string') setModel(stored.aiModel);
+          if (typeof stored.aiApiKey === 'string') setApiKey(stored.aiApiKey);
+          const bu = (stored.aiBaseUrl as string) || (stored.aiEndpoint as string) || '';
+          if (bu) setBaseUrl(bu);
+          if (typeof stored.aiLanguage === 'string') setAiLanguage(stored.aiLanguage as AILanguageCode);
+          // if provider is profile, hydrate model/baseUrl from profile
+          if (typeof p === 'string' && p.startsWith(PROFILE_PREFIX) && Array.isArray(stored.aiProfiles)) {
+            const pr = (stored.aiProfiles as AIProfile[]).find((x) => profileProviderId(x.id) === p);
+            if (pr) {
+              setModel(pr.model);
+              setApiKey(pr.apiKey);
+              setBaseUrl(pr.baseUrl);
+            }
+          }
+        });
 
     void load();
     const onVisible = () => {
@@ -139,23 +153,75 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
     return () => document.removeEventListener('visibilitychange', onVisible);
   }, []);
 
-  const providerConfig = AI_PROVIDERS[provider];
+  const isProfile = provider.startsWith(PROFILE_PREFIX);
+  const activeProfile = isProfile ? profiles.find((pr) => profileProviderId(pr.id) === provider) : null;
+  const providerConfig =
+    !isProfile && provider in AI_PROVIDERS ? AI_PROVIDERS[provider as keyof typeof AI_PROVIDERS] : null;
 
-  const handleProviderChange = (newProvider: AIProviderKey) => {
-    const nextModel = AI_PROVIDERS[newProvider].defaultModel;
+  const handleProviderChange = (newProvider: string) => {
     setProvider(newProvider);
-    setModel(nextModel);
-    void localStorage.set({ aiProvider: newProvider, aiModel: nextModel });
+    if (newProvider in AI_PROVIDERS) {
+      const nextModel = AI_PROVIDERS[newProvider as keyof typeof AI_PROVIDERS].defaultModel;
+      setModel(nextModel);
+      void localStorage.set({ aiProvider: newProvider, aiModel: nextModel });
+      // persist baseUrl separately
+      void localStorage.set({ aiBaseUrl: baseUrl });
+    } else if (newProvider.startsWith(PROFILE_PREFIX)) {
+      const pr = profiles.find((x) => profileProviderId(x.id) === newProvider);
+      if (pr) {
+        setModel(pr.model);
+        setApiKey(pr.apiKey);
+        setBaseUrl(pr.baseUrl);
+        void localStorage.set({ aiProvider: newProvider });
+      }
+    } else if (newProvider === '__add_profile__') {
+      // quickly create placeholder profile
+      const id = Math.random().toString(36).slice(2, 10);
+      const np: AIProfile = {
+        id,
+        name: `Custom ${profiles.length + 1}`,
+        baseUrl: 'https://api.example.com/v1',
+        apiKey: '',
+        model: 'gpt-4o-mini',
+      };
+      const next = [...profiles, np];
+      setProfiles(next);
+      setProvider(profileProviderId(id));
+      void localStorage.set({ aiProfiles: next, aiProvider: profileProviderId(id) });
+    }
   };
 
   const handleModelChange = (nextModel: string) => {
     setModel(nextModel);
-    void localStorage.set({ aiModel: nextModel });
+    if (isProfile && activeProfile) {
+      const next = profiles.map((p) => (p.id === activeProfile.id ? { ...p, model: nextModel } : p));
+      setProfiles(next);
+      void localStorage.set({ aiProfiles: next });
+    } else {
+      void localStorage.set({ aiModel: nextModel });
+    }
   };
 
   const handleApiKeyChange = (nextKey: string) => {
     setApiKey(nextKey);
-    void localStorage.set({ aiApiKey: nextKey });
+    if (isProfile && activeProfile) {
+      const next = profiles.map((p) => (p.id === activeProfile.id ? { ...p, apiKey: nextKey } : p));
+      setProfiles(next);
+      void localStorage.set({ aiProfiles: next });
+    } else {
+      void localStorage.set({ aiApiKey: nextKey });
+    }
+  };
+
+  const handleBaseUrlChange = (next: string) => {
+    setBaseUrl(next);
+    if (isProfile && activeProfile) {
+      const np = profiles.map((p) => (p.id === activeProfile.id ? { ...p, baseUrl: next } : p));
+      setProfiles(np);
+      void localStorage.set({ aiProfiles: np });
+    } else {
+      void localStorage.set({ aiBaseUrl: next });
+    }
   };
 
   const handleLanguageChange = (nextLanguage: AILanguageCode) => {
@@ -178,7 +244,7 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
               <label className="block text-xs font-semibold text-foreground mb-1.5">
                 {i18n.t('settings.provider')}
               </label>
-              <Select value={provider} onValueChange={(v) => handleProviderChange(v as AIProviderKey)}>
+              <Select value={provider} onValueChange={handleProviderChange}>
                 <SelectTrigger className="w-full rounded-xl px-4 py-2.5 text-sm focus:border-accent focus:ring-accent/10">
                   <SelectValue />
                 </SelectTrigger>
@@ -188,25 +254,59 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
                       {cfg.label}
                     </SelectItem>
                   ))}
+                  {profiles.map((pr) => (
+                    <SelectItem key={pr.id} value={profileProviderId(pr.id)}>
+                      {pr.name} — {pr.model}
+                    </SelectItem>
+                  ))}
+                  <SelectItem value="__add_profile__">+ {i18n.t('settings.addProfile')}</SelectItem>
                 </SelectContent>
               </Select>
             </div>
 
-            <div>
-              <label className="block text-xs font-semibold text-foreground mb-1.5">{i18n.t('settings.model')}</label>
-              <Select value={model} onValueChange={handleModelChange}>
-                <SelectTrigger className="w-full rounded-xl px-4 py-2.5 text-sm focus:border-accent focus:ring-accent/10">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {providerConfig.models.map((m) => (
-                    <SelectItem key={m.id} value={m.id}>
-                      {m.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+            {isProfile ? (
+              <>
+                <div>
+                  <label className="block text-xs font-semibold text-foreground mb-1.5">
+                    {i18n.t('settings.model')}
+                  </label>
+                  <Input
+                    value={model}
+                    onChange={(e) => handleModelChange(e.target.value)}
+                    placeholder="gpt-4o-mini"
+                    className="w-full rounded-xl px-4 py-2.5 text-sm"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-semibold text-foreground mb-1.5">
+                    {i18n.t('settings.baseUrl')}
+                  </label>
+                  <Input
+                    value={baseUrl}
+                    onChange={(e) => handleBaseUrlChange(e.target.value)}
+                    placeholder="https://api.example.com/v1"
+                    className="w-full rounded-xl px-4 py-2.5 text-sm"
+                  />
+                  <p className="mt-1 text-[11px] text-muted-foreground">{i18n.t('settings.baseUrlHint')}</p>
+                </div>
+              </>
+            ) : (
+              <div>
+                <label className="block text-xs font-semibold text-foreground mb-1.5">{i18n.t('settings.model')}</label>
+                <Select value={model} onValueChange={handleModelChange}>
+                  <SelectTrigger className="w-full rounded-xl px-4 py-2.5 text-sm focus:border-accent focus:ring-accent/10">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {providerConfig?.models.map((m) => (
+                      <SelectItem key={m.id} value={m.id}>
+                        {m.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
 
             <div>
               <label className="block text-xs font-semibold text-foreground mb-1.5">{i18n.t('settings.apiKey')}</label>
@@ -214,10 +314,25 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
                 type="password"
                 value={apiKey}
                 onChange={(e) => handleApiKeyChange(e.target.value)}
-                placeholder="sk-..."
+                placeholder={isProfile ? 'sk-... (empty for local)' : 'sk-...'}
                 className="w-full rounded-xl px-4 py-2.5 text-sm focus:border-accent focus:ring-accent/10"
               />
             </div>
+            {!isProfile && provider === 'openai' && (
+              <div>
+                <label className="block text-xs font-semibold text-foreground mb-1.5">
+                  {i18n.t('settings.baseUrl')}{' '}
+                  <span className="font-normal text-muted-foreground">({i18n.t('settings.baseUrlOptional')})</span>
+                </label>
+                <Input
+                  value={baseUrl}
+                  onChange={(e) => handleBaseUrlChange(e.target.value)}
+                  placeholder="https://api.example.com/v1"
+                  className="w-full rounded-xl px-4 py-2.5 text-sm"
+                />
+                <p className="mt-1 text-[11px] text-muted-foreground">{i18n.t('settings.baseUrlHint')}</p>
+              </div>
+            )}
 
             <div>
               <label className="block text-xs font-semibold text-foreground mb-1.5">
@@ -331,17 +446,25 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
 }
 
 function VoiceStep({ onNext, onSkip, onBack, index, total }: StepProps) {
-  const [provider, setProvider] = useState<VoiceProvider>('openai');
+  const [provider, setProvider] = useState<string>('openai');
   const [apiKey, setApiKey] = useState('');
+  const [baseUrl, setBaseUrl] = useState('');
+  const [model, setModel] = useState('');
+  const [profiles, setProfiles] = useState<AIProfile[]>([]);
   const [microphoneId, setMicrophoneId] = useState('');
 
   useEffect(() => {
     const load = () =>
-      localStorage.get(['voiceProvider', 'voiceApiKey', 'voiceMicrophoneId']).then((stored) => {
-        if (stored.voiceProvider === 'openai' || stored.voiceProvider === 'groq') setProvider(stored.voiceProvider);
-        if (typeof stored.voiceApiKey === 'string') setApiKey(stored.voiceApiKey);
-        if (typeof stored.voiceMicrophoneId === 'string') setMicrophoneId(stored.voiceMicrophoneId);
-      });
+      localStorage
+        .get(['voiceProvider', 'voiceApiKey', 'voiceBaseUrl', 'voiceModel', 'voiceMicrophoneId', 'aiProfiles'])
+        .then((stored) => {
+          if (Array.isArray(stored.aiProfiles)) setProfiles(stored.aiProfiles as AIProfile[]);
+          if (typeof stored.voiceProvider === 'string') setProvider(stored.voiceProvider);
+          if (typeof stored.voiceApiKey === 'string') setApiKey(stored.voiceApiKey);
+          if (typeof stored.voiceBaseUrl === 'string') setBaseUrl(stored.voiceBaseUrl);
+          if (typeof stored.voiceModel === 'string') setModel(stored.voiceModel);
+          if (typeof stored.voiceMicrophoneId === 'string') setMicrophoneId(stored.voiceMicrophoneId);
+        });
 
     void load();
     const onVisible = () => {
@@ -356,7 +479,7 @@ function VoiceStep({ onNext, onSkip, onBack, index, total }: StepProps) {
     void localStorage.set({ voiceMicrophoneId: deviceId });
   };
 
-  const handleProviderChange = (nextProvider: VoiceProvider) => {
+  const handleProviderChange = (nextProvider: string) => {
     setProvider(nextProvider);
     void localStorage.set({ voiceProvider: nextProvider });
   };
@@ -386,11 +509,16 @@ function VoiceStep({ onNext, onSkip, onBack, index, total }: StepProps) {
                 </label>
                 <select
                   value={provider}
-                  onChange={(e) => handleProviderChange(e.target.value as VoiceProvider)}
+                  onChange={(e) => handleProviderChange(e.target.value)}
                   className="w-full border border-border rounded-xl px-3 py-2 text-[13px] text-foreground bg-card font-medium outline-none focus:border-accent focus:ring-2 focus:ring-accent/10"
                 >
                   <option value="openai">OpenAI</option>
                   <option value="groq">Groq</option>
+                  {profiles.map((pr) => (
+                    <option key={pr.id} value={profileProviderId(pr.id)}>
+                      {pr.name} (Custom)
+                    </option>
+                  ))}
                 </select>
               </div>
               <div className="flex-1">
@@ -406,6 +534,40 @@ function VoiceStep({ onNext, onSkip, onBack, index, total }: StepProps) {
                 />
               </div>
             </div>
+            {!provider.startsWith(PROFILE_PREFIX) && (
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-[11px] font-semibold text-foreground mb-1">
+                    {i18n.t('settings.baseUrl')}{' '}
+                    <span className="font-normal text-muted-foreground">({i18n.t('settings.baseUrlOptional')})</span>
+                  </label>
+                  <input
+                    value={baseUrl}
+                    onChange={(e) => {
+                      setBaseUrl(e.target.value);
+                      void localStorage.set({ voiceBaseUrl: e.target.value });
+                    }}
+                    placeholder="https://api.example.com/v1"
+                    className="w-full border border-border rounded-xl px-3 py-2 text-[13px] text-foreground bg-card font-medium outline-none focus:border-accent focus:ring-2 focus:ring-accent/10 placeholder:text-muted-foreground/50"
+                  />
+                </div>
+                <div>
+                  <label className="block text-[11px] font-semibold text-foreground mb-1">
+                    {i18n.t('settings.model')}{' '}
+                    <span className="font-normal text-muted-foreground">({i18n.t('settings.baseUrlOptional')})</span>
+                  </label>
+                  <input
+                    value={model}
+                    onChange={(e) => {
+                      setModel(e.target.value);
+                      void localStorage.set({ voiceModel: e.target.value });
+                    }}
+                    placeholder="whisper-1"
+                    className="w-full border border-border rounded-xl px-3 py-2 text-[13px] text-foreground bg-card font-medium outline-none focus:border-accent focus:ring-2 focus:ring-accent/10 placeholder:text-muted-foreground/50"
+                  />
+                </div>
+              </div>
+            )}
 
             <MicrophonePicker value={microphoneId} onChange={handleMicrophoneChange} />
 

--- a/src/ui/shared/SettingsView.tsx
+++ b/src/ui/shared/SettingsView.tsx
@@ -8,6 +8,8 @@ import {
   Globe,
   ImageIcon,
   Mic,
+  Pencil,
+  Plus,
   Shield,
   Sparkles,
   Star,
@@ -18,10 +20,18 @@ import {
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { i18n } from '#imports';
 import { PRESET_LABELS, type PresetKey } from '@/core/blur/regexes';
-import { AI_PROVIDERS, type AIProviderKey, CUSTOM_MODEL_VALUE, isCustomModel } from '@/core/capture/ai/models';
+import {
+  AI_PROVIDERS,
+  type AIProfile,
+  CUSTOM_MODEL_VALUE,
+  isCustomModel,
+  isProfileProvider,
+  makeProfileId,
+  PROFILE_PREFIX,
+  profileProviderId,
+} from '@/core/capture/ai/models';
 import { AI_LANGUAGES, type AILanguageCode } from '@/core/capture/ai/prompts';
 import { resolveVoiceApiKey } from '@/core/capture/voice/api-key';
-import type { VoiceProvider } from '@/core/capture/voice/transcribe';
 import { type BrandLogo, defaultFooterLine, makeBrandLogo } from '@/core/export/branding';
 import { DEFAULT_TARGET_COLOR, TARGET_COLORS } from '@/core/screenshot/types';
 import { localStorage } from '@/lib/browser-api';
@@ -48,14 +58,14 @@ function useKeyCheck() {
   const [status, setStatus] = useState<KeyStatus>(null);
   const validated = useRef('');
 
-  const check = useCallback(async (provider: string, apiKey: string) => {
-    const fingerprint = `${provider}:${apiKey}`;
+  const check = useCallback(async (provider: string, apiKey: string, baseUrl?: string) => {
+    const fingerprint = `${provider}:${apiKey}:${baseUrl ?? ''}`;
     if (validated.current === fingerprint) {
       setStatus('valid');
       return;
     }
     setStatus('checking');
-    const result = await sendMessage('validateApiKey', { provider, apiKey }).catch(() => null);
+    const result = await sendMessage('validateApiKey', { provider, apiKey, baseUrl }).catch(() => null);
     if (result?.valid) validated.current = fingerprint;
     setStatus(result?.valid ? 'valid' : result?.reason === 'rejected' ? 'rejected' : 'unreachable');
   }, []);
@@ -94,10 +104,17 @@ const FOOTER_PRESETS = () => [
   i18n.t('settings.footerPresetNoDistribute'),
 ];
 
+const ADD_PROFILE_VALUE = '__add_profile__';
+
 export default function SettingsView({ onBack }: SettingsViewProps) {
-  const [provider, setProvider] = useState<AIProviderKey>('openai');
+  const [provider, setProvider] = useState<string>('openai');
   const [model, setModel] = useState(AI_PROVIDERS.openai.defaultModel);
   const [apiKey, setApiKey] = useState('');
+  const [aiBaseUrl, setAiBaseUrl] = useState('');
+  const [aiProfiles, setAiProfiles] = useState<AIProfile[]>([]);
+  const [editingProfile, setEditingProfile] = useState<AIProfile | null>(null);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [newProfile, setNewProfile] = useState({ name: '', baseUrl: '', apiKey: '', model: '' });
   const [saved, setSaved] = useState(false);
   const aiKeyCheck = useKeyCheck();
   const voiceKeyCheck = useKeyCheck();
@@ -107,8 +124,10 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
   const pending = useRef<SettingsSnapshot>({});
   const saveTimer = useRef<number | undefined>(undefined);
   const [aiLanguage, setAiLanguage] = useState<AILanguageCode>('en');
-  const [voiceProvider, setVoiceProvider] = useState<VoiceProvider>('openai');
+  const [voiceProvider, setVoiceProvider] = useState<string>('openai');
   const [voiceApiKey, setVoiceApiKey] = useState('');
+  const [voiceBaseUrl, setVoiceBaseUrl] = useState('');
+  const [voiceModel, setVoiceModel] = useState('');
   const [voiceMicrophoneId, setVoiceMicrophoneId] = useState('');
   const [targetColor, setTargetColor] = useState<string>(DEFAULT_TARGET_COLOR);
   const [brandLogo, setBrandLogo] = useState<BrandLogo | null>(null);
@@ -130,10 +149,15 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
         'aiApiKey',
         'aiProvider',
         'aiModel',
+        'aiBaseUrl',
+        'aiEndpoint',
+        'aiProfiles',
         'aiLanguage',
         'blurPresets',
         'voiceProvider',
         'voiceApiKey',
+        'voiceBaseUrl',
+        'voiceModel',
         'voiceMicrophoneId',
         'targetColor',
         'brandLogo',
@@ -141,14 +165,39 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
         'brandAttribution',
       ])
       .then((result) => {
-        const p = (result.aiProvider as AIProviderKey) || 'openai';
-        setProvider(p);
-        setModel((result.aiModel as string) || AI_PROVIDERS[p].defaultModel);
+        if (Array.isArray(result.aiProfiles)) setAiProfiles(result.aiProfiles as AIProfile[]);
+        const p = (result.aiProvider as string) || 'openai';
+        // if legacy profile not in list, fallback to openai
+        if (isProfileProvider(p) && Array.isArray(result.aiProfiles)) {
+          const exists = (result.aiProfiles as AIProfile[]).some((pr) => profileProviderId(pr.id) === p);
+          setProvider(exists ? p : 'openai');
+        } else {
+          setProvider(p in AI_PROVIDERS ? p : 'openai');
+        }
+        // model/key/baseUrl handling
+        if (isProfileProvider(p) && Array.isArray(result.aiProfiles)) {
+          const prof = (result.aiProfiles as AIProfile[]).find((pr) => profileProviderId(pr.id) === p);
+          if (prof) {
+            setModel(prof.model || '');
+          } else {
+            setModel((result.aiModel as string) || AI_PROVIDERS.openai.defaultModel);
+          }
+        } else {
+          setModel(
+            (result.aiModel as string) ||
+              AI_PROVIDERS[p as keyof typeof AI_PROVIDERS]?.defaultModel ||
+              AI_PROVIDERS.openai.defaultModel,
+          );
+        }
         if (result.aiApiKey) setApiKey(result.aiApiKey as string);
+        const base = (result.aiBaseUrl as string) || (result.aiEndpoint as string) || '';
+        if (base) setAiBaseUrl(base);
         if (result.aiLanguage) setAiLanguage(result.aiLanguage as AILanguageCode);
         if (result.blurPresets) setBlurPresets(result.blurPresets as Record<PresetKey, boolean>);
-        setVoiceProvider((result.voiceProvider as VoiceProvider) || 'openai');
+        setVoiceProvider((result.voiceProvider as string) || 'openai');
         if (result.voiceApiKey) setVoiceApiKey(result.voiceApiKey as string);
+        if (result.voiceBaseUrl) setVoiceBaseUrl(result.voiceBaseUrl as string);
+        if (result.voiceModel) setVoiceModel(result.voiceModel as string);
         if (result.voiceMicrophoneId) setVoiceMicrophoneId(result.voiceMicrophoneId as string);
         if (result.targetColor) setTargetColor(result.targetColor as string);
         if (result.brandLogo) setBrandLogo(result.brandLogo as BrandLogo);
@@ -158,14 +207,21 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
       });
   }, []);
 
+  const isProfile = isProfileProvider(provider);
+  const activeProfile = isProfile ? aiProfiles.find((pr) => profileProviderId(pr.id) === provider) : null;
+
   const stored = {
-    aiApiKey: apiKey,
+    aiApiKey: isProfile ? (activeProfile?.apiKey ?? '') : apiKey,
     aiProvider: provider,
-    aiModel: model,
+    aiModel: isProfile ? (activeProfile?.model ?? '') : model,
+    aiBaseUrl: isProfile ? '' : aiBaseUrl,
+    aiProfiles,
     aiLanguage,
     blurPresets,
     voiceProvider,
     voiceApiKey,
+    voiceBaseUrl,
+    voiceModel,
     voiceMicrophoneId,
     targetColor,
     brandLogo,
@@ -222,11 +278,17 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
     setBrandLogo(await makeBrandLogo(file));
   };
 
-  const handleProviderChange = (newProvider: AIProviderKey) => {
+  const handleProviderChange = (newProvider: string) => {
+    if (newProvider === ADD_PROFILE_VALUE) {
+      setShowAddForm(true);
+      return;
+    }
     setProvider(newProvider);
     aiKeyCheck.setStatus(null);
-    setCustomModel(false);
-    setModel(AI_PROVIDERS[newProvider].defaultModel);
+    if (newProvider in AI_PROVIDERS) {
+      setCustomModel(false);
+      setModel(AI_PROVIDERS[newProvider as keyof typeof AI_PROVIDERS].defaultModel);
+    }
   };
 
   const handleModelChange = (value: string) => {
@@ -239,9 +301,53 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
     setModel(value);
   };
 
-  const providerConfig = AI_PROVIDERS[provider];
-  const usingCustomModel = customModel || isCustomModel(model, providerConfig);
-  const voiceKey = resolveVoiceApiKey({ voiceProvider, voiceApiKey, aiProvider: provider, aiApiKey: apiKey });
+  const updateProfileField = (id: string, patch: Partial<AIProfile>) => {
+    setAiProfiles((prev) => prev.map((p) => (p.id === id ? { ...p, ...patch } : p)));
+  };
+
+  const handleAddProfile = () => {
+    if (!newProfile.baseUrl.trim() || !newProfile.model.trim()) return;
+    const id = makeProfileId();
+    const profile: AIProfile = {
+      id,
+      name: newProfile.name.trim() || `Custom ${aiProfiles.length + 1}`,
+      baseUrl: newProfile.baseUrl.trim(),
+      apiKey: newProfile.apiKey.trim(),
+      model: newProfile.model.trim(),
+    };
+    const next = [...aiProfiles, profile];
+    setAiProfiles(next);
+    setProvider(profileProviderId(id));
+    setNewProfile({ name: '', baseUrl: '', apiKey: '', model: '' });
+    setShowAddForm(false);
+  };
+
+  const handleDeleteProfile = (id: string) => {
+    const next = aiProfiles.filter((p) => p.id !== id);
+    setAiProfiles(next);
+    if (provider === profileProviderId(id)) {
+      setProvider('openai');
+      setModel(AI_PROVIDERS.openai.defaultModel);
+    }
+    if (editingProfile?.id === id) setEditingProfile(null);
+  };
+
+  const isOpenAIProvider = provider === 'openai';
+  const providerConfig =
+    !isProfile && AI_PROVIDERS[provider as keyof typeof AI_PROVIDERS]
+      ? AI_PROVIDERS[provider as keyof typeof AI_PROVIDERS]
+      : null;
+  const usingCustomModel = providerConfig ? customModel || isCustomModel(model, providerConfig) : false;
+  const voiceKey = resolveVoiceApiKey({
+    voiceProvider,
+    voiceApiKey,
+    voiceBaseUrl,
+    voiceModel,
+    aiProvider: provider,
+    aiApiKey: isProfile ? (activeProfile?.apiKey ?? '') : apiKey,
+    aiProfiles,
+    aiBaseUrl,
+  });
 
   const BLUR_PRESET_I18N: Record<PresetKey, string> = {
     email: 'blurPresets.email',
@@ -251,6 +357,21 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
     ipAddress: 'blurPresets.ipAddress',
     macAddress: 'blurPresets.macAddress',
   };
+
+  const aiBaseUrlForCheck = isProfile ? activeProfile?.baseUrl : aiBaseUrl;
+  const aiApiKeyForCheck = isProfile ? (activeProfile?.apiKey ?? '') : apiKey;
+  const canCheckAiKey = (() => {
+    if (isProfile) return Boolean(activeProfile?.baseUrl.trim() && activeProfile?.model.trim());
+    if (aiBaseUrl.trim()) return true; // allow keyless check with baseUrl
+    return Boolean(apiKey.trim());
+  })();
+
+  const voiceProviderIsProfile = typeof voiceProvider === 'string' && voiceProvider.startsWith(PROFILE_PREFIX);
+  const canCheckVoiceKey = (() => {
+    if (voiceProviderIsProfile) return true;
+    if (voiceBaseUrl.trim()) return true;
+    return Boolean(voiceApiKey.trim());
+  })();
 
   return (
     <div className="bg-card flex flex-col">
@@ -289,7 +410,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
             <label className="block text-[11px] font-semibold text-foreground mb-1">
               {i18n.t('settings.provider')}
             </label>
-            <Select value={provider} onValueChange={(v) => handleProviderChange(v as AIProviderKey)}>
+            <Select value={provider} onValueChange={handleProviderChange}>
               <SelectTrigger className="w-full rounded-lg px-3 py-2 text-[13px]">
                 <SelectValue />
               </SelectTrigger>
@@ -299,67 +420,250 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
                     {cfg.label}
                   </SelectItem>
                 ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div>
-            <label className="block text-[11px] font-semibold text-foreground mb-1">{i18n.t('settings.model')}</label>
-            <Select value={usingCustomModel ? CUSTOM_MODEL_VALUE : model} onValueChange={handleModelChange}>
-              <SelectTrigger className="w-full rounded-lg px-3 py-2 text-[13px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {providerConfig.models.map((m) => (
-                  <SelectItem key={m.id} value={m.id}>
-                    {m.label}
+                {aiProfiles.map((pr) => (
+                  <SelectItem key={pr.id} value={profileProviderId(pr.id)}>
+                    {pr.name} — {pr.model}
                   </SelectItem>
                 ))}
-                <SelectItem value={CUSTOM_MODEL_VALUE}>{i18n.t('settings.modelCustom')}</SelectItem>
+                <SelectItem value={ADD_PROFILE_VALUE}>+ {i18n.t('settings.addProfile')}</SelectItem>
               </SelectContent>
             </Select>
-            {usingCustomModel && (
-              <Input
-                value={model}
-                onChange={(e) => setModel(e.target.value)}
-                placeholder={providerConfig.defaultModel}
-                aria-label={i18n.t('settings.modelCustom')}
-                className="mt-1.5 h-8 text-[12px] rounded-lg border-border"
-              />
+            {aiProfiles.length > 0 && !isProfile && (
+              <p className="mt-1 text-[10px] text-muted-foreground">{i18n.t('settings.profilesHint')}</p>
             )}
           </div>
 
-          <div>
-            <label className="block text-[11px] font-semibold text-foreground mb-1">{i18n.t('settings.apiKey')}</label>
-            <div className="flex items-center gap-1.5">
+          {isProfile && activeProfile ? (
+            <>
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <label className="block text-[11px] font-semibold text-foreground mb-1">
+                    {i18n.t('settings.profileName')}
+                  </label>
+                  <Input
+                    value={activeProfile.name}
+                    onChange={(e) => updateProfileField(activeProfile.id, { name: e.target.value })}
+                    placeholder="Local Ollama"
+                    className="h-8 text-[12px] rounded-lg border-border"
+                  />
+                </div>
+                <div>
+                  <label className="block text-[11px] font-semibold text-foreground mb-1">
+                    {i18n.t('settings.model')}
+                  </label>
+                  <Input
+                    value={activeProfile.model}
+                    onChange={(e) => updateProfileField(activeProfile.id, { model: e.target.value })}
+                    placeholder="gpt-4o-mini"
+                    className="h-8 text-[12px] rounded-lg border-border"
+                  />
+                </div>
+              </div>
+              <div>
+                <label className="block text-[11px] font-semibold text-foreground mb-1">
+                  {i18n.t('settings.baseUrl')}
+                </label>
+                <Input
+                  value={activeProfile.baseUrl}
+                  onChange={(e) => updateProfileField(activeProfile.id, { baseUrl: e.target.value })}
+                  placeholder="https://api.example.com/v1"
+                  className="h-8 text-[12px] rounded-lg border-border"
+                />
+                <p className="mt-1 text-[10px] text-muted-foreground">{i18n.t('settings.baseUrlHint')}</p>
+              </div>
+              <div>
+                <label className="block text-[11px] font-semibold text-foreground mb-1">
+                  {i18n.t('settings.apiKey')}
+                </label>
+                <div className="flex items-center gap-1.5">
+                  <Input
+                    type="password"
+                    value={activeProfile.apiKey}
+                    onChange={(e) => updateProfileField(activeProfile.id, { apiKey: e.target.value })}
+                    placeholder="sk-... (leave empty for local)"
+                    className="h-8 text-[12px] rounded-lg border-border"
+                  />
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={!canCheckAiKey || aiKeyCheck.status === 'checking'}
+                    onClick={() => void aiKeyCheck.check(provider, aiApiKeyForCheck, aiBaseUrlForCheck)}
+                    className="h-8 shrink-0 rounded-lg bg-card text-[11px] font-semibold"
+                  >
+                    {i18n.t('settings.checkKey')}
+                  </Button>
+                </div>
+                <KeyStatusNote status={aiKeyCheck.status} />
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleDeleteProfile(activeProfile.id)}
+                  className="h-7 text-[11px]"
+                >
+                  <Trash2 size={11} className="mr-1" /> {i18n.t('settings.deleteProfile')}
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              <div>
+                <label className="block text-[11px] font-semibold text-foreground mb-1">
+                  {i18n.t('settings.model')}
+                </label>
+                <Select value={usingCustomModel ? CUSTOM_MODEL_VALUE : model} onValueChange={handleModelChange}>
+                  <SelectTrigger className="w-full rounded-lg px-3 py-2 text-[13px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {providerConfig?.models.map((m) => (
+                      <SelectItem key={m.id} value={m.id}>
+                        {m.label}
+                      </SelectItem>
+                    ))}
+                    <SelectItem value={CUSTOM_MODEL_VALUE}>{i18n.t('settings.modelCustom')}</SelectItem>
+                  </SelectContent>
+                </Select>
+                {usingCustomModel && (
+                  <Input
+                    value={model}
+                    onChange={(e) => setModel(e.target.value)}
+                    placeholder={providerConfig?.defaultModel}
+                    aria-label={i18n.t('settings.modelCustom')}
+                    className="mt-1.5 h-8 text-[12px] rounded-lg border-border"
+                  />
+                )}
+              </div>
+
+              <div>
+                <label className="block text-[11px] font-semibold text-foreground mb-1">
+                  {i18n.t('settings.apiKey')}
+                </label>
+                <div className="flex items-center gap-1.5">
+                  <Input
+                    type="password"
+                    value={apiKey}
+                    onChange={(e) => {
+                      setApiKey(e.target.value);
+                      aiKeyCheck.setStatus(null);
+                    }}
+                    placeholder="sk-..."
+                    className="h-8 text-[12px] rounded-lg border-border"
+                  />
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={!canCheckAiKey || aiKeyCheck.status === 'checking'}
+                    onClick={() => void aiKeyCheck.check(provider, apiKey, aiBaseUrl)}
+                    className="h-8 shrink-0 rounded-lg bg-card text-[11px] font-semibold"
+                  >
+                    {i18n.t('settings.checkKey')}
+                  </Button>
+                </div>
+                <KeyStatusNote status={aiKeyCheck.status} />
+                {!apiKey.trim() && !aiBaseUrl.trim() && (
+                  <p
+                    className="mt-1.5 flex items-start gap-1.5 text-[10px] text-destructive leading-relaxed"
+                    role="alert"
+                  >
+                    <TriangleAlert size={11} className="shrink-0 mt-0.5" />
+                    <span>{i18n.t('settings.aiNoKey')}</span>
+                  </p>
+                )}
+              </div>
+
+              {(isOpenAIProvider || provider === 'groq') && (
+                <div>
+                  <label className="block text-[11px] font-semibold text-foreground mb-1">
+                    {i18n.t('settings.baseUrl')}{' '}
+                    <span className="font-normal text-muted-foreground">({i18n.t('settings.baseUrlOptional')})</span>
+                  </label>
+                  <Input
+                    value={aiBaseUrl}
+                    onChange={(e) => {
+                      setAiBaseUrl(e.target.value);
+                      aiKeyCheck.setStatus(null);
+                    }}
+                    placeholder="https://api.example.com/v1"
+                    className="h-8 text-[12px] rounded-lg border-border"
+                  />
+                  <p className="mt-1 text-[10px] text-muted-foreground">{i18n.t('settings.baseUrlHint')}</p>
+                </div>
+              )}
+            </>
+          )}
+
+          {showAddForm && (
+            <div className="border border-accent rounded-lg p-3 space-y-2 bg-secondary/30">
+              <p className="text-[11px] font-semibold text-foreground">{i18n.t('settings.addProfile')}</p>
+              <Input
+                value={newProfile.name}
+                onChange={(e) => setNewProfile((p) => ({ ...p, name: e.target.value }))}
+                placeholder={i18n.t('settings.profileName')}
+                className="h-8 text-[12px]"
+              />
+              <Input
+                value={newProfile.baseUrl}
+                onChange={(e) => setNewProfile((p) => ({ ...p, baseUrl: e.target.value }))}
+                placeholder="https://api.example.com/v1"
+                className="h-8 text-[12px]"
+              />
+              <Input
+                value={newProfile.model}
+                onChange={(e) => setNewProfile((p) => ({ ...p, model: e.target.value }))}
+                placeholder="gpt-4o-mini"
+                className="h-8 text-[12px]"
+              />
               <Input
                 type="password"
-                value={apiKey}
-                onChange={(e) => {
-                  setApiKey(e.target.value);
-                  aiKeyCheck.setStatus(null);
-                }}
-                placeholder="sk-..."
-                className="h-8 text-[12px] rounded-lg border-border"
+                value={newProfile.apiKey}
+                onChange={(e) => setNewProfile((p) => ({ ...p, apiKey: e.target.value }))}
+                placeholder="sk-... (empty for local)"
+                className="h-8 text-[12px]"
               />
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!apiKey || aiKeyCheck.status === 'checking'}
-                onClick={() => void aiKeyCheck.check(provider, apiKey)}
-                className="h-8 shrink-0 rounded-lg bg-card text-[11px] font-semibold"
-              >
-                {i18n.t('settings.checkKey')}
-              </Button>
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  onClick={handleAddProfile}
+                  disabled={!newProfile.baseUrl.trim() || !newProfile.model.trim()}
+                  className="h-7 text-[11px]"
+                >
+                  {i18n.t('common.save')}
+                </Button>
+                <Button variant="outline" size="sm" onClick={() => setShowAddForm(false)} className="h-7 text-[11px]">
+                  {i18n.t('common.cancel')}
+                </Button>
+              </div>
             </div>
-            <KeyStatusNote status={aiKeyCheck.status} />
-            {!apiKey.trim() && (
-              <p className="mt-1.5 flex items-start gap-1.5 text-[10px] text-destructive leading-relaxed" role="alert">
-                <TriangleAlert size={11} className="shrink-0 mt-0.5" />
-                <span>{i18n.t('settings.aiNoKey')}</span>
-              </p>
-            )}
-          </div>
+          )}
+
+          {aiProfiles.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 pt-1">
+              {aiProfiles.map((pr) => (
+                <span
+                  key={pr.id}
+                  className={`inline-flex items-center gap-1 px-2 py-1 rounded-md border text-[10px] ${provider === profileProviderId(pr.id) ? 'border-accent text-accent' : 'border-border text-muted-foreground'}`}
+                >
+                  {pr.name}
+                  <button onClick={() => setProvider(profileProviderId(pr.id))} className="hover:text-accent">
+                    <Pencil size={10} />
+                  </button>
+                  <button onClick={() => handleDeleteProfile(pr.id)} className="hover:text-destructive">
+                    <Trash2 size={10} />
+                  </button>
+                </span>
+              ))}
+              {!showAddForm && (
+                <button
+                  onClick={() => setShowAddForm(true)}
+                  className="inline-flex items-center gap-1 px-2 py-1 rounded-md border border-dashed border-border text-[10px] text-muted-foreground hover:border-accent hover:text-accent"
+                >
+                  <Plus size={10} /> {i18n.t('settings.addProfile')}
+                </button>
+              )}
+            </div>
+          )}
 
           <div>
             <label className="block text-[11px] font-semibold text-foreground mb-1">
@@ -517,13 +821,18 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
             <select
               value={voiceProvider}
               onChange={(e) => {
-                setVoiceProvider(e.target.value as VoiceProvider);
+                setVoiceProvider(e.target.value);
                 voiceKeyCheck.setStatus(null);
               }}
               className="w-full border border-border rounded-lg px-3 py-2 text-[13px] text-foreground bg-card font-medium outline-none focus:border-ring focus:ring-2 focus:ring-ring/10"
             >
               <option value="openai">OpenAI</option>
               <option value="groq">Groq</option>
+              {aiProfiles.map((pr) => (
+                <option key={pr.id} value={profileProviderId(pr.id)}>
+                  {pr.name} (Custom)
+                </option>
+              ))}
             </select>
           </div>
 
@@ -542,8 +851,16 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
               <Button
                 variant="outline"
                 size="sm"
-                disabled={!voiceApiKey || voiceKeyCheck.status === 'checking'}
-                onClick={() => void voiceKeyCheck.check(voiceProvider, voiceApiKey)}
+                disabled={!canCheckVoiceKey || voiceKeyCheck.status === 'checking'}
+                onClick={() =>
+                  void voiceKeyCheck.check(
+                    voiceProvider,
+                    voiceApiKey,
+                    voiceProviderIsProfile
+                      ? aiProfiles.find((p) => profileProviderId(p.id) === voiceProvider)?.baseUrl
+                      : voiceBaseUrl,
+                  )
+                }
                 className="h-8 shrink-0 rounded-lg bg-card text-[11px] font-semibold"
               >
                 {i18n.t('settings.checkKey')}
@@ -563,6 +880,41 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
               </p>
             )}
           </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label className="block text-[11px] font-semibold text-foreground mb-1">
+                {i18n.t('settings.baseUrl')}{' '}
+                <span className="font-normal text-muted-foreground">({i18n.t('settings.baseUrlOptional')})</span>
+              </label>
+              <Input
+                value={voiceBaseUrl}
+                onChange={(e) => {
+                  setVoiceBaseUrl(e.target.value);
+                  voiceKeyCheck.setStatus(null);
+                }}
+                placeholder="https://api.example.com/v1"
+                className="h-8 text-[12px] rounded-lg border-border"
+                disabled={voiceProviderIsProfile}
+              />
+            </div>
+            <div>
+              <label className="block text-[11px] font-semibold text-foreground mb-1">
+                {i18n.t('settings.model')}{' '}
+                <span className="font-normal text-muted-foreground">({i18n.t('settings.baseUrlOptional')})</span>
+              </label>
+              <Input
+                value={voiceModel}
+                onChange={(e) => setVoiceModel(e.target.value)}
+                placeholder="whisper-1"
+                className="h-8 text-[12px] rounded-lg border-border"
+                disabled={voiceProviderIsProfile}
+              />
+            </div>
+          </div>
+          {voiceProviderIsProfile && (
+            <p className="text-[10px] text-muted-foreground">{i18n.t('settings.voiceProfileHint')}</p>
+          )}
 
           {import.meta.env.BROWSER !== 'firefox' && (
             <MicrophonePicker value={voiceMicrophoneId} onChange={setVoiceMicrophoneId} />


### PR DESCRIPTION
…verride, voice STT)

- AI profiles multislot (aiProfiles[]) with profile: prefix, stored in browser.storage.local; provider can be openai/anthropic/profile:<id>
- OpenAI baseUrl override for openai provider (proxy) and per-profile custom endpoints (e.g. http://localhost:11434/v1)
- Keyless local allowed (localhost/127.0.0.1/http://) for self-hosted
- Central resolve helper (resolveAIConfig) threading baseUrl through description/meta/rewrite and background ai-description/guide-meta
- Provider factory now accepts baseUrl; validateApiKey builds dynamic /v1/models and /v1/audio/transcriptions URLs, sends bearer only if key present
- Voice STT also OpenAI-spec via same profiles or direct voiceBaseUrl/ voiceModel overrides
- Settings multislot UI + onboarding voice/baseUrl fields
- i18n locales updated (en/de/es/fr/pt-BR)
- Tests updated for 5-arg generateGuideMeta and 8-key VOICE_KEY_SETTINGS