### PR TITLE
fix(capture): keep blurred field values out of the guide

### DIFF
--- a/src/core/capture/dom/context.ts
+++ b/src/core/capture/dom/context.ts
@@ -1,3 +1,5 @@
+import { isRedactedField } from './element-utils';
+
 export interface SiblingElement {
   tag: string;
   role: string | null;
@@ -81,6 +83,7 @@ function getElementValue(el: Element): string | null {
   if (el instanceof HTMLInputElement && (el.type === 'checkbox' || el.type === 'radio'))
     return el.checked ? 'checked' : 'unchecked';
   if (el instanceof HTMLInputElement && el.type === 'password') return '***';
+  if (isRedactedField(el)) return '***';
   if (el instanceof HTMLInputElement && el.value) return `value=${el.value.slice(0, 50)}`;
   if (el instanceof HTMLTextAreaElement && el.value) return `value=${el.value.slice(0, 50)}`;
   if (el instanceof HTMLSelectElement && el.selectedOptions.length)

--- a/src/core/capture/dom/element-utils.ts
+++ b/src/core/capture/dom/element-utils.ts
@@ -65,6 +65,10 @@ export function isSensitiveField(el: Element | null): boolean {
   return el instanceof HTMLInputElement && el.type === 'password';
 }
 
+export function isRedactedField(el: Element | null): boolean {
+  return el instanceof Element && !!el.closest('[data-mimik-blur]');
+}
+
 export function eventTarget(e: Event): Element | null {
   const inner = e.composedPath?.()[0];
   if (inner instanceof Element) return inner;

--- a/src/core/capture/events/__tests__/blur-redaction.test.ts
+++ b/src/core/capture/events/__tests__/blur-redaction.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { sendMessage } from '@/lib/messaging';
+import { extractDOMContext } from '../../dom/context';
+import { isRedactedField } from '../../dom/element-utils';
+import { InputSession } from '../input-session';
+
+vi.mock('@/lib/messaging', () => ({ sendMessage: vi.fn(), onMessage: vi.fn() }));
+
+function blurredInput(value: string): HTMLInputElement {
+  const el = document.createElement('input');
+  el.type = 'text';
+  el.value = value;
+  el.setAttribute('aria-label', 'API key');
+  el.setAttribute('data-mimik-blur', 'input');
+  document.body.appendChild(el);
+  return el;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  vi.mocked(sendMessage).mockReset();
+  vi.mocked(sendMessage).mockResolvedValue({ stepId: 'step-1' } as never);
+});
+
+describe('isRedactedField', () => {
+  it('reports a field the scanner blurred', () => {
+    expect(isRedactedField(blurredInput('sk-live-1'))).toBe(true);
+  });
+
+  it('reports a field inside a manually blurred container', () => {
+    const box = document.createElement('div');
+    box.setAttribute('data-mimik-blur', 'manual');
+    const el = document.createElement('input');
+    box.appendChild(el);
+    document.body.appendChild(box);
+    expect(isRedactedField(el)).toBe(true);
+  });
+
+  it('does not report an unblurred field', () => {
+    const el = document.createElement('input');
+    document.body.appendChild(el);
+    expect(isRedactedField(el)).toBe(false);
+  });
+});
+
+describe('DOM context sent to the AI', () => {
+  it('masks a blurred value', () => {
+    const el = blurredInput('sk-live-abcdef');
+    expect(extractDOMContext(el, 'input').target.value).toBe('***');
+  });
+
+  it('still carries an unblurred value', () => {
+    const el = document.createElement('input');
+    el.type = 'text';
+    el.value = 'ada@example.com';
+    document.body.appendChild(el);
+    expect(extractDOMContext(el, 'input').target.value).toBe('value=ada@example.com');
+  });
+});
+
+describe('InputSession.update on a blurred field', () => {
+  it('stores no value and keeps it out of the description', async () => {
+    const el = blurredInput('sk-live-abcdef');
+    const session = new InputSession('guide-1');
+    await session.start(el);
+    vi.mocked(sendMessage).mockClear();
+
+    session.update(el);
+
+    const [, payload] = vi.mocked(sendMessage).mock.calls[0];
+    expect(payload).not.toHaveProperty('inputValue');
+    expect(JSON.stringify(payload)).not.toContain('sk-live-abcdef');
+  });
+
+  it('still stores the value for an unblurred field', async () => {
+    const el = document.createElement('input');
+    el.type = 'text';
+    el.value = 'ada';
+    el.setAttribute('aria-label', 'Name');
+    document.body.appendChild(el);
+    const session = new InputSession('guide-1');
+    await session.start(el);
+    vi.mocked(sendMessage).mockClear();
+
+    session.update(el);
+
+    const [, payload] = vi.mocked(sendMessage).mock.calls[0];
+    expect(payload).toMatchObject({ inputValue: 'ada' });
+  });
+});

--- a/src/core/capture/events/input-session.ts
+++ b/src/core/capture/events/input-session.ts
@@ -3,7 +3,7 @@ import { logger } from '@/lib/logger';
 import { sendMessage } from '@/lib/messaging';
 import { extractDOMContext } from '../dom/context';
 import { extractElementMeta, type FrozenRect, freezeRect } from '../dom/element-meta';
-import { getFieldLabel, getFieldValue, isSensitiveField } from '../dom/element-utils';
+import { getFieldLabel, getFieldValue, isRedactedField, isSensitiveField } from '../dom/element-utils';
 
 export class InputSession {
   stepId: string | null = null;
@@ -38,8 +38,9 @@ export class InputSession {
     if (!this.stepId) return;
     this.atEvent = freezeRect(target);
     const label = getFieldLabel(target);
-    if (isSensitiveField(target)) {
-      sendMessage('updateInputStep', { stepId: this.stepId, description: i18n.t('steps.typeSecret') }).catch((err) =>
+    if (isSensitiveField(target) || isRedactedField(target)) {
+      const description = isSensitiveField(target) ? i18n.t('steps.typeSecret') : i18n.t('steps.typeInto', [label]);
+      sendMessage('updateInputStep', { stepId: this.stepId, description }).catch((err) =>
         logger.warn('Failed to update input step', err),
       );
       return;

--- a/src/core/guideme/content.ts
+++ b/src/core/guideme/content.ts
@@ -1,5 +1,4 @@
 import { browser } from '#imports';
-import { isSensitiveField } from '@/core/capture/dom/element-utils';
 import type { Step } from '@/core/guides/types';
 import { logger } from '@/lib/logger';
 import { sendMessage } from '@/lib/messaging';
@@ -15,6 +14,7 @@ export class GuideMeController {
   private overlay: GuideMeOverlay | null = null;
   private storageListener: ((changes: Record<string, { newValue?: unknown }>) => void) | null = null;
   private clickHandler: ((e: Event) => void) | null = null;
+  private clickEvent: 'click' | 'change' = 'click';
   private currentTarget: HTMLElement | null = null;
   private currentStepIndex = -1;
   private watchTimer: ReturnType<typeof setInterval> | null = null;
@@ -109,8 +109,9 @@ export class GuideMeController {
   private setupActionDetection(step: Step, target: HTMLElement) {
     this.currentTarget = target;
 
-    if (step.action === 'input' && isSensitiveField(target)) {
+    if (step.action === 'input' && !step.inputValue) {
       this.clickHandler = () => this.advanceStep();
+      this.clickEvent = 'change';
       target.addEventListener('change', this.clickHandler, { once: true });
       return;
     }
@@ -132,6 +133,7 @@ export class GuideMeController {
     }
 
     this.clickHandler = () => this.advanceStep();
+    this.clickEvent = 'click';
     target.addEventListener('click', this.clickHandler, { once: true });
   }
 
@@ -143,7 +145,7 @@ export class GuideMeController {
 
   private removeActionDetection() {
     if (this.clickHandler && this.currentTarget) {
-      this.currentTarget.removeEventListener('click', this.clickHandler);
+      this.currentTarget.removeEventListener(this.clickEvent, this.clickHandler);
     }
     this.clickHandler = null;
     this.currentTarget = null;


### PR DESCRIPTION
Smart Blur hid a field in the screenshot and still stored what was typed into it: in the step description, saved with the guide, replayed by Guide Me, and sent to the AI provider. Blurring a card number or an API key looked like it protected it.

A blurred field now describes itself without its value and stores none, and the DOM context sends `***` as it already did for passwords. Guide Me cannot see blur at replay time, so it waits for a change on any input step with no stored value, covering passwords and cleared fields by the same rule.

The scanner only marks a field whose value already matches a preset when Smart Blur opens. Blurring an empty field and typing into it afterwards is still captured in full, tracked separately.
