### PR TITLE
fix(capture): settle toggles before the shot, and place frame rects in the tab

### DIFF
--- a/src/core/capture/__tests__/click-intercept.test.ts
+++ b/src/core/capture/__tests__/click-intercept.test.ts
@@ -56,8 +56,38 @@ describe('shouldInterceptClick', () => {
     expect(shouldInterceptClick(el('<textarea></textarea>'), click())).toBe(false);
   });
 
-  it('still intercepts a checkbox, which is a click and not typing', () => {
-    expect(shouldInterceptClick(el('<input type="checkbox">'), click())).toBe(true);
+  it('lets a checkbox toggle first, so the shot is not one state behind', () => {
+    expect(shouldInterceptClick(el('<input type="checkbox">'), click())).toBe(false);
+    expect(shouldInterceptClick(el('<input type="radio">'), click())).toBe(false);
+  });
+
+  it('lets an aria toggle through, the way a component library builds one', () => {
+    expect(shouldInterceptClick(el('<div role="checkbox" aria-checked="false">Ship it</div>'), click())).toBe(false);
+    expect(shouldInterceptClick(el('<div role="switch" aria-checked="false">Dark mode</div>'), click())).toBe(false);
+    expect(shouldInterceptClick(el('<div role="radio" aria-checked="false">Weekly</div>'), click())).toBe(false);
+  });
+
+  it('lets a label through, because clicking it toggles the box it drives', () => {
+    const host = document.createElement('div');
+    host.innerHTML = '<input type="checkbox" id="bike"><label for="bike">I have a bike</label>';
+    document.body.appendChild(host);
+    expect(shouldInterceptClick(host.querySelector('label') as HTMLElement, click())).toBe(false);
+  });
+
+  it('lets a wrapping label through as well', () => {
+    const label = el('<label>Remember me<input type="checkbox"></label>');
+    expect(shouldInterceptClick(label, click())).toBe(false);
+  });
+
+  it('still intercepts a label that drives a text field, which is not a toggle', () => {
+    const host = document.createElement('div');
+    host.innerHTML = '<input type="text" id="email"><label for="email">Email</label>';
+    document.body.appendChild(host);
+    expect(shouldInterceptClick(host.querySelector('label') as HTMLElement, click())).toBe(true);
+  });
+
+  it('still intercepts an ordinary button inside a label', () => {
+    expect(shouldInterceptClick(el('<button>Save</button>'), click())).toBe(true);
   });
 });
 

--- a/src/core/capture/dom/__tests__/frame-offset.test.ts
+++ b/src/core/capture/dom/__tests__/frame-offset.test.ts
@@ -1,0 +1,230 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  contentOrigin,
+  frameOffset,
+  installFrameOffsetResponder,
+  NO_OFFSET,
+  translateMeta,
+} from '@/core/capture/dom/frame-offset';
+import type { ElementMeta } from '@/core/guides/types';
+
+function meta(over: Partial<ElementMeta> = {}): ElementMeta {
+  return {
+    tag: 'input',
+    cssSelector: '#vehicle1',
+    textContent: null,
+    ariaLabel: null,
+    placeholder: null,
+    altText: null,
+    name: 'vehicle1',
+    role: 'input',
+    href: null,
+    inputType: 'checkbox',
+    dataTestId: null,
+    rect: { x: 20, y: 30, width: 13, height: 13 },
+    devicePixelRatio: 1,
+    ...over,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.innerHTML = '';
+});
+
+describe('translateMeta', () => {
+  it('moves a frame-local rect into top-frame coordinates', () => {
+    // The jsfiddle reproduction: the result frame sits at 981,527.
+    const moved = translateMeta(meta(), { x: 981, y: 527 });
+    expect(moved.rect).toEqual({ x: 1001, y: 557, width: 13, height: 13 });
+  });
+
+  it('moves the click point with the rect, so the marker lands on the element', () => {
+    const moved = translateMeta(meta({ clickPoint: { x: 26, y: 36 } }), { x: 981, y: 527 });
+    expect(moved.clickPoint).toEqual({ x: 1007, y: 563 });
+  });
+
+  it('leaves a top-frame capture untouched', () => {
+    const original = meta({ clickPoint: { x: 26, y: 36 } });
+    expect(translateMeta(original, NO_OFFSET)).toBe(original);
+  });
+
+  it('keeps every other field of the meta intact', () => {
+    const moved = translateMeta(meta(), { x: 10, y: 10 });
+    expect(moved).toMatchObject({ cssSelector: '#vehicle1', inputType: 'checkbox', name: 'vehicle1' });
+  });
+
+  it('does not invent a click point where there was none', () => {
+    expect(translateMeta(meta(), { x: 10, y: 10 }).clickPoint).toBeUndefined();
+  });
+});
+
+describe('contentOrigin', () => {
+  it('starts inside the frame border and padding, where the child coordinates do', () => {
+    const frame = document.createElement('iframe');
+    document.body.appendChild(frame);
+    vi.spyOn(frame, 'getBoundingClientRect').mockReturnValue({ left: 100, top: 200 } as DOMRect);
+    vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+      borderLeftWidth: '2px',
+      borderTopWidth: '4px',
+      paddingLeft: '6px',
+      paddingTop: '8px',
+    } as CSSStyleDeclaration);
+
+    expect(contentOrigin(frame)).toEqual({ x: 108, y: 212 });
+  });
+
+  it('treats missing style values as no edge rather than NaN', () => {
+    const frame = document.createElement('iframe');
+    document.body.appendChild(frame);
+    vi.spyOn(frame, 'getBoundingClientRect').mockReturnValue({ left: 50, top: 60 } as DOMRect);
+    vi.spyOn(window, 'getComputedStyle').mockReturnValue({} as CSSStyleDeclaration);
+
+    expect(contentOrigin(frame)).toEqual({ x: 50, y: 60 });
+  });
+});
+
+describe('frameOffset in the top frame', () => {
+  it('does not ask anyone, because there is nothing above it', async () => {
+    const post = vi.spyOn(window, 'postMessage');
+    await expect(frameOffset()).resolves.toEqual(NO_OFFSET);
+    expect(post).not.toHaveBeenCalled();
+  });
+});
+
+describe('frameOffset in a child frame', () => {
+  function pretendNested() {
+    const parent = { postMessage: vi.fn() } as unknown as Window;
+    Object.defineProperty(window, 'parent', { configurable: true, value: parent });
+    Object.defineProperty(window, 'top', { configurable: true, value: parent });
+    return {
+      parent,
+      restore: () => {
+        Object.defineProperty(window, 'parent', { configurable: true, value: window });
+        Object.defineProperty(window, 'top', { configurable: true, value: window });
+      },
+    };
+  }
+
+  it('takes the offset its parent reports', async () => {
+    const { parent, restore } = pretendNested();
+    const pending = frameOffset();
+
+    const request = vi.mocked(parent.postMessage).mock.calls[0][0] as { id: string };
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { channel: 'mimik-frame-offset', kind: 'response', id: request.id, x: 981, y: 527 },
+        source: parent,
+      }),
+    );
+
+    await expect(pending).resolves.toEqual({ x: 981, y: 527 });
+    restore();
+  });
+
+  it('ignores an answer that does not match the question it asked', async () => {
+    vi.useFakeTimers();
+    const { parent, restore } = pretendNested();
+    const pending = frameOffset();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { channel: 'mimik-frame-offset', kind: 'response', id: 'someone-elses', x: 999, y: 999 },
+        source: parent,
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(400);
+
+    await expect(pending).resolves.toEqual(NO_OFFSET);
+    vi.useRealTimers();
+    restore();
+  });
+
+  it('gives up rather than stalling the capture when no parent answers', async () => {
+    vi.useFakeTimers();
+    const { restore } = pretendNested();
+    const pending = frameOffset();
+
+    await vi.advanceTimersByTimeAsync(400);
+
+    await expect(pending).resolves.toEqual(NO_OFFSET);
+    vi.useRealTimers();
+    restore();
+  });
+});
+
+describe('the responder', () => {
+  function childFrame(rect: { left: number; top: number }) {
+    const frame = document.createElement('iframe');
+    document.body.appendChild(frame);
+    vi.spyOn(frame, 'getBoundingClientRect').mockReturnValue(rect as DOMRect);
+    vi.spyOn(window, 'getComputedStyle').mockReturnValue({} as CSSStyleDeclaration);
+    return frame;
+  }
+
+  function ask(source: Window | null, id = 'req-1') {
+    window.dispatchEvent(
+      new MessageEvent('message', { data: { channel: 'mimik-frame-offset', kind: 'request', id }, source }),
+    );
+  }
+
+  it('tells a child frame where it sits', async () => {
+    const stop = installFrameOffsetResponder();
+    const frame = childFrame({ left: 981, top: 527 });
+    const child = frame.contentWindow as Window;
+    const replies: unknown[] = [];
+    vi.spyOn(child, 'postMessage').mockImplementation(((msg: unknown) => replies.push(msg)) as never);
+
+    ask(child);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(replies).toEqual([{ channel: 'mimik-frame-offset', kind: 'response', id: 'req-1', x: 981, y: 527 }]);
+    stop();
+  });
+
+  it('ignores a window that is not one of its frames', async () => {
+    const stop = installFrameOffsetResponder();
+    const stranger = { postMessage: vi.fn() } as unknown as Window;
+
+    ask(stranger);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(stranger.postMessage).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it('ignores traffic that is not an offset request', async () => {
+    const stop = installFrameOffsetResponder();
+    const frame = childFrame({ left: 10, top: 10 });
+    const child = frame.contentWindow as Window;
+    const post = vi.spyOn(child, 'postMessage').mockImplementation((() => {}) as never);
+
+    window.dispatchEvent(new MessageEvent('message', { data: { hello: 'there' }, source: child }));
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { channel: 'mimik-frame-offset', kind: 'response', id: 'x' },
+        source: child,
+      }),
+    );
+    await Promise.resolve();
+
+    expect(post).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it('stops answering once torn down', async () => {
+    const stop = installFrameOffsetResponder();
+    const frame = childFrame({ left: 10, top: 10 });
+    const child = frame.contentWindow as Window;
+    const post = vi.spyOn(child, 'postMessage').mockImplementation((() => {}) as never);
+
+    stop();
+    ask(child);
+    await Promise.resolve();
+
+    expect(post).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/capture/dom/element-utils.ts
+++ b/src/core/capture/dom/element-utils.ts
@@ -29,6 +29,30 @@ export function isTextField(el: Element): boolean {
   return el instanceof HTMLTextAreaElement || (el instanceof HTMLElement && el.isContentEditable);
 }
 
+const TOGGLE_ROLES = new Set(['checkbox', 'radio', 'switch']);
+const TOGGLE_INPUT_TYPES = new Set(['checkbox', 'radio']);
+
+function isToggleInput(el: Element | null): el is HTMLInputElement {
+  return el instanceof HTMLInputElement && TOGGLE_INPUT_TYPES.has(el.type);
+}
+
+/**
+ * A click whose whole visible effect is the control flipping state: a checkbox,
+ * a radio, an aria switch, or a label that drives one. The step is worth showing
+ * settled rather than mid-flip, so these are captured after the toggle lands.
+ */
+export function isToggleControl(el: HTMLElement): boolean {
+  if (isToggleInput(el)) return true;
+
+  const role = el.getAttribute('role');
+  if (role && TOGGLE_ROLES.has(role)) return true;
+
+  const label = el instanceof HTMLLabelElement ? el : el.closest('label');
+  if (!label) return false;
+  const control = label.control ?? (label.htmlFor ? label.ownerDocument.getElementById(label.htmlFor) : null);
+  return isToggleInput(control);
+}
+
 export function isNavigatingClick(el: HTMLElement): boolean {
   const anchor = el.closest('a[href]');
   if (!anchor) return false;

--- a/src/core/capture/dom/frame-offset.ts
+++ b/src/core/capture/dom/frame-offset.ts
@@ -1,0 +1,155 @@
+import type { ElementMeta } from '@/core/guides/types';
+
+/**
+ * `getBoundingClientRect` is relative to the frame it runs in, but the
+ * screenshot is of the whole tab. A click inside an iframe therefore reports a
+ * rect that is short by the iframe's own position, and the target outline lands
+ * that far from the element it is meant to circle.
+ *
+ * A frame asks its parent where it sits; the parent adds its own offset and
+ * answers, so the sum walks all the way up to the top frame. Nothing here can
+ * reach across origins by hand — `frameElement` throws on a cross-origin parent,
+ * which is exactly the case a fiddle or an embedded widget puts us in — so it
+ * goes over postMessage, which crosses origins by design.
+ */
+
+const CHANNEL = 'mimik-frame-offset';
+const REPLY_TIMEOUT_MS = 300;
+const FRAME_SELECTOR = 'iframe, frame, embed, object';
+
+export interface FrameOffset {
+  x: number;
+  y: number;
+}
+
+export const NO_OFFSET: FrameOffset = { x: 0, y: 0 };
+
+interface OffsetRequest {
+  channel: typeof CHANNEL;
+  kind: 'request';
+  id: string;
+}
+
+interface OffsetResponse {
+  channel: typeof CHANNEL;
+  kind: 'response';
+  id: string;
+  x: number;
+  y: number;
+}
+
+function isRequest(data: unknown): data is OffsetRequest {
+  const msg = data as OffsetRequest | null;
+  return !!msg && msg.channel === CHANNEL && msg.kind === 'request' && typeof msg.id === 'string';
+}
+
+function isResponse(data: unknown): data is OffsetResponse {
+  const msg = data as OffsetResponse | null;
+  return (
+    !!msg &&
+    msg.channel === CHANNEL &&
+    msg.kind === 'response' &&
+    typeof msg.id === 'string' &&
+    Number.isFinite(msg.x) &&
+    Number.isFinite(msg.y)
+  );
+}
+
+/** The child frame element whose document sent this message, if it is ours. */
+function frameFor(source: MessageEventSource | null): Element | null {
+  if (!source) return null;
+  for (const frame of document.querySelectorAll(FRAME_SELECTOR)) {
+    if ((frame as HTMLIFrameElement).contentWindow === source) return frame;
+  }
+  return null;
+}
+
+/**
+ * Where a frame's content box starts. The child's coordinates begin inside the
+ * border and padding, not at the element's edge.
+ */
+export function contentOrigin(frame: Element): FrameOffset {
+  const rect = frame.getBoundingClientRect();
+  const style = frame.ownerDocument.defaultView?.getComputedStyle(frame);
+  const edge = (value: string | undefined) => {
+    const px = Number.parseFloat(value ?? '0');
+    return Number.isFinite(px) ? px : 0;
+  };
+  return {
+    x: rect.left + edge(style?.borderLeftWidth) + edge(style?.paddingLeft),
+    y: rect.top + edge(style?.borderTopWidth) + edge(style?.paddingTop),
+  };
+}
+
+/** This frame's position within the top frame. `{0,0}` when already on top. */
+export function frameOffset(): Promise<FrameOffset> {
+  if (window.self === window.top || !window.parent || window.parent === window.self) {
+    return Promise.resolve(NO_OFFSET);
+  }
+
+  return new Promise<FrameOffset>((resolve) => {
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    let settled = false;
+
+    const finish = (offset: FrameOffset) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      window.removeEventListener('message', onMessage);
+      resolve(offset);
+    };
+
+    const onMessage = (event: MessageEvent) => {
+      if (event.source !== window.parent || !isResponse(event.data) || event.data.id !== id) return;
+      finish({ x: event.data.x, y: event.data.y });
+    };
+
+    // A parent without the content script never answers, so fall back to the
+    // untranslated rect rather than holding the capture queue open.
+    const timer = setTimeout(() => finish(NO_OFFSET), REPLY_TIMEOUT_MS);
+
+    window.addEventListener('message', onMessage);
+    const request: OffsetRequest = { channel: CHANNEL, kind: 'request', id };
+    window.parent.postMessage(request, '*');
+  });
+}
+
+/**
+ * Answer offset requests from child frames. Only frames of this document get an
+ * answer, and the reply carries nothing but geometry.
+ */
+export function installFrameOffsetResponder(): () => void {
+  const onMessage = (event: MessageEvent) => {
+    if (!isRequest(event.data)) return;
+    const frame = frameFor(event.source);
+    if (!frame) return;
+
+    const child = event.source as Window;
+    const local = contentOrigin(frame);
+    void frameOffset().then((own) => {
+      const response: OffsetResponse = {
+        channel: CHANNEL,
+        kind: 'response',
+        id: (event.data as OffsetRequest).id,
+        x: own.x + local.x,
+        y: own.y + local.y,
+      };
+      child.postMessage(response, '*');
+    });
+  };
+
+  window.addEventListener('message', onMessage);
+  return () => window.removeEventListener('message', onMessage);
+}
+
+/** Move a frame-local rect and click point into top-frame coordinates. */
+export function translateMeta(meta: ElementMeta, offset: FrameOffset): ElementMeta {
+  if (offset.x === 0 && offset.y === 0) return meta;
+  return {
+    ...meta,
+    rect: { ...meta.rect, x: meta.rect.x + offset.x, y: meta.rect.y + offset.y },
+    clickPoint: meta.clickPoint
+      ? { x: meta.clickPoint.x + offset.x, y: meta.clickPoint.y + offset.y }
+      : meta.clickPoint,
+  };
+}

--- a/src/core/capture/events/__tests__/click-replay.test.ts
+++ b/src/core/capture/events/__tests__/click-replay.test.ts
@@ -157,3 +157,69 @@ describe('click interception', () => {
     expect(seen).toBe(1);
   });
 });
+
+describe('toggle controls', () => {
+  function placeCheckbox(): HTMLInputElement {
+    const box = place('input') as HTMLInputElement;
+    box.type = 'checkbox';
+    return box;
+  }
+
+  function recordCheckedAtCapture(box: HTMLInputElement): boolean[] {
+    const seen: boolean[] = [];
+    vi.mocked(sendMessage).mockImplementation(((name: string) => {
+      if (name === 'captureStep') seen.push(box.checked);
+      const d = deferred();
+      pending.push(d);
+      return d.promise;
+    }) as unknown as typeof sendMessage);
+    return seen;
+  }
+
+  it('screenshots a checkbox after it flips, not in the state it is leaving', async () => {
+    const box = placeCheckbox();
+    const checkedAtCapture = recordCheckedAtCapture(box);
+
+    userClick(box);
+    await settle();
+
+    expect(box.checked).toBe(true);
+    expect(checkedAtCapture).toEqual([true]);
+  });
+
+  it('screenshots an unchecking click as unchecked', async () => {
+    const box = placeCheckbox();
+    box.checked = true;
+    const checkedAtCapture = recordCheckedAtCapture(box);
+
+    userClick(box);
+    await settle();
+
+    expect(box.checked).toBe(false);
+    expect(checkedAtCapture).toEqual([false]);
+  });
+
+  it('does not hold the toggle back from the page', async () => {
+    const box = placeCheckbox();
+    let seen = 0;
+    box.addEventListener('click', () => {
+      seen += 1;
+    });
+
+    userClick(box);
+    await settle();
+
+    expect(seen).toBe(1);
+  });
+
+  it('records the toggle once, not once per replay', async () => {
+    const box = placeCheckbox();
+
+    userClick(box);
+    await settle();
+    for (const d of pending) d.resolve();
+    await settle();
+
+    expect(vi.mocked(sendMessage).mock.calls.filter((c) => c[0] === 'captureStep')).toHaveLength(1);
+  });
+});

--- a/src/core/capture/events/click-intercept.ts
+++ b/src/core/capture/events/click-intercept.ts
@@ -1,4 +1,4 @@
-import { isTextField } from '../dom/element-utils';
+import { isTextField, isToggleControl } from '../dom/element-utils';
 
 const replayed = new WeakSet<Event>();
 
@@ -10,6 +10,10 @@ export function shouldInterceptClick(target: HTMLElement, event: MouseEvent): bo
   if (!event.isTrusted || event.shiftKey) return false;
   if (target instanceof HTMLSelectElement || target instanceof HTMLOptionElement) return false;
   if (target.isContentEditable) return false;
+  // Holding a toggle back would screenshot it in the state the step is about to
+  // leave, and the replayed click lands after the capture, so the guide would
+  // show every checkbox one state behind.
+  if (isToggleControl(target)) return false;
   return !isTextField(target);
 }
 

--- a/src/core/capture/events/handlers.ts
+++ b/src/core/capture/events/handlers.ts
@@ -13,6 +13,7 @@ import {
   isTextField,
   isTooLarge,
 } from '../dom/element-utils';
+import { frameOffset, installFrameOffsetResponder, translateMeta } from '../dom/frame-offset';
 import { isReplayedClick, replayClick, replayInit, shouldInterceptClick } from './click-intercept';
 import { InputSession } from './input-session';
 
@@ -64,12 +65,14 @@ class CaptureController {
   private ring = new HoverRing(DEFAULT_TARGET_COLOR);
   private hovered: HTMLElement | null = null;
   private busy = false;
+  private stopAnsweringFrames: () => void;
 
   constructor(
     private guideId: string,
     isTopFrame: boolean,
   ) {
     this.input = new InputSession(guideId);
+    this.stopAnsweringFrames = installFrameOffsetResponder();
     this.listeners = [
       ['click', this.onClick.bind(this), ACTIVE_CAPTURE],
       ['auxclick', this.onAuxClick.bind(this), ACTIVE_CAPTURE],
@@ -103,11 +106,12 @@ class CaptureController {
   private capture(action: string, target: HTMLElement, point?: { x: number; y: number }) {
     const atEvent = freezeRect(target);
     return async () => {
-      const elementMeta = extractElementMeta(target, atEvent);
+      const base = extractElementMeta(target, atEvent);
+      const elementMeta = translateMeta(point ? { ...base, clickPoint: point } : base, await frameOffset());
       await sendMessage('captureStep', {
         guideId: this.guideId,
         action,
-        elementMeta: point ? { ...elementMeta, clickPoint: point } : elementMeta,
+        elementMeta,
         domContext: extractDOMContext(target, action),
       });
     };
@@ -315,6 +319,7 @@ class CaptureController {
     for (const [event, handler, opts] of this.listeners) {
       window.removeEventListener(event, handler, opts);
     }
+    this.stopAnsweringFrames();
     this.hovered = null;
     this.ring.dispose();
     this.queue.add(() => this.input.finalize());

--- a/src/core/capture/events/input-session.ts
+++ b/src/core/capture/events/input-session.ts
@@ -3,6 +3,7 @@ import { sendMessage } from '@/lib/messaging';
 import { extractDOMContext } from '../dom/context';
 import { extractElementMeta, type FrozenRect, freezeRect } from '../dom/element-meta';
 import { getFieldLabel, getFieldValue } from '../dom/element-utils';
+import { frameOffset, translateMeta } from '../dom/frame-offset';
 
 export class InputSession {
   stepId: string | null = null;
@@ -24,7 +25,7 @@ export class InputSession {
     const res = await sendMessage('captureStep', {
       guideId: this.guideId,
       action: 'input',
-      elementMeta: extractElementMeta(target, atEvent),
+      elementMeta: translateMeta(extractElementMeta(target, atEvent), await frameOffset()),
       domContext: extractDOMContext(target, 'input'),
     });
     if ('stepId' in res) {
@@ -53,7 +54,7 @@ export class InputSession {
     this.atEvent = undefined;
     await sendMessage('finalizeInputStep', {
       stepId,
-      elementMeta: extractElementMeta(target, atEvent),
+      elementMeta: translateMeta(extractElementMeta(target, atEvent), await frameOffset()),
       domContext: extractDOMContext(target, 'input'),
     });
   }


### PR DESCRIPTION
Closes #69.

The report describes two symptoms, and they turned out to have two unrelated causes. Both reproduce in the linked jsfiddle.

## 1. The screenshot is one state behind

`shouldInterceptClick` treats a checkbox exactly like a button:

```
preventDefault() → screenshot → replayClick()
```

For a button that ordering is the whole point — the guide should show the page as it was when you clicked, not after it navigated away. For a checkbox it is backwards, because the flip *is* the thing the step is about. The screenshot was taken while the click was still held, so the box was recorded in the state it was about to leave, and the replayed click toggled it afterwards.

Toggles now pass through uninterrupted. The native change lands before the capture queue's three-frame paint wait, so the shot shows the result.

Covered: native `checkbox` and `radio` inputs, `role="checkbox" | "radio" | "switch"` for component libraries that roll their own, and `<label>` elements that drive one — clicking a label toggles the box it points at, so holding that click back had the same effect.

## 2. The target outline is drawn off to the side

Unrelated, and broader than checkboxes: it affects **every** capture inside an iframe.

`getBoundingClientRect()` is relative to the frame it runs in. `captureVisibleTab` shoots the entire tab. Nothing translated between the two, so a click inside an iframe reported a rect short by the frame's own position. In the reproduction the fiddle's result frame sits at **x=981, y=527**, which is exactly how far off the outline was drawn:

```js
// on jsfiddle.net/h09zfav2/
[...document.querySelectorAll('iframe')][0].getBoundingClientRect()  // → x: 981, y: 527
document.querySelector('iframe[name=result]').contentDocument        // → null (cross-origin)
```

That `null` is why this cannot be solved locally: `frameElement` throws across origins, which is the normal case for embedded content. So each frame asks its parent where it sits over `postMessage`, the parent adds its own offset and answers, and the sum walks up to the top frame. A parent that never answers — no content script, restricted page — times out after 300ms and the capture proceeds untranslated, exactly as it does today.

## Testing

`pnpm lint && pnpm test && pnpm build && pnpm build:firefox` all pass. 19 new tests.

The checkbox tests drive the real `CaptureController` rather than the predicate alone, and I checked they actually reproduce the bug — reverting only the source fix and keeping the tests fails three of them, with the checkbox captured unchecked:

```
× screenshots a checkbox after it flips, not in the state it is leaving
× screenshots an unchecking click as unchecked
× does not hold the toggle back from the page
```

One existing test asserted the old behaviour (`still intercepts a checkbox, which is a click and not typing`) and is replaced, since that assertion is the bug.

## On the React Aria observation

I did not try to fix that, and this PR does not claim to. It is worth noting that `role="checkbox"` controls are no longer intercepted, and interception is a plausible cause of the interaction breaking there, so it may improve — but it should be verified separately rather than assumed, and a separate report is still the right call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q33Tvr7FGFuuxhoN7HPHmg
