### PR TITLE
fix(capture): hold a real paused state during blur mode

### DIFF
--- a/src/core/capture/__tests__/machine.test.ts
+++ b/src/core/capture/__tests__/machine.test.ts
@@ -104,6 +104,92 @@ describe('captureMachine', () => {
     expect(actor.getSnapshot().context.currentUrl).toBe('');
   });
 
+  it('transitions RECORDING → PAUSED on PAUSE_CAPTURE and keeps the recording context', () => {
+    const actor = startActor();
+    actor.send({ type: 'START_RECORDING', url: 'https://example.com' });
+    actor.send({ type: 'USER_ACTION' });
+    const before = actor.getSnapshot().context;
+
+    actor.send({ type: 'PAUSE_CAPTURE' });
+
+    const snap = actor.getSnapshot();
+    expect(snap.value).toBe(CaptureState.PAUSED);
+    expect(snap.context.currentGuideId).toBe(before.currentGuideId);
+    expect(snap.context.stepCount).toBe(1);
+    expect(snap.context.currentUrl).toBe('https://example.com');
+  });
+
+  it('transitions PAUSED → RECORDING on RESUME_CAPTURE', () => {
+    const actor = startActor();
+    actor.send({ type: 'START_RECORDING', url: 'https://example.com' });
+    actor.send({ type: 'PAUSE_CAPTURE' });
+    actor.send({ type: 'RESUME_CAPTURE' });
+    expect(actor.getSnapshot().value).toBe(CaptureState.RECORDING);
+  });
+
+  it('does not count USER_ACTION while PAUSED', () => {
+    const actor = startActor();
+    actor.send({ type: 'START_RECORDING', url: 'https://example.com' });
+    actor.send({ type: 'USER_ACTION' });
+    actor.send({ type: 'PAUSE_CAPTURE' });
+
+    actor.send({ type: 'USER_ACTION' });
+
+    expect(actor.getSnapshot().context.stepCount).toBe(1);
+  });
+
+  it('transitions PAUSED → IDLE on STOP_RECORDING and resets context', () => {
+    const actor = startActor();
+    actor.send({ type: 'START_RECORDING', url: 'https://example.com' });
+    actor.send({ type: 'PAUSE_CAPTURE' });
+
+    actor.send({ type: 'STOP_RECORDING' });
+
+    const snap = actor.getSnapshot();
+    expect(snap.value).toBe(CaptureState.IDLE);
+    expect(snap.context.currentGuideId).toBeNull();
+    expect(snap.context.stepCount).toBe(0);
+    expect(snap.context.currentUrl).toBe('');
+  });
+
+  it('updates currentUrl on URL_CHANGED while PAUSED', () => {
+    const actor = startActor();
+    actor.send({ type: 'START_RECORDING', url: 'https://example.com/page1' });
+    actor.send({ type: 'PAUSE_CAPTURE' });
+
+    actor.send({ type: 'URL_CHANGED', url: 'https://example.com/page2' });
+
+    expect(actor.getSnapshot().value).toBe(CaptureState.PAUSED);
+    expect(actor.getSnapshot().context.currentUrl).toBe('https://example.com/page2');
+  });
+
+  it('stays IDLE when PAUSE_CAPTURE is sent in IDLE state', () => {
+    const actor = startActor();
+    actor.send({ type: 'PAUSE_CAPTURE' });
+    expect(actor.getSnapshot().value).toBe(CaptureState.IDLE);
+  });
+
+  it('stays PAUSED when START_RECORDING is sent while paused', () => {
+    const actor = startActor();
+    actor.send({ type: 'START_RECORDING', url: 'https://first.com' });
+    const guideId = actor.getSnapshot().context.currentGuideId;
+    actor.send({ type: 'PAUSE_CAPTURE' });
+
+    actor.send({ type: 'START_RECORDING', url: 'https://second.com' });
+
+    const snap = actor.getSnapshot();
+    expect(snap.value).toBe(CaptureState.PAUSED);
+    expect(snap.context.currentGuideId).toBe(guideId);
+    expect(snap.context.currentUrl).toBe('https://first.com');
+  });
+
+  it('stays RECORDING when RESUME_CAPTURE is sent while already recording', () => {
+    const actor = startActor();
+    actor.send({ type: 'START_RECORDING', url: 'https://example.com' });
+    actor.send({ type: 'RESUME_CAPTURE' });
+    expect(actor.getSnapshot().value).toBe(CaptureState.RECORDING);
+  });
+
   it('generates a unique guideId for each recording session', () => {
     const actor = startActor();
 

--- a/src/core/capture/machine.ts
+++ b/src/core/capture/machine.ts
@@ -3,13 +3,20 @@ import { assign, createMachine, type SnapshotFrom } from 'xstate';
 export const CaptureState = {
   IDLE: 'IDLE',
   RECORDING: 'RECORDING',
+  PAUSED: 'PAUSED',
 } as const;
 
 export type CaptureStateValue = (typeof CaptureState)[keyof typeof CaptureState];
 
+export function hasActiveRecording(state: CaptureStateValue): boolean {
+  return state === CaptureState.RECORDING || state === CaptureState.PAUSED;
+}
+
 type CaptureEvent =
   | { type: 'START_RECORDING'; url?: string; insertTargetGuideId?: string; insertAtIndex?: number }
   | { type: 'STOP_RECORDING' }
+  | { type: 'PAUSE_CAPTURE' }
+  | { type: 'RESUME_CAPTURE' }
   | { type: 'USER_ACTION' }
   | { type: 'URL_CHANGED'; url: string };
 
@@ -65,6 +72,31 @@ export const captureMachine = createMachine({
         USER_ACTION: {
           actions: assign({
             stepCount: ({ context }) => context.stepCount + 1,
+          }),
+        },
+        URL_CHANGED: {
+          actions: assign({
+            currentUrl: ({ event }) => event.url,
+          }),
+        },
+        PAUSE_CAPTURE: {
+          target: CaptureState.PAUSED,
+        },
+      },
+    },
+    [CaptureState.PAUSED]: {
+      on: {
+        RESUME_CAPTURE: {
+          target: CaptureState.RECORDING,
+        },
+        STOP_RECORDING: {
+          target: CaptureState.IDLE,
+          actions: assign({
+            currentGuideId: null,
+            stepCount: 0,
+            currentUrl: '',
+            insertTargetGuideId: null,
+            insertAtIndex: null,
           }),
         },
         URL_CHANGED: {

--- a/src/entrypoints/background/__tests__/step-pipeline.test.ts
+++ b/src/entrypoints/background/__tests__/step-pipeline.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createActor } from 'xstate';
+import { CaptureState, captureMachine } from '@/core/capture/machine';
+
+const { addStepToGuideMock, createStepMock, localStorageGetMock, saveScreenshotMock } = vi.hoisted(() => ({
+  addStepToGuideMock: vi.fn(),
+  createStepMock: vi.fn(),
+  localStorageGetMock: vi.fn(),
+  saveScreenshotMock: vi.fn(),
+}));
+
+vi.mock('@/core/guides/service', () => ({
+  addStepToGuide: addStepToGuideMock,
+  createStep: createStepMock,
+  saveScreenshot: saveScreenshotMock,
+}));
+
+vi.mock('@/core/guides/db', () => ({ db: {} }));
+
+vi.mock('@/lib/browser-api', () => ({
+  captureVisibleTab: vi.fn(),
+  localStorage: { get: localStorageGetMock },
+}));
+
+vi.mock('../actor', () => ({ getActor: () => actor }));
+
+import type { CaptureStepData } from '@/lib/messaging';
+import { handleCaptureStep } from '../step-pipeline';
+
+const actor = createActor(captureMachine);
+actor.start();
+
+const elementMeta = {
+  tag: 'button',
+  cssSelector: 'button.pay',
+  textContent: 'Pay now',
+  ariaLabel: null,
+  placeholder: null,
+  altText: null,
+  name: null,
+  role: null,
+  href: null,
+  inputType: null,
+  dataTestId: null,
+  rect: { x: 10, y: 20, width: 80, height: 30 },
+  devicePixelRatio: 1,
+} satisfies CaptureStepData['elementMeta'];
+
+const step: CaptureStepData = {
+  guideId: 'guide-1',
+  action: 'click',
+  elementMeta,
+};
+
+function startRecording() {
+  actor.send({ type: 'START_RECORDING', url: 'https://example.com' });
+  return actor.getSnapshot().context.currentGuideId!;
+}
+
+describe('handleCaptureStep while blur mode pauses capture', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorageGetMock.mockResolvedValue({});
+    createStepMock.mockResolvedValue(undefined);
+    addStepToGuideMock.mockResolvedValue(undefined);
+    actor.send({ type: 'STOP_RECORDING' });
+  });
+
+  it('refuses steps while PAUSED, the reporter outcome', async () => {
+    startRecording();
+    actor.send({ type: 'PAUSE_CAPTURE' });
+    expect(actor.getSnapshot().value).toBe(CaptureState.PAUSED);
+
+    const res = await handleCaptureStep(step);
+
+    expect(res).toEqual({ ignored: true });
+    expect(createStepMock).not.toHaveBeenCalled();
+    expect(addStepToGuideMock).not.toHaveBeenCalled();
+  });
+
+  it('creates the step with the same wiring in RECORDING, proving the boundary is faithful', async () => {
+    const guideId = startRecording();
+
+    const res = await handleCaptureStep({ ...step, guideId });
+
+    expect(res).toEqual({ stepId: expect.any(String) });
+    expect(createStepMock).toHaveBeenCalledTimes(1);
+    expect(createStepMock.mock.calls[0][0].guideId).toBe(guideId);
+    expect(addStepToGuideMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -163,6 +163,7 @@ export default defineBackground(() => {
 
   onMessage('enterBlurMode', async () => {
     await waitUntilReady();
+    getActor().send({ type: 'PAUSE_CAPTURE' });
     await broadcastStopCapture();
     const activeTab = await getActiveTab();
     if (activeTab?.id) {
@@ -175,6 +176,7 @@ export default defineBackground(() => {
     await waitUntilReady();
     await localStorage.set({ mimikBlurMode: false });
     const actor = getActor();
+    actor.send({ type: 'RESUME_CAPTURE' });
     const guideId = actor.getSnapshot().context.currentGuideId;
     if (guideId) {
       await broadcastStartCapture(guideId);

--- a/src/entrypoints/background/navigation.ts
+++ b/src/entrypoints/background/navigation.ts
@@ -1,4 +1,4 @@
-import { CaptureState } from '@/core/capture/machine';
+import { CaptureState, type CaptureStateValue, hasActiveRecording } from '@/core/capture/machine';
 import {
   getTab,
   onHistoryStateUpdated,
@@ -17,7 +17,7 @@ export function registerNavigationListeners() {
     if (details.frameId !== 0) return;
     await waitUntilReady();
     const state = getActor().getSnapshot();
-    if (state.value === CaptureState.RECORDING) {
+    if (hasActiveRecording(state.value as CaptureStateValue)) {
       logger.debug('URL changed (navigation) →', details.url);
       getActor().send({ type: 'URL_CHANGED', url: details.url });
     }
@@ -27,7 +27,7 @@ export function registerNavigationListeners() {
     if (details.frameId !== 0) return;
     await waitUntilReady();
     const state = getActor().getSnapshot();
-    if (state.value === CaptureState.RECORDING) {
+    if (hasActiveRecording(state.value as CaptureStateValue)) {
       logger.debug('URL changed (SPA pushState) →', details.url);
       getActor().send({ type: 'URL_CHANGED', url: details.url });
     }
@@ -36,7 +36,7 @@ export function registerNavigationListeners() {
   onTabActivated(async (activeInfo) => {
     await waitUntilReady();
     const state = getActor().getSnapshot();
-    if (state.value !== CaptureState.RECORDING) return;
+    if (!hasActiveRecording(state.value as CaptureStateValue)) return;
     if (!state.context.currentGuideId) return;
 
     try {
@@ -57,7 +57,7 @@ export function registerNavigationListeners() {
     if (changeInfo.status !== 'complete') return;
     await waitUntilReady();
     const state = getActor().getSnapshot();
-    if (state.value !== CaptureState.RECORDING) return;
+    if (!hasActiveRecording(state.value as CaptureStateValue)) return;
     if (!isInjectableTab(tab)) return;
 
     try {
@@ -67,6 +67,13 @@ export function registerNavigationListeners() {
       try {
         await injectContentScript(tabId);
       } catch {}
+    }
+
+    // A full navigation while paused tears down the blur panel, the only way
+    // back to RECORDING. Offer it again so the pause does not strand the
+    // recording. START_BLUR is a no-op for subframes and on BlurManager.start.
+    if (state.value === CaptureState.PAUSED && tab.active) {
+      sendMessageToTab(tabId, { type: TabMessage.START_BLUR }).catch(() => {});
     }
   });
 }

--- a/src/ui/sidepanel/App.tsx
+++ b/src/ui/sidepanel/App.tsx
@@ -1,7 +1,7 @@
 import { Globe, Search, Settings, Video } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { browser, i18n } from '#imports';
-import { CaptureState } from '@/core/capture/machine';
+import { hasActiveRecording } from '@/core/capture/machine';
 import { isRecordableUrl } from '@/core/capture/recordable-tabs';
 import type { GuideMeSession } from '@/core/guideme/session';
 import { SESSION_KEY } from '@/core/guideme/session';
@@ -111,7 +111,7 @@ export default function App() {
       },
       onDisconnect: () => setIsAlive(false),
       onStateUpdate: (update) => {
-        if (update.state === CaptureState.RECORDING) {
+        if (hasActiveRecording(update.state)) {
           setIsRecording(true);
           const guideId = update.currentGuideId;
           if (guideId) {


### PR DESCRIPTION
> **AI model(s) used (required):** GPT-5.6 Terra and Claude Opus 5. I can explain and debug every line.

## Type of change

- [x] 🐛 Bug fix (fix)

## Description

Blur mode said capture was paused while clicks and keystrokes kept recording, so the capture machine now holds a real `PAUSED` state instead of sending a one-shot `STOP_CAPTURE` to whichever frames existed at that moment. Frames that load during blur ask the background for state and now get `PAUSED`, and steps arriving while paused are refused rather than written.

## Related issue

Closes #58

## How this was tested

- [x] `pnpm lint && pnpm test && pnpm build && pnpm build:firefox` passes locally
- [ ] Tested by hand in the browser
- [x] Tests added or updated

`pnpm test` 1122 passed, 1112 on main plus 10 new. `pnpm lint` is clean apart from a pre-existing warning in `src/core/blur/scanner.ts`, which this PR does not touch. Reverting only the source fix and keeping the tests fails the paused-transition cases and the refusal case.

## Screenshots

No UI change, this is capture state only.

## Checklist

- [x] I can explain and debug every line, without going back to an AI tool
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] Existing behaviour still works
