### PR TITLE
feat: add DeepSeek provider support

### DIFF
--- a/src/core/capture/ai/__tests__/validate.test.ts
+++ b/src/core/capture/ai/__tests__/validate.test.ts
@@ -59,6 +59,14 @@ describe('validateApiKey', () => {
     expect(init.headers.Authorization).toBe('Bearer gsk-key');
   });
 
+  it('checks a deepseek key against deepseek, not openai', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+    expect(await validateApiKey('deepseek', 'sk-deepseek')).toEqual({ valid: true });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.deepseek.com/models');
+    expect(init.headers.Authorization).toBe('Bearer sk-deepseek');
+  });
+
   it('gives up rather than spinning forever when a host never answers', async () => {
     fetchMock.mockResolvedValue({ ok: true, status: 200 });
     await validateApiKey('openai', 'sk-key');

--- a/src/core/capture/ai/models.ts
+++ b/src/core/capture/ai/models.ts
@@ -29,6 +29,15 @@ export const AI_PROVIDERS: Record<string, AIProviderConfig> = {
       { id: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4' },
     ],
   },
+  deepseek: {
+    label: 'DeepSeek',
+    defaultModel: 'deepseek-v4-flash',
+    models: [
+      { id: 'deepseek-v4-flash', label: 'DeepSeek V4 Flash' },
+      { id: 'deepseek-v4-pro', label: 'DeepSeek V4 Pro' },
+      { id: 'deepseek-v4-flash-vision-exp', label: 'DeepSeek V4 Flash Vision Exp' },
+    ],
+  },
 };
 
 export type AIProviderKey = keyof typeof AI_PROVIDERS;

--- a/src/core/capture/ai/provider.ts
+++ b/src/core/capture/ai/provider.ts
@@ -1,7 +1,10 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
 
+const DEEPSEEK_BASE_URL = 'https://api.deepseek.com';
+
 export function createModel(provider: string, model: string, apiKey: string) {
   if (provider === 'anthropic') return createAnthropic({ apiKey })(model);
+  if (provider === 'deepseek') return createOpenAI({ apiKey, baseURL: DEEPSEEK_BASE_URL, name: 'deepseek' })(model);
   return createOpenAI({ apiKey })(model);
 }

--- a/src/core/capture/ai/validate.ts
+++ b/src/core/capture/ai/validate.ts
@@ -21,6 +21,10 @@ const ENDPOINTS: Record<string, { url: string; headers: (key: string) => Record<
     url: 'https://api.groq.com/openai/v1/models',
     headers: (key) => ({ Authorization: `Bearer ${key}` }),
   },
+  deepseek: {
+    url: 'https://api.deepseek.com/models',
+    headers: (key) => ({ Authorization: `Bearer ${key}` }),
+  },
 };
 
 export async function validateApiKey(provider: string, apiKey: string): Promise<KeyValidation> {

--- a/src/core/guides/types.ts
+++ b/src/core/guides/types.ts
@@ -59,7 +59,7 @@ export interface Screenshot {
 
 export interface Settings {
   aiApiKey: string;
-  aiProvider: 'openai' | 'anthropic';
+  aiProvider: 'openai' | 'anthropic' | 'deepseek';
   aiModel: string;
   voiceEnabled: boolean;
   voiceProvider: VoiceProvider;


### PR DESCRIPTION
## Summary

- Add DeepSeek as an AI provider option
- Route DeepSeek requests through the OpenAI-compatible adapter with DeepSeek's base URL
- Add DeepSeek model options to the model picker
- Validate DeepSeek API keys against DeepSeek's models endpoint

## Checks

- pnpm.cmd typecheck
- pnpm.cmd test src/core/capture/ai/__tests__/validate.test.ts src/core/capture/ai/__tests__/models.test.ts
- pnpm.cmd build