### PR TITLE
fix(capture): keep typed passwords out of the guide

### DIFF
--- a/src/core/capture/dom/__tests__/element-utils.test.ts
+++ b/src/core/capture/dom/__tests__/element-utils.test.ts
@@ -1,6 +1,13 @@
 // @vitest-environment happy-dom
 import { beforeEach, describe, expect, it } from 'vitest';
-import { isTooLarge } from '../element-utils';
+import {
+  eventTarget,
+  findFocusableAncestor,
+  getFieldLabel,
+  getFieldValue,
+  isSensitiveField,
+  isTooLarge,
+} from '../element-utils';
 
 const VIEWPORT_WIDTH = 1000;
 const VIEWPORT_HEIGHT = 800;
@@ -37,5 +44,154 @@ describe('isTooLarge', () => {
 
   it('reports an element just past the 0.8 width ratio', () => {
     expect(isTooLarge(makeElement(VIEWPORT_WIDTH * 0.81, 40))).toBe(true);
+  });
+});
+
+describe('getFieldValue', () => {
+  function makeInput(type: string, value: string): HTMLInputElement {
+    const el = document.createElement('input');
+    el.type = type;
+    el.value = value;
+    return el;
+  }
+
+  it('returns nothing for a password field so the typed value is never captured', () => {
+    expect(getFieldValue(makeInput('password', 'hunter2'))).toBe('');
+  });
+
+  it('still returns the value for an ordinary text field', () => {
+    expect(getFieldValue(makeInput('text', 'ada@example.com'))).toBe('ada@example.com');
+  });
+
+  it('returns the value for a contenteditable element', () => {
+    const el = document.createElement('div');
+    el.setAttribute('contenteditable', 'true');
+    el.textContent = ' notes ';
+    expect(getFieldValue(el)).toBe('notes');
+  });
+});
+
+describe('isSensitiveField', () => {
+  it('reports a password input as sensitive', () => {
+    const el = document.createElement('input');
+    el.type = 'password';
+    expect(isSensitiveField(el)).toBe(true);
+  });
+
+  it('does not report a text input as sensitive', () => {
+    const el = document.createElement('input');
+    el.type = 'text';
+    expect(isSensitiveField(el)).toBe(false);
+  });
+
+  it('does not report a textarea as sensitive', () => {
+    expect(isSensitiveField(document.createElement('textarea'))).toBe(false);
+  });
+});
+
+describe('eventTarget', () => {
+  function retargeted(host: Element, inner: Element): Event {
+    return { target: host, composedPath: () => [inner, host, document.body] } as unknown as Event;
+  }
+
+  it('returns the inner field rather than the web component wrapping it', () => {
+    const host = document.createElement('faceplate-text-input');
+    const inner = document.createElement('input');
+    inner.type = 'password';
+    expect(eventTarget(retargeted(host, inner))).toBe(inner);
+  });
+
+  it('leaves an ordinary target untouched', () => {
+    const button = document.createElement('button');
+    expect(eventTarget({ target: button, composedPath: () => [button] } as unknown as Event)).toBe(button);
+  });
+
+  it('falls back to target when composedPath is unavailable', () => {
+    const button = document.createElement('button');
+    expect(eventTarget({ target: button } as unknown as Event)).toBe(button);
+  });
+
+  it('returns null when there is no element to resolve', () => {
+    expect(eventTarget({ target: null } as unknown as Event)).toBe(null);
+  });
+});
+
+describe('findFocusableAncestor', () => {
+  function wrappedInput(type: string) {
+    const host = document.createElement('faceplate-text-input');
+    const shadow = host.attachShadow({ mode: 'open' });
+    const label = document.createElement('label');
+    const outer = document.createElement('span');
+    const decoration = document.createElement('span');
+    const input = document.createElement('input');
+    input.type = type;
+    input.id = `field-${type}`;
+    label.htmlFor = input.id;
+    outer.appendChild(decoration);
+    outer.appendChild(input);
+    label.appendChild(outer);
+    shadow.appendChild(label);
+    document.body.appendChild(host);
+    return { host, decoration, input };
+  }
+
+  it('resolves a decorative span inside a web component to the control it labels', () => {
+    const { host, decoration, input } = wrappedInput('text');
+    expect(findFocusableAncestor(decoration)).toBe(input);
+    host.remove();
+  });
+
+  it('resolves to the password control so the sensitive guard sees it', () => {
+    const { host, decoration, input } = wrappedInput('password');
+    expect(findFocusableAncestor(decoration)).toBe(input);
+    expect(isSensitiveField(findFocusableAncestor(decoration))).toBe(true);
+    host.remove();
+  });
+
+  it('still returns the nearest focusable ancestor on an ordinary page', () => {
+    const button = document.createElement('button');
+    const span = document.createElement('span');
+    button.appendChild(span);
+    document.body.appendChild(button);
+    expect(findFocusableAncestor(span)).toBe(button);
+    button.remove();
+  });
+});
+
+describe('getFieldLabel', () => {
+  function slottedField(labelText: string) {
+    const host = document.createElement('faceplate-text-input');
+    host.textContent = labelText;
+    const shadow = host.attachShadow({ mode: 'open' });
+    const label = document.createElement('label');
+    const marker = document.createElement('span');
+    marker.textContent = '*';
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.id = 'slotted-field';
+    label.htmlFor = input.id;
+    label.appendChild(marker);
+    label.appendChild(input);
+    shadow.appendChild(label);
+    document.body.appendChild(host);
+    return { host, input };
+  }
+
+  it('uses the slotted host text rather than the required marker', () => {
+    const { host, input } = slottedField('Email or username');
+    expect(getFieldLabel(input)).toBe('Email or username');
+    host.remove();
+  });
+
+  it('prefers an explicit aria-label over everything else', () => {
+    const input = document.createElement('input');
+    input.setAttribute('aria-label', 'Search');
+    expect(getFieldLabel(input)).toBe('Search');
+  });
+
+  it('falls back to the name when nothing readable is available', () => {
+    const input = document.createElement('input');
+    input.setAttribute('name', 'username');
+    expect(getFieldLabel(input)).toBe('username');
   });
 });

--- a/src/core/capture/dom/element-utils.ts
+++ b/src/core/capture/dom/element-utils.ts
@@ -3,16 +3,32 @@ export const FOCUSABLE_SELECTOR =
 
 const MAX_ELEMENT_RATIO = 0.8;
 
+function labelledControl(el: Element): HTMLElement | null {
+  const label = el.closest('label');
+  return label instanceof HTMLLabelElement && label.control instanceof HTMLElement ? label.control : null;
+}
+
+function shadowHost(el: Element): Element | null {
+  const root = el.getRootNode();
+  return root instanceof ShadowRoot && root.host instanceof Element ? root.host : null;
+}
+
 export function findFocusableAncestor(el: Element): HTMLElement {
-  let cursor: Element | null = el;
-  while (cursor) {
-    const match: Element | null = cursor.closest(FOCUSABLE_SELECTOR);
-    if (match instanceof HTMLElement) return match;
-    if (match) {
-      cursor = match.parentElement;
-      continue;
+  let scope: Element | null = el;
+  while (scope) {
+    let cursor: Element | null = scope;
+    while (cursor) {
+      const match: Element | null = cursor.closest(FOCUSABLE_SELECTOR);
+      if (match instanceof HTMLElement) return match;
+      if (match) {
+        cursor = match.parentElement;
+        continue;
+      }
+      break;
     }
-    break;
+    const control = labelledControl(scope);
+    if (control) return control;
+    scope = shadowHost(scope);
   }
   if (el instanceof HTMLElement) return el;
   let parent: Element | null = el.parentElement;
@@ -45,10 +61,42 @@ export function isMimikElement(el: Element): boolean {
   return !!el.closest('[data-mimik-ignore]');
 }
 
+export function isSensitiveField(el: Element | null): boolean {
+  return el instanceof HTMLInputElement && el.type === 'password';
+}
+
+export function eventTarget(e: Event): Element | null {
+  const inner = e.composedPath?.()[0];
+  if (inner instanceof Element) return inner;
+  return e.target instanceof Element ? e.target : null;
+}
+
 export function getFieldValue(el: HTMLElement): string {
+  if (isSensitiveField(el)) return '';
   if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) return el.value;
   if (el.isContentEditable) return el.textContent?.trim() ?? '';
   return '';
+}
+
+function meaningfulLabel(text: string | null | undefined): string | null {
+  const trimmed = text?.trim();
+  if (!trimmed || !/[a-z0-9]/i.test(trimmed)) return null;
+  return (
+    trimmed
+      .split('\n')
+      .map((line) => line.trim())
+      .find((line) => /[a-z0-9]/i.test(line)) ?? null
+  );
+}
+
+function slottedLabel(el: Element): string | null {
+  const host = shadowHost(el);
+  if (!host) return null;
+  return (
+    meaningfulLabel(host.getAttribute('aria-label')) ??
+    meaningfulLabel(host.getAttribute('label')) ??
+    meaningfulLabel((host as HTMLElement).textContent)
+  );
 }
 
 export function getFieldLabel(el: HTMLElement): string {
@@ -61,23 +109,26 @@ export function getFieldLabel(el: HTMLElement): string {
   if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
     const labels = el.labels;
     if (labels && labels.length > 0) {
-      const labelText = labels[0].innerText?.trim();
+      const labelText = meaningfulLabel(labels[0].innerText);
       if (labelText) return labelText;
     }
   }
+
+  const slotted = slottedLabel(el);
+  if (slotted) return slotted;
 
   const id = el.getAttribute('id');
   if (id) {
     const label = document.querySelector(`label[for="${CSS.escape(id)}"]`);
     if (label) {
-      const labelText = (label as HTMLElement).innerText?.trim();
+      const labelText = meaningfulLabel((label as HTMLElement).innerText);
       if (labelText) return labelText;
     }
   }
 
   const parentLabel = el.closest('label');
   if (parentLabel) {
-    const labelText = parentLabel.innerText?.trim();
+    const labelText = meaningfulLabel(parentLabel.innerText);
     if (labelText) return labelText;
   }
 

--- a/src/core/capture/events/handlers.ts
+++ b/src/core/capture/events/handlers.ts
@@ -7,9 +7,11 @@ import { sendMessage } from '@/lib/messaging';
 import { extractDOMContext } from '../dom/context';
 import { extractElementMeta, freezeRect } from '../dom/element-meta';
 import {
+  eventTarget,
   findFocusableAncestor,
   isMimikElement,
   isNavigatingClick,
+  isSensitiveField,
   isTextField,
   isTooLarge,
 } from '../dom/element-utils';
@@ -136,7 +138,7 @@ class CaptureController {
   }
 
   private onMouseOver(e: Event) {
-    const target = this.hoverTarget((e as MouseEvent).target);
+    const target = this.hoverTarget(eventTarget(e));
     if (target === this.hovered) return;
     this.hovered = target;
     if (this.busy) return;
@@ -153,7 +155,7 @@ class CaptureController {
 
   private onClick(e: Event) {
     const me = e as MouseEvent;
-    const raw = me.target;
+    const raw = eventTarget(me);
     if (!raw || !(raw instanceof Element) || isReplayedClick(me) || me.shiftKey) return;
     const target = findFocusableAncestor(raw);
     if (isMimikElement(target)) return;
@@ -210,7 +212,7 @@ class CaptureController {
   }
 
   private onAuxClick(e: Event) {
-    const raw = (e as MouseEvent).target;
+    const raw = eventTarget(e);
     if (!raw || !(raw instanceof Element)) return;
     const target = findFocusableAncestor(raw);
     if (isMimikElement(target)) return;
@@ -219,7 +221,8 @@ class CaptureController {
 
   private onKeydown(e: Event) {
     const ke = e as KeyboardEvent;
-    const target = ke.target instanceof HTMLElement ? ke.target : document.activeElement;
+    const resolved = eventTarget(ke);
+    const target = resolved instanceof HTMLElement ? resolved : document.activeElement;
     if (!target || !(target instanceof HTMLElement) || isMimikElement(target)) return;
 
     if (this.input.active && (ke.key === 'Enter' || ke.key === 'Escape')) {
@@ -227,12 +230,12 @@ class CaptureController {
       return;
     }
 
-    if (isTextField(target)) return;
+    if (isSensitiveField(target) || isTextField(target)) return;
     this.enqueue(this.capture(`keydown:${ke.key}`, target));
   }
 
   private onInput(e: Event) {
-    const target = e.target;
+    const target = eventTarget(e);
     if (!target || !(target instanceof HTMLElement)) return;
     if (
       !(
@@ -270,10 +273,8 @@ class CaptureController {
   }
 
   private onClipboard(e: Event) {
-    const target =
-      (e as ClipboardEvent).target instanceof HTMLElement
-        ? ((e as ClipboardEvent).target as HTMLElement)
-        : document.activeElement;
+    const resolved = eventTarget(e);
+    const target = resolved instanceof HTMLElement ? resolved : document.activeElement;
     if (!target || !(target instanceof HTMLElement) || isMimikElement(target)) return;
     this.enqueue(this.capture(e.type, target));
   }
@@ -283,7 +284,7 @@ class CaptureController {
     const pe = e as PointerEvent;
     this.dragStartX = pe.pageX;
     this.dragStartY = pe.pageY;
-    this.dragStartElement = pe.target instanceof Element ? pe.target : null;
+    this.dragStartElement = eventTarget(pe);
   }
 
   private onPointerUp(e: Event) {
@@ -307,8 +308,9 @@ class CaptureController {
   }
 
   private onDragEnd(e: Event) {
-    if (!e.target || !(e.target instanceof Element) || isMimikElement(e.target)) return;
-    this.enqueue(this.capture('drag', findFocusableAncestor(e.target as Element)));
+    const target = eventTarget(e);
+    if (!target || isMimikElement(target)) return;
+    this.enqueue(this.capture('drag', findFocusableAncestor(target)));
   }
 
   stop() {

--- a/src/core/capture/events/input-session.ts
+++ b/src/core/capture/events/input-session.ts
@@ -1,8 +1,9 @@
+import { i18n } from '#imports';
 import { logger } from '@/lib/logger';
 import { sendMessage } from '@/lib/messaging';
 import { extractDOMContext } from '../dom/context';
 import { extractElementMeta, type FrozenRect, freezeRect } from '../dom/element-meta';
-import { getFieldLabel, getFieldValue } from '../dom/element-utils';
+import { getFieldLabel, getFieldValue, isSensitiveField } from '../dom/element-utils';
 
 export class InputSession {
   stepId: string | null = null;
@@ -36,8 +37,15 @@ export class InputSession {
   update(target: HTMLElement) {
     if (!this.stepId) return;
     this.atEvent = freezeRect(target);
+    const label = getFieldLabel(target);
+    if (isSensitiveField(target)) {
+      sendMessage('updateInputStep', { stepId: this.stepId, description: i18n.t('steps.typeSecret') }).catch((err) =>
+        logger.warn('Failed to update input step', err),
+      );
+      return;
+    }
     const val = getFieldValue(target);
-    const desc = val ? `Type "${val}" in ${getFieldLabel(target)}` : `Clear ${getFieldLabel(target)}`;
+    const desc = val ? `Type "${val}" in ${label}` : `Clear ${label}`;
     sendMessage('updateInputStep', { stepId: this.stepId, description: desc, inputValue: val || undefined }).catch(
       (err) => logger.warn('Failed to update input step', err),
     );

--- a/src/core/guideme/content.ts
+++ b/src/core/guideme/content.ts
@@ -1,4 +1,5 @@
 import { browser } from '#imports';
+import { isSensitiveField } from '@/core/capture/dom/element-utils';
 import type { Step } from '@/core/guides/types';
 import { logger } from '@/lib/logger';
 import { sendMessage } from '@/lib/messaging';
@@ -107,6 +108,12 @@ export class GuideMeController {
 
   private setupActionDetection(step: Step, target: HTMLElement) {
     this.currentTarget = target;
+
+    if (step.action === 'input' && isSensitiveField(target)) {
+      this.clickHandler = () => this.advanceStep();
+      target.addEventListener('change', this.clickHandler, { once: true });
+      return;
+    }
 
     if (step.action === 'input' && step.inputValue) {
       if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -387,6 +387,7 @@ steps:
   click: "$1 anklicken"
   typeIntoField: "In Feld $1 eingeben $2"
   typeInto: "In $1 eingeben"
+  typeSecret: "Passwort eingeben"
   copyFrom: "Aus $1 kopieren"
   pasteInto: "In $1 einfügen"
   cutFrom: "Aus $1 ausschneiden"

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -456,6 +456,7 @@ steps:
   click: "Click $1"
   typeIntoField: "Type into $1 field $2"
   typeInto: "Type into $1"
+  typeSecret: "Type password"
   copyFrom: "Copy from $1"
   pasteInto: "Paste into $1"
   cutFrom: "Cut from $1"

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -456,6 +456,7 @@ steps:
   click: "Clic en $1"
   typeIntoField: "Escribir en el campo $1 $2"
   typeInto: "Escribir en $1"
+  typeSecret: "Escribir contraseña"
   copyFrom: "Copiar de $1"
   pasteInto: "Pegar en $1"
   cutFrom: "Cortar de $1"

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -456,6 +456,7 @@ steps:
   click: "Cliquer sur $1"
   typeIntoField: "Saisir dans le champ $1 $2"
   typeInto: "Saisir dans $1"
+  typeSecret: "Saisir le mot de passe"
   copyFrom: "Copier depuis $1"
   pasteInto: "Coller dans $1"
   cutFrom: "Couper depuis $1"

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -456,6 +456,7 @@ steps:
   click: "Clicar em $1"
   typeIntoField: "Digitar no campo $1 $2"
   typeInto: "Digitar em $1"
+  typeSecret: "Digitar senha"
   copyFrom: "Copiar de $1"
   pasteInto: "Colar em $1"
   cutFrom: "Recortar de $1"

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -456,6 +456,7 @@ steps:
   click: "点击 $1"
   typeIntoField: "在 $1 字段中输入 $2"
   typeInto: "在 $1 中输入"
+  typeSecret: "输入密码"
   copyFrom: "从 $1 复制"
   pasteInto: "粘贴到 $1"
   cutFrom: "从 $1 剪切"


### PR DESCRIPTION
Recording a login stored the literal password: in the step description, saved with the guide, replayed by Guide Me, and in every export. With a narration key set it reached the AI provider too.

Password fields now read "Type password" and store no value, and Guide Me waits for the field to change rather than filling it. The guard resolves targets through shadow roots so it sees inputs wrapped in web components.

Only `type="password"` is covered. A blurred card number or API key is still stored in full.

Closes #85
