### PR TITLE
feat(ai): add OpenRouter as an AI provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,9 @@ src/
 │   │   ├── ai/              # AI description + title generation (Vercel AI SDK)
 │   │   │   ├── description.ts   # getAIDescription (DOM context → AI → step text)
 │   │   │   ├── title.ts         # generateGuideTitle (steps → AI → guide name)
-│   │   │   ├── models.ts        # AI_PROVIDERS config (OpenAI/Anthropic model lists)
+│   │   │   ├── models.ts        # AI_PROVIDERS config (OpenAI/Anthropic/OpenRouter model lists)
 │   │   │   ├── prompts.ts       # Prompt templates
-│   │   │   └── provider.ts      # createModel factory (OpenAI/Anthropic)
+│   │   │   └── provider.ts      # createModel factory (OpenAI/Anthropic/OpenRouter)
 │   │   ├── dom/              # DOM extraction utilities
 │   │   │   ├── context.ts       # DOMContext extraction + serialization
 │   │   │   ├── element-meta.ts  # extractElementMeta (selector, text, aria, rect)

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Need to blur something custom? The manual blur picker lets you select any DOM el
 
 ### 🧠 AI descriptions (optional)
 
-Bring your own API key (OpenAI or Anthropic) and Mimik generates human-readable step descriptions like *"Click the **Submit** button to save changes"* instead of the rule-based `Click Submit`.
+Bring your own API key (OpenAI, Anthropic, or OpenRouter) and Mimik generates human-readable step descriptions like *"Click the **Submit** button to save changes"* instead of the rule-based `Click Submit`.
 
 Descriptions are generated from a lightweight DOM context (~50-100 tokens), not screenshots. Roughly 15-30x cheaper than vision models. Choose the language you want descriptions in (English, Spanish, Portuguese, French, German).
 

--- a/src/core/capture/ai/__tests__/description.test.ts
+++ b/src/core/capture/ai/__tests__/description.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+import type { DOMContext } from '../../dom/context';
+import { getAIDescription } from '../description';
+
+const DOM_CONTEXT: DOMContext = {
+  page: { title: 'Public profile - Settings', path: '/settings/profile' },
+  container: { tag: 'form', role: null, label: 'Public profile' },
+  heading: 'Public profile',
+  siblings: [
+    { tag: 'input', role: null, name: 'Name', value: null },
+    { tag: 'button', role: null, name: 'Update profile', value: null },
+  ],
+  target: { tag: 'button', role: null, name: 'Update profile', value: null, action: 'click' },
+};
+
+function completion(content: string) {
+  return new Response(
+    JSON.stringify({
+      id: 'chatcmpl-1',
+      choices: [{ index: 0, message: { role: 'assistant', content }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 80, completion_tokens: 9 },
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+beforeEach(() => {
+  fakeBrowser.reset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('getAIDescription over openrouter', () => {
+  it('asks openrouter for the description and returns what it says', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(completion('Click the Update profile button'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const description = await getAIDescription(DOM_CONTEXT, 'openrouter', 'openai/gpt-4o-mini', 'sk-or-key');
+
+    expect(description).toBe('Click the Update profile button');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://openrouter.ai/api/v1/chat/completions');
+    expect(init.headers.authorization).toBe('Bearer sk-or-key');
+  });
+
+  it('sends the serialized dom context, not a screenshot', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(completion('Click Update profile'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await getAIDescription(DOM_CONTEXT, 'openrouter', 'openai/gpt-4o-mini', 'sk-or-key');
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    const prompt = JSON.stringify(body.messages);
+    expect(body.model).toBe('openai/gpt-4o-mini');
+    expect(prompt).toContain('Public profile');
+    expect(prompt).toContain('/settings/profile');
+    expect(prompt).not.toContain('image_url');
+  });
+
+  it('honours the stored ai language', async () => {
+    await fakeBrowser.storage.local.set({ aiLanguage: 'fr' });
+    const fetchMock = vi.fn().mockResolvedValue(completion('Cliquez sur Mettre à jour'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await getAIDescription(DOM_CONTEXT, 'openrouter', 'openai/gpt-4o-mini', 'sk-or-key');
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(JSON.stringify(body.messages)).toContain('French');
+  });
+
+  it('strips the quotes a model wraps its answer in', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(completion('"Click the Update profile button"')));
+    expect(await getAIDescription(DOM_CONTEXT, 'openrouter', 'openai/gpt-4o-mini', 'sk-or-key')).toBe(
+      'Click the Update profile button',
+    );
+  });
+
+  it('falls back to null when openrouter rejects the key, instead of throwing into capture', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: { message: 'No auth credentials found' } }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    );
+    expect(await getAIDescription(DOM_CONTEXT, 'openrouter', 'openai/gpt-4o-mini', 'sk-or-bad')).toBeNull();
+  });
+});

--- a/src/core/capture/ai/__tests__/openrouter-models.live.test.ts
+++ b/src/core/capture/ai/__tests__/openrouter-models.live.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Live check that every curated OpenRouter model actually answers.
+ * Skipped unless OPENROUTER_API_KEY is set. Run with:
+ *
+ *   OPENROUTER_API_KEY=sk-or-... pnpm vitest run openrouter.live
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+import type { DOMContext } from '../../dom/context';
+import { getAIDescription } from '../description';
+import { AI_PROVIDERS } from '../models';
+
+const API_KEY = process.env.OPENROUTER_API_KEY;
+
+const DOM_CONTEXT: DOMContext = {
+  page: { title: 'Public profile - Settings', path: '/settings/profile' },
+  container: { tag: 'form', role: null, label: 'Public profile' },
+  heading: 'Public profile',
+  siblings: [
+    { tag: 'input', role: null, name: 'Name', value: null },
+    { tag: 'button', role: null, name: 'Update profile', value: null },
+  ],
+  target: { tag: 'button', role: null, name: 'Update profile', value: null, action: 'click' },
+};
+
+describe.skipIf(!API_KEY)('every curated openrouter model answers', () => {
+  beforeEach(() => {
+    fakeBrowser.reset();
+  });
+
+  it.each(AI_PROVIDERS.openrouter.models.map((m) => m.id))('%s describes a step', async (id) => {
+    const description = await getAIDescription(DOM_CONTEXT, 'openrouter', id, API_KEY as string);
+    process.stdout.write(`\n  [${id}] ${description}\n`);
+    expect(description).toBeTruthy();
+  }, 45_000);
+});

--- a/src/core/capture/ai/__tests__/openrouter.live.test.ts
+++ b/src/core/capture/ai/__tests__/openrouter.live.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Live check against the real OpenRouter API. Skipped unless OPENROUTER_API_KEY
+ * is set, so `pnpm test` stays offline by default:
+ *
+ *   OPENROUTER_API_KEY=sk-or-... pnpm vitest run openrouter.live
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+import type { DOMContext } from '../../dom/context';
+import { getAIDescription } from '../description';
+import { AI_PROVIDERS } from '../models';
+import { validateApiKey } from '../validate';
+
+const API_KEY = process.env.OPENROUTER_API_KEY;
+const MODEL = process.env.OPENROUTER_MODEL || AI_PROVIDERS.openrouter.defaultModel;
+
+const DOM_CONTEXT: DOMContext = {
+  page: { title: 'Public profile - Settings', path: '/settings/profile' },
+  container: { tag: 'form', role: null, label: 'Public profile' },
+  heading: 'Public profile',
+  siblings: [
+    { tag: 'input', role: null, name: 'Name', value: null },
+    { tag: 'input', role: null, name: 'Email', value: null },
+    { tag: 'button', role: null, name: 'Update profile', value: null },
+  ],
+  target: { tag: 'button', role: null, name: 'Update profile', value: null, action: 'click' },
+};
+
+describe.skipIf(!API_KEY)('openrouter, against the live API', () => {
+  beforeEach(() => {
+    fakeBrowser.reset();
+  });
+
+  it('accepts a real key', async () => {
+    expect(await validateApiKey('openrouter', API_KEY as string)).toEqual({ valid: true });
+  }, 20_000);
+
+  it('rejects a key that is not real', async () => {
+    expect(await validateApiKey('openrouter', 'sk-or-v1-not-a-real-key')).toEqual({
+      valid: false,
+      reason: 'rejected',
+    });
+  }, 20_000);
+
+  it('describes a step in one short sentence', async () => {
+    const description = await getAIDescription(DOM_CONTEXT, 'openrouter', MODEL, API_KEY as string);
+    expect(description).toBeTruthy();
+    expect((description as string).length).toBeLessThan(120);
+    // console.* is silenced in vitest.setup.ts, so write straight to stdout.
+    process.stdout.write(`\n  [openrouter:${MODEL}] ${description}\n`);
+  }, 30_000);
+});

--- a/src/core/capture/ai/__tests__/provider.test.ts
+++ b/src/core/capture/ai/__tests__/provider.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createModel, OPENROUTER_BASE_URL } from '../provider';
+
+function chatCompletion() {
+  return new Response(
+    JSON.stringify({
+      id: 'chatcmpl-1',
+      choices: [{ index: 0, message: { role: 'assistant', content: 'Click Save' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('createModel', () => {
+  it('keeps openai on its own provider', () => {
+    expect(createModel('openai', 'gpt-4o-mini', 'sk-key').provider).toBe('openai.responses');
+  });
+
+  it('keeps anthropic on its own provider', () => {
+    expect(createModel('anthropic', 'claude-3-5-haiku-20241022', 'ant-key').provider).toBe('anthropic.messages');
+  });
+
+  it('falls back to openai for a provider it does not know', () => {
+    expect(createModel('mystery', 'gpt-4o-mini', 'sk-key').provider).toBe('openai.responses');
+  });
+
+  it('routes openrouter through chat completions, not the responses API', () => {
+    expect(createModel('openrouter', 'openai/gpt-4o-mini', 'sk-or-key').provider).toBe('openrouter.chat');
+  });
+
+  it('passes an openrouter model id through untouched', () => {
+    expect(createModel('openrouter', 'anthropic/claude-3.5-haiku', 'sk-or-key').modelId).toBe(
+      'anthropic/claude-3.5-haiku',
+    );
+  });
+
+  it('sends an openrouter request to openrouter, bearing the key', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(chatCompletion());
+    vi.stubGlobal('fetch', fetchMock);
+
+    await createModel('openrouter', 'openai/gpt-4o-mini', 'sk-or-key').doGenerate({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'describe this step' }] }],
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${OPENROUTER_BASE_URL}/chat/completions`);
+    expect(init.headers.authorization).toBe('Bearer sk-or-key');
+    expect(JSON.parse(init.body).model).toBe('openai/gpt-4o-mini');
+  });
+});

--- a/src/core/capture/ai/__tests__/validate.test.ts
+++ b/src/core/capture/ai/__tests__/validate.test.ts
@@ -59,6 +59,19 @@ describe('validateApiKey', () => {
     expect(init.headers.Authorization).toBe('Bearer gsk-key');
   });
 
+  it('checks an openrouter key against the endpoint that authenticates, not the public model list', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+    expect(await validateApiKey('openrouter', 'sk-or-key')).toEqual({ valid: true });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://openrouter.ai/api/v1/key');
+    expect(init.headers.Authorization).toBe('Bearer sk-or-key');
+  });
+
+  it('reports a rejected openrouter key as rejected', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 401 });
+    expect(await validateApiKey('openrouter', 'sk-or-bad')).toEqual({ valid: false, reason: 'rejected' });
+  });
+
   it('gives up rather than spinning forever when a host never answers', async () => {
     fetchMock.mockResolvedValue({ ok: true, status: 200 });
     await validateApiKey('openai', 'sk-key');

--- a/src/core/capture/ai/models.ts
+++ b/src/core/capture/ai/models.ts
@@ -29,6 +29,17 @@ export const AI_PROVIDERS: Record<string, AIProviderConfig> = {
       { id: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4' },
     ],
   },
+  openrouter: {
+    label: 'OpenRouter',
+    defaultModel: 'openai/gpt-4o-mini',
+    models: [
+      { id: 'openai/gpt-4o-mini', label: 'GPT-4o Mini' },
+      { id: 'anthropic/claude-haiku-4.5', label: 'Claude Haiku 4.5' },
+      { id: 'google/gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash Lite' },
+      { id: 'meta-llama/llama-3.3-70b-instruct', label: 'Llama 3.3 70B' },
+      { id: 'deepseek/deepseek-chat', label: 'DeepSeek Chat' },
+    ],
+  },
 };
 
 export type AIProviderKey = keyof typeof AI_PROVIDERS;

--- a/src/core/capture/ai/provider.ts
+++ b/src/core/capture/ai/provider.ts
@@ -1,7 +1,13 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
 
+export const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+
 export function createModel(provider: string, model: string, apiKey: string) {
   if (provider === 'anthropic') return createAnthropic({ apiKey })(model);
+  // OpenRouter speaks the chat completions dialect, not the responses API the
+  // openai provider reaches for by default.
+  if (provider === 'openrouter')
+    return createOpenAI({ apiKey, baseURL: OPENROUTER_BASE_URL, name: 'openrouter' }).chat(model);
   return createOpenAI({ apiKey })(model);
 }

--- a/src/core/capture/ai/validate.ts
+++ b/src/core/capture/ai/validate.ts
@@ -17,6 +17,12 @@ const ENDPOINTS: Record<string, { url: string; headers: (key: string) => Record<
       'anthropic-dangerous-direct-browser-access': 'true',
     }),
   },
+  // /models is public on OpenRouter and answers 200 for any key, so check the
+  // key against /key, which is the endpoint that actually authenticates.
+  openrouter: {
+    url: 'https://openrouter.ai/api/v1/key',
+    headers: (key) => ({ Authorization: `Bearer ${key}` }),
+  },
   groq: {
     url: 'https://api.groq.com/openai/v1/models',
     headers: (key) => ({ Authorization: `Bearer ${key}` }),

--- a/src/core/capture/voice/__tests__/api-key.test.ts
+++ b/src/core/capture/voice/__tests__/api-key.test.ts
@@ -56,6 +56,12 @@ describe('resolveVoiceApiKey', () => {
     ).toEqual({ provider: 'openai', apiKey: '', source: 'none' });
   });
 
+  it('does not lend an openrouter key to a whisper endpoint', () => {
+    expect(
+      resolveVoiceApiKey({ voiceProvider: 'openai', voiceApiKey: '', aiProvider: 'openrouter', aiApiKey: 'sk-or-x' }),
+    ).toEqual({ provider: 'openai', apiKey: '', source: 'none' });
+  });
+
   it('treats a missing ai provider as openai', () => {
     expect(resolveVoiceApiKey({ voiceProvider: 'openai', aiProvider: undefined, aiApiKey: 'sk-ai' }).source).toBe('ai');
   });

--- a/src/core/guides/types.ts
+++ b/src/core/guides/types.ts
@@ -59,7 +59,7 @@ export interface Screenshot {
 
 export interface Settings {
   aiApiKey: string;
-  aiProvider: 'openai' | 'anthropic';
+  aiProvider: 'openai' | 'anthropic' | 'openrouter';
   aiModel: string;
   voiceEnabled: boolean;
   voiceProvider: VoiceProvider;


### PR DESCRIPTION
Closes #70.

Adds OpenRouter alongside OpenAI and Anthropic. Both provider pickers already render from `AI_PROVIDERS`, so the settings and onboarding UIs pick it up without changes.

## Not quite drop-in OpenAI-compatible

The obvious implementation is "OpenRouter speaks OpenAI, so reuse the openai provider with a different `baseURL`". That doesn't work here: with `@ai-sdk/openai@3`, calling `createOpenAI(...)(model)` builds a **Responses API** model, which OpenRouter doesn't implement. It has to go through `.chat()`:

```ts
if (provider === 'openrouter')
  return createOpenAI({ apiKey, baseURL: OPENROUTER_BASE_URL, name: 'openrouter' }).chat(model);
```

## Key validation uses /key, not /models

The natural mirror of the OpenAI check would be `GET /api/v1/models`, but that endpoint is **public** on OpenRouter and returns 200 for any string — so every key, including a typo'd one, would validate. `GET /api/v1/key` actually authenticates, so a bad key returns 401 and surfaces in settings as rejected.

## Models

The curated ids use OpenRouter's `vendor/model` form, and each was run against the live API rather than taken from documentation. Anything not listed still works through the existing custom-model field, which is what the issue asked for.

## Voice keys are unaffected

`resolveVoiceApiKey` only lends the AI key to Whisper when `aiProvider === 'openai'`, so an OpenRouter key is never sent to OpenAI's transcription endpoint. No change needed — added a regression test so it stays that way.

## Testing

`pnpm lint && pnpm test && pnpm build && pnpm build:firefox` all pass.

New tests:
- `provider.test.ts` — the factory routes openrouter to chat completions, leaves openai/anthropic untouched, and an unknown provider still falls back to openai
- `description.test.ts` — drives `getAIDescription` end to end over mocked HTTP: request URL, auth header, serialized DOM context in the body, language suffix, quote stripping, and a null return on 401 rather than throwing into the capture pipeline
- `validate.test.ts` / `api-key.test.ts` — key validation and the voice-key regression

Two live-API tests are guarded behind an env var and skip by default:

```
OPENROUTER_API_KEY=sk-or-... pnpm vitest run openrouter.live
```

They were run against the real API while preparing this, covering key acceptance, rejection of an invalid key, and a description from every curated model.

> One note: the live tests currently need the `TextEncoder` fix from `chore/test-harness-encoder`. The setup shim truncates multi-byte characters, and the step-description prompt contains `→`, so undici sends a mismatched content-length. Offline tests and CI are unaffected. Happy to open that as a separate PR, or fold it in here if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q33Tvr7FGFuuxhoN7HPHmg
