### PR TITLE
feat: add UK Smart Blur presets

### DIFF
--- a/src/core/blur/__tests__/uk-presets.test.ts
+++ b/src/core/blur/__tests__/uk-presets.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { findMatches, PRESET_LABELS, PRESET_REGEXES, type PresetKey } from '../regexes';
+
+const UK_KEYS: PresetKey[] = ['ukPhone', 'ukPostcode', 'ukNino', 'ukSortCode'];
+
+const fresh = (key: PresetKey) => {
+  const r = PRESET_REGEXES[key];
+  r.lastIndex = 0;
+  return r;
+};
+
+describe('UK preset registration', () => {
+  it('carries a label for every UK preset', () => {
+    for (const key of UK_KEYS) {
+      expect(PRESET_LABELS[key]).toBeDefined();
+      expect(PRESET_LABELS[key].length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('ukPhone', () => {
+  it.each([
+    '07700 900461',
+    '07700900461',
+    '+44 7700 900461',
+    '+447700900461',
+    '0113 496 0122',
+    '(020) 7946 0958',
+    '020 7946 0958',
+    '+44 (0)20 7946 0958',
+    '+44(0)7700900461',
+  ])('matches %s', (value) => {
+    expect(value).toMatch(fresh('ukPhone'));
+  });
+
+  it('finds a number embedded in prose', () => {
+    const match = fresh('ukPhone').exec('Call us on 07700 900461 before noon.');
+    expect(match?.[0]).toBe('07700 900461');
+  });
+
+  it.each([
+    '12345678',
+    '1234 5678',
+    'Order 2024 20260401',
+    '01/02/2026',
+    'Total is 1234.56',
+  ])('leaves %s alone, unlike the general phone preset', (value) => {
+    expect(value).not.toMatch(fresh('ukPhone'));
+  });
+
+  it('does not fire mid-way through a longer digit run', () => {
+    expect('9077009004619').not.toMatch(fresh('ukPhone'));
+  });
+});
+
+describe('ukPostcode', () => {
+  it.each(['SW1A 2AA', 'M160RA', 'sw1a 2aa', 'EC1A 1BB', 'LS1 4AP'])('matches %s', (value) => {
+    expect(value).toMatch(fresh('ukPostcode'));
+  });
+
+  it.each(['A1 servicing', 'room B2 4people', 'HELLO WORLD', '12345'])('leaves %s alone', (value) => {
+    expect(value).not.toMatch(fresh('ukPostcode'));
+  });
+});
+
+describe('ukNino', () => {
+  it.each(['QQ 12 34 56 C', 'QQ123456C', 'ab 12 34 56 d'])('matches %s', (value) => {
+    expect(value).toMatch(fresh('ukNino'));
+  });
+
+  it.each(['Q1 12 34 56 C', 'QQ 12 34 56 E', 'QQ 12 34 56'])('leaves %s alone', (value) => {
+    expect(value).not.toMatch(fresh('ukNino'));
+  });
+});
+
+describe('ukSortCode', () => {
+  it.each(['04-00-04', '12-34-56'])('matches %s', (value) => {
+    expect(value).toMatch(fresh('ukSortCode'));
+  });
+
+  it.each(['123-45-67', '12-345-56', '1234-56-78', '12/34/56'])('leaves %s alone', (value) => {
+    expect(value).not.toMatch(fresh('ukSortCode'));
+  });
+
+  it('does not extend into neighbouring digits', () => {
+    expect('112-34-56').not.toMatch(fresh('ukSortCode'));
+    expect('12-34-567').not.toMatch(fresh('ukSortCode'));
+  });
+});
+
+describe('UK patterns through the scanner round trip', () => {
+  it.each([
+    ['ukPhone', 'Ring +44 (0)20 7946 0958 today'],
+    ['ukPostcode', 'Deliver to SW1A 2AA please'],
+    ['ukNino', 'NINO QQ123456C on file'],
+    ['ukSortCode', 'Sort code 04-00-04 applies'],
+  ] as [PresetKey, string][])('%s survives new RegExp(source, flags) and findMatches', (key, text) => {
+    const original = PRESET_REGEXES[key];
+    const rebuilt = new RegExp(original.source, original.flags);
+    expect(findMatches(text, [rebuilt]).length).toBeGreaterThan(0);
+  });
+});
+
+describe('the general phone preset is untouched', () => {
+  it('still matches what it matched before', () => {
+    const r = PRESET_REGEXES.phone;
+    r.lastIndex = 0;
+    expect('(555) 014-2378').toMatch(r);
+  });
+});

--- a/src/core/blur/manager.ts
+++ b/src/core/blur/manager.ts
@@ -13,6 +13,10 @@ const DEFAULT_PRESETS: Record<PresetKey, boolean> = {
   creditCard: false,
   ipAddress: false,
   macAddress: false,
+  ukPhone: false,
+  ukPostcode: false,
+  ukNino: false,
+  ukSortCode: false,
 };
 
 const EVENTS = ['mimik-blur:update-presets', 'mimik-blur:start-picker', 'mimik-blur:reset', 'mimik-blur:done'] as const;
@@ -83,6 +87,10 @@ export class BlurManager {
       creditCard: false,
       ipAddress: false,
       macAddress: false,
+      ukPhone: false,
+      ukPostcode: false,
+      ukNino: false,
+      ukSortCode: false,
     };
     for (const key of activeKeys) presets[key] = true;
     browser.storage.local.set({ blurPresets: presets });

--- a/src/core/blur/panel.ts
+++ b/src/core/blur/panel.ts
@@ -2,7 +2,18 @@ import { i18n } from '#imports';
 import type { PresetKey } from './regexes';
 import { PRESET_LABELS } from './regexes';
 
-const PRESET_KEYS: PresetKey[] = ['email', 'phone', 'ssn', 'creditCard', 'ipAddress', 'macAddress'];
+const PRESET_KEYS: PresetKey[] = [
+  'email',
+  'phone',
+  'ssn',
+  'creditCard',
+  'ipAddress',
+  'macAddress',
+  'ukPhone',
+  'ukPostcode',
+  'ukNino',
+  'ukSortCode',
+];
 
 const STYLES = `
   :host {

--- a/src/core/blur/regexes.ts
+++ b/src/core/blur/regexes.ts
@@ -1,4 +1,14 @@
-export type PresetKey = 'email' | 'phone' | 'ssn' | 'creditCard' | 'ipAddress' | 'macAddress';
+export type PresetKey =
+  | 'email'
+  | 'phone'
+  | 'ssn'
+  | 'creditCard'
+  | 'ipAddress'
+  | 'macAddress'
+  | 'ukPhone'
+  | 'ukPostcode'
+  | 'ukNino'
+  | 'ukSortCode';
 
 export const PRESET_REGEXES: Record<PresetKey, RegExp> = {
   email: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
@@ -7,6 +17,10 @@ export const PRESET_REGEXES: Record<PresetKey, RegExp> = {
   phone: /(?:\+?\d{1,3}[\s.-]?)?(?:\(?\d{2,4}\)?[\s.-]?)?\d{3,4}[\s.-]?\d{4}\b/g,
   ipAddress: /\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b/g,
   macAddress: /\b[0-9A-F]{2}(?:[:-][0-9A-F]{2}){5}\b/gi,
+  ukPhone: /(?<!\d)(?:\+44[\s-]?(?:\(0\)[\s-]?)?\d{2,4}|\(?0\d{2,4}\)?)[\s-]?\d{3,4}[\s-]?\d{3,4}\b/g,
+  ukPostcode: /\b[A-Z]{1,2}\d[A-Z\d]?\s?\d[A-Z]{2}\b/gi,
+  ukNino: /\b[A-Z]{2}\s?\d{2}\s?\d{2}\s?\d{2}\s?[A-D]\b/gi,
+  ukSortCode: /(?<!\d)\d{2}-\d{2}-\d{2}(?!\d)/g,
 };
 
 export const PRESET_LABELS: Record<PresetKey, string> = {
@@ -16,6 +30,10 @@ export const PRESET_LABELS: Record<PresetKey, string> = {
   creditCard: 'Credit Card',
   ipAddress: 'IP Address',
   macAddress: 'MAC Address',
+  ukPhone: 'UK Phone Numbers',
+  ukPostcode: 'UK Postcode',
+  ukNino: 'National Insurance Number',
+  ukSortCode: 'UK Sort Code',
 };
 
 export interface MatchRange {

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -141,6 +141,10 @@ blurPresets:
   creditCard: Kreditkarte
   ipAddress: IP-Adresse
   macAddress: MAC-Adresse
+  ukPhone: Britische Telefonnummern
+  ukPostcode: Britische Postleitzahlen
+  ukNino: National-Insurance-Nummern
+  ukSortCode: "Britische Bankleitzahlen (Sort Codes)"
 
 fullview:
   allGuides: Alle Anleitungen

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -141,6 +141,10 @@ blurPresets:
   creditCard: Credit Card
   ipAddress: IP Address
   macAddress: MAC Address
+  ukPhone: UK phone numbers
+  ukPostcode: UK postcodes
+  ukNino: National Insurance numbers
+  ukSortCode: UK sort codes
 
 fullview:
   allGuides: All Guides

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -141,6 +141,10 @@ blurPresets:
   creditCard: "Tarjeta de crédito"
   ipAddress: "Dirección IP"
   macAddress: "Dirección MAC"
+  ukPhone: "Números de teléfono del Reino Unido"
+  ukPostcode: "Códigos postales del Reino Unido"
+  ukNino: "Número de seguro nacional (NINO)"
+  ukSortCode: "Código bancario del Reino Unido (Sort Code)"
 
 fullview:
   allGuides: Todas las guías

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -141,6 +141,10 @@ blurPresets:
   creditCard: "Carte bancaire"
   ipAddress: Adresse IP
   macAddress: Adresse MAC
+  ukPhone: "Numéros de téléphone britanniques"
+  ukPostcode: "Codes postaux britanniques"
+  ukNino: "Numéro d'assurance nationale (NINO)"
+  ukSortCode: "Code guichet britannique (Sort Code)"
 
 fullview:
   allGuides: Tous les guides

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -141,6 +141,10 @@ blurPresets:
   creditCard: Cartão de crédito
   ipAddress: Endereço IP
   macAddress: Endereço MAC
+  ukPhone: Números de telefone do Reino Unido
+  ukPostcode: Códigos postais do Reino Unido
+  ukNino: Número de seguro nacional do Reino Unido (NINO)
+  ukSortCode: Código bancário do Reino Unido (Sort Code)
 
 fullview:
   allGuides: Todos os guias

--- a/src/ui/onboarding/App.tsx
+++ b/src/ui/onboarding/App.tsx
@@ -27,6 +27,10 @@ const BLUR_PRESET_I18N: Record<PresetKey, string> = {
   creditCard: 'creditCard',
   ipAddress: 'ipAddress',
   macAddress: 'macAddress',
+  ukPhone: 'ukPhone',
+  ukPostcode: 'ukPostcode',
+  ukNino: 'ukNino',
+  ukSortCode: 'ukSortCode',
 };
 
 function MascotLarge({ size = 280 }: { size?: number }) {
@@ -509,6 +513,10 @@ function SmartBlurStep({ onNext, onBack, index, total }: StepProps) {
     creditCard: false,
     ipAddress: false,
     macAddress: false,
+    ukPhone: false,
+    ukPostcode: false,
+    ukNino: false,
+    ukSortCode: false,
   });
 
   useEffect(() => {

--- a/src/ui/shared/SettingsView.tsx
+++ b/src/ui/shared/SettingsView.tsx
@@ -122,6 +122,10 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
     creditCard: false,
     ipAddress: false,
     macAddress: false,
+    ukPhone: false,
+    ukPostcode: false,
+    ukNino: false,
+    ukSortCode: false,
   });
 
   useEffect(() => {
@@ -250,6 +254,10 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
     creditCard: 'blurPresets.creditCard',
     ipAddress: 'blurPresets.ipAddress',
     macAddress: 'blurPresets.macAddress',
+    ukPhone: 'blurPresets.ukPhone',
+    ukPostcode: 'blurPresets.ukPostcode',
+    ukNino: 'blurPresets.ukNino',
+    ukSortCode: 'blurPresets.ukSortCode',
   };
 
   return (


### PR DESCRIPTION
### What

Four new Smart Blur presets for UK data, following up on the offer in #61:

- **UK phone numbers**: `07700 900461`, `+44 7700 900461`, `+44 (0)20 7946 0958`, `0113 496 0122`, `(020) 7946 0958`
- **UK postcodes**: `SW1A 2AA`, `M160RA` (case-insensitive, with or without the space)
- **National Insurance numbers**: `QQ 12 34 56 C`, `QQ123456C`
- **UK sort codes**: `04-00-04`

All four default to off, matching how `ssn` and `creditCard` ship today.

### What it deliberately does not do

The existing `phone` preset is byte-for-byte untouched. #61 documents its false positives on bare 7-8 digit runs; rewriting it would change matching for every current user, so these are additive instead. There's a test pinning the old preset's behaviour.

The new `ukPhone` pattern avoids that failure mode by anchoring on `+44` or a leading `0` with digit lookarounds: `12345678`, `1234 5678`, dates and order references do not match. The test file carries those as explicit negative cases, since they're the evidence from #61.

### Known tradeoffs

`ukSortCode` matches anything shaped `dd-dd-dd`, which collides with `dd-mm-yy` dates. The two are the same shape, so this is inherent. Likewise the postcode pattern can match postcode-shaped tokens such as `MP3 4GB` or a bare hex colour fragment. Over-blurring is the safe direction for a redaction tool, and both presets default to off, but you should know it's there.

### Tests

44 new tests (1133 passing in total), covering positive matches, embedded-in-prose extraction, the #61 false-positive guards, boundary behaviour (no matching mid-way through longer digit runs), and a scanner round-trip check proving the lookbehind patterns survive `new RegExp(source, flags)` reconstruction. `pnpm typecheck`, `pnpm lint`, and both browser builds are clean.

### i18n

Four `blurPresets.*` labels added across all five locales. Not a native speaker in most of them, so happy for the translations to be corrected.
