### PR TITLE
fix(test): encode real UTF-8 in the jsdom TextEncoder shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.1.1",
     "@vitest/coverage-istanbul": "^4.1.3",
     "@wxt-dev/i18n": "^0.2.5",
     "fake-indexeddb": "^6.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^6.1.1
+        version: 6.1.1(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1))
       '@vitest/coverage-istanbul':
         specifier: ^4.1.3
         version: 4.1.3(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@29.0.1)(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)))
@@ -1424,8 +1427,8 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.12':
     resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
 
-  '@rolldown/pluginutils@1.0.0-rc.7':
-    resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1617,17 +1620,20 @@ packages:
       '@types/react': ^18.0.0 || ^19.0.0
       react: ^18.0.0 || ^19.0.0
 
-  '@vitejs/plugin-react@6.0.1':
-    resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
+  '@vitejs/plugin-react@6.1.1':
+    resolution: {integrity: sha512-yxLaQV9gkhS8ezJqCM6+ndU7mDY6gqAg75NQ+0IjwEI8IYOmQCgkRwHKVSfWXW076DsqMo0Dk+0FK1U+M5RgFw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
       babel-plugin-react-compiler: ^1.0.0
+      oxc-transform-react: ^0.145.0
       vite: ^8.0.0
     peerDependenciesMeta:
       '@rolldown/plugin-babel':
         optional: true
       babel-plugin-react-compiler:
+        optional: true
+      oxc-transform-react:
         optional: true
 
   '@vitest/coverage-istanbul@4.1.3':
@@ -4891,7 +4897,7 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.12': {}
 
-  '@rolldown/pluginutils@1.0.0-rc.7': {}
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -5060,9 +5066,9 @@ snapshots:
       media-captions: 1.0.4
       react: 19.2.4
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1))':
+  '@vitejs/plugin-react@6.1.1(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1))':
     dependencies:
-      '@rolldown/pluginutils': 1.0.0-rc.7
+      '@rolldown/pluginutils': 1.0.1
       vite: 8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)
 
   '@vitest/coverage-istanbul@4.1.3(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@29.0.1)(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)))':
@@ -5154,12 +5160,13 @@ snapshots:
 
   '@wxt-dev/module-react@1.2.2(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1))(wxt@0.20.20(@types/node@25.5.0)(jiti@2.6.1))':
     dependencies:
-      '@vitejs/plugin-react': 6.0.1(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1))
+      '@vitejs/plugin-react': 6.1.1(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1))
       vite: 8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)
       wxt: 0.20.20(@types/node@25.5.0)(jiti@2.6.1)
     transitivePeerDependencies:
       - '@rolldown/plugin-babel'
       - babel-plugin-react-compiler
+      - oxc-transform-react
 
   '@wxt-dev/storage@1.2.8':
     dependencies:

--- a/src/core/blur/scanner.ts
+++ b/src/core/blur/scanner.ts
@@ -57,7 +57,7 @@ export class BlurScanner {
         if (!node.parentElement) return NodeFilter.FILTER_REJECT;
         if (EXCLUDED_TAGS.has(node.parentElement.tagName)) return NodeFilter.FILTER_REJECT;
         if (node.parentElement.closest(`[${BLUR_ATTR}]`)) return NodeFilter.FILTER_REJECT;
-        if (!node.textContent || !node.textContent.trim()) return NodeFilter.FILTER_REJECT;
+        if (!node.textContent?.trim()) return NodeFilter.FILTER_REJECT;
         return NodeFilter.FILTER_ACCEPT;
       },
     });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -94,22 +94,17 @@ vi.mock("wxt/testing", async () => {
   };
 });
 
+// jsdom rejects the Uint8Array that a TextEncoder from another realm hands back,
+// so re-wrap the bytes in this realm's Uint8Array. The encoding itself stays
+// native UTF-8: hand-rolling it as one byte per code unit truncates anything
+// outside latin1, which silently corrupts multi-byte text and makes any real
+// fetch fail with "body length does not match content-length header".
 class ESBuildAndJSDOMCompatibleTextEncoder extends TextEncoder {
-  constructor() {
-    super();
-  }
-
-  encode(input: string) {
+  encode(input = "") {
     if (typeof input !== "string") {
       throw new TypeError("`input` must be a string");
     }
-    const decodedURI = decodeURIComponent(encodeURIComponent(input));
-    const arr = new Uint8Array(decodedURI.length);
-    const chars = decodedURI.split("");
-    for (let i = 0; i < chars.length; i++) {
-      arr[i] = decodedURI[i].charCodeAt(0);
-    }
-    return arr;
+    return Uint8Array.from(super.encode(input));
   }
 }
 


### PR DESCRIPTION
Three test-tooling fixes, found while working on #73. Independent of that PR — this one stands on its own.

## The TextEncoder shim truncates multi-byte characters

`vitest.setup.ts` replaces the global `TextEncoder` with one that builds its byte array **one entry per UTF-16 code unit**:

```ts
const arr = new Uint8Array(decodedURI.length);
arr[i] = decodedURI[i].charCodeAt(0);
```

So anything outside latin1 is truncated to a single byte:

```
SHIM: 1 bytes | NATIVE: 3 bytes    // for "→"
```

Nothing catches it today because no test makes a real request. The moment one does, undici derives `content-length` from this encoder and the request dies before it leaves the process:

```
Cannot connect to API: Request body length does not match content-length header
```

That is not hypothetical for this repo: `STEP_DESCRIPTION_PROMPT` renders `→ Target: ...`, so any live check of the AI description pipeline fails on the arrow, regardless of provider or key. Isolated it three ways — the same request succeeds in plain Node and fails under Vitest, an ASCII-only prompt passes in both, and swapping the encoder is the only variable that changes the outcome.

The fix keeps the reason the shim exists — jsdom rejects a `Uint8Array` originating in another realm — by re-wrapping the bytes in this realm's `Uint8Array`, while letting the native encoder do the actual encoding:

```ts
return Uint8Array.from(super.encode(input));
```

All 1127 existing tests still pass, including the 14 jsdom and 3 happy-dom suites the shim was added for.

## `@vitejs/plugin-react` was missing from devDependencies

`vitest.config.ts` imports it, but it isn't declared, so every single test run opened with a wall of warning output:

```
vitest.config.ts (1:326) [UNRESOLVED_IMPORT] Warning:
Could not resolve '@vitejs/plugin-react' in vitest.config.ts
... Module not found, treating it as an external dependency
```

Adding it to `devDependencies` silences that and makes the React plugin actually load.

## One biome warning

`pnpm lint` reported a single `useOptionalChain` warning in `core/blur/scanner.ts`. Folded the nested guard into an optional chain, so lint is now clean at zero warnings.

## Testing

`pnpm lint && pnpm test && pnpm build && pnpm build:firefox` all pass. Lint output is clean, and test output no longer carries the unresolved-import warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q33Tvr7FGFuuxhoN7HPHmg
