### PR TITLE
feat(export): export a guide as an animated gif

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,12 +185,22 @@ Extraction walks up from the target element to find:
 | Markdown | `core/export/markdown-export.ts` | Standard MD with base64 image data URLs |
 | DOCX | `core/export/docx-export.ts` | Lazy-imported, Word-compatible |
 | Video | `core/export/video-export.ts` | WebCodecs via mediabunny (lazy), mp4/H.264 with WebM/VP9 fallback |
+| GIF | `core/export/gif-export.ts` | gifenc (lazy), same frame timeline as the video; user picks Small/Medium/Large from `GIF_SPECS` |
 
 Video frames reuse `renderScreenshot`, so the auto-crop, click-target outline, annotations and
 redactions are already baked in. Each step holds 1.5s wide, eases into a crop around the target
 over 0.73s, holds 3s close, and consecutive steps cross-dissolve over 0.33s at 30fps. Capability
 probing lives in `video-support.ts`, which must stay free of mediabunny imports because both
 export UIs load it eagerly.
+
+`composeGuideFrames` owns that timeline and hands each finished frame to a sink, so video and GIF
+draw identical frames at whatever fps the caller asks for. GIF runs it at the frame rate and size in
+`GIF_SPECS` (Small/Medium/Large, 8-15fps) because it has no interframe compression: every frame of a
+zoom or dissolve is a full frame, so 30fps at 720p runs to hundreds of megabytes. Each frame gets its
+own 128-colour palette, since one global palette lets the branded cover card tint every screenshot
+behind it. Encoding yields to the event loop every few frames to keep the tab responsive; moving it
+to a Web Worker crashed the renderer with `KILLED_BAD_MESSAGE` on the first `postMessage` and is
+unexplained.
 
 ## Tech Stack
 
@@ -205,7 +215,7 @@ export UIs load it eagerly.
 | State (UI) | Zustand |
 | Storage | Dexie.js (IndexedDB) |
 | Messaging | webext-core |
-| Export | jsPDF, docx, mediabunny (WebCodecs video), client-side HTML/Markdown |
+| Export | jsPDF, docx, mediabunny (WebCodecs video), gifenc (GIF), client-side HTML/Markdown |
 | AI (optional) | Vercel AI SDK (`ai`, `@ai-sdk/openai`, `@ai-sdk/anthropic`) |
 | Event queue | p-queue (concurrency: 1) |
 | Icons | Lucide React |

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "dexie": "^4.3.0",
     "docx": "^9.6.1",
     "fflate": "^0.8.2",
+    "gifenc": "^1.0.3",
     "jspdf": "^4.2.1",
     "lucide-react": "^0.577.0",
     "mediabunny": "^1.52.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
       fflate:
         specifier: ^0.8.2
         version: 0.8.2
+      gifenc:
+        specifier: ^1.0.3
+        version: 1.0.3
       jspdf:
         specifier: ^4.2.1
         version: 4.2.1(patch_hash=e301aed06890ed05f438774320bce683b16494cc9344453aa36d1d07f2b83e97)
@@ -2268,6 +2271,9 @@ packages:
 
   get-port-please@3.2.0:
     resolution: {integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==}
+
+  gifenc@1.0.3:
+    resolution: {integrity: sha512-xdr6AdrfGBcfzncONUOlXMBuc5wJDtOueE3c5rdG0oNgtINLD+f2iFZltrBRZYzACRbKr+mSVU/x98zv2u3jmw==}
 
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
@@ -5704,6 +5710,8 @@ snapshots:
   get-nonce@1.0.1: {}
 
   get-port-please@3.2.0: {}
+
+  gifenc@1.0.3: {}
 
   giget@2.0.0:
     dependencies:

--- a/src/core/export/__tests__/gif-export.test.ts
+++ b/src/core/export/__tests__/gif-export.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_EXPORT_OPTIONS } from '@/core/export/options';
+import type { Guide, Screenshot, Step } from '@/core/guides/types';
+
+const rec = vi.hoisted(() => ({
+  written: [] as { width: number; height: number; options: Record<string, unknown> }[],
+  finished: 0,
+}));
+
+const branding = vi.hoisted(() => ({
+  value: {
+    logo: null as null | { dataUrl: string; width: number; height: number },
+    footer: '',
+    attribution: false,
+    accent: '#4F46E5',
+    custom: false,
+  },
+}));
+
+function fakeCtx(width: number, height: number) {
+  const store: Record<string, unknown> = { filter: 'none' };
+  const base: Record<string, unknown> = {
+    canvas: { width, height },
+    measureText: (t: unknown) => ({ width: String(t).length * 8 }),
+    getImageData: () => ({ data: new Uint8ClampedArray(width * height * 4) }),
+  };
+  return new Proxy(base, {
+    has: () => true,
+    get(target, key) {
+      const k = String(key);
+      if (k in target) return target[k];
+      if (k in store) return store[k];
+      return () => undefined;
+    },
+    set(_target, key, value) {
+      store[String(key)] = value;
+      return true;
+    },
+  }) as unknown as OffscreenCanvasRenderingContext2D;
+}
+
+vi.mock('gifenc', () => ({
+  quantize: vi.fn(() => [[0, 0, 0]]),
+  applyPalette: vi.fn(() => new Uint8Array(4)),
+  GIFEncoder: () => ({
+    writeFrame: (_i: Uint8Array, width: number, height: number, options: Record<string, unknown> = {}) => {
+      rec.written.push({ width, height, options });
+    },
+    finish: () => {
+      rec.finished += 1;
+    },
+    bytes: () => new Uint8Array([0x47, 0x49, 0x46]),
+  }),
+}));
+
+vi.mock('@/core/screenshot/render', () => ({
+  renderScreenshot: vi.fn(async () => new Blob(['webp'])),
+}));
+
+vi.mock('@/core/export/branding', async () => {
+  const actual = await vi.importActual<typeof import('@/core/export/branding')>('@/core/export/branding');
+  return { ...actual, loadBranding: vi.fn(async () => branding.value) };
+});
+
+const { exportGuideAsGif, gifDelayMs } = await import('@/core/export/gif-export');
+const { GIF_SPECS } = await import('@/core/export/options');
+const SPEC = GIF_SPECS.medium;
+const { totalStepFrames } = await import('@/core/export/video-export');
+
+const guide: Guide = {
+  id: 'g1',
+  title: 'Reset your password',
+  createdAt: new Date('2026-03-04T10:00:00Z').getTime(),
+  updatedAt: new Date('2026-03-04T10:00:00Z').getTime(),
+  stepIds: [],
+  starred: false,
+  deletedAt: null,
+};
+
+function makeStep(i: number, overrides: Partial<Step> = {}): Step {
+  return {
+    id: `s${i}`,
+    guideId: 'g1',
+    index: i,
+    description: `Click the button labelled ${i}`,
+    action: 'click',
+    url: 'https://example.com/settings',
+    timestamp: guide.createdAt,
+    screenshotId: `shot-s${i}`,
+    ...overrides,
+  };
+}
+
+function makeShot(stepId: string): Screenshot {
+  return {
+    id: `shot-${stepId}`,
+    stepId,
+    blob: new Blob(['raw']),
+    mimeType: 'image/webp',
+    width: 1280,
+    height: 720,
+    bounds: { x: 100, y: 200, width: 120, height: 40 },
+    pixelRatio: 1,
+  };
+}
+
+function shotsFor(steps: Step[]): Map<string, Screenshot> {
+  return new Map(steps.filter((s) => !s.blockType).map((s) => [s.id, makeShot(s.id)]));
+}
+
+const opts = (o = {}) => ({ ...DEFAULT_EXPORT_OPTIONS, cover: false, ...o });
+
+beforeEach(() => {
+  rec.written = [];
+  rec.finished = 0;
+  branding.value = { logo: null, footer: '', attribution: false, accent: '#4F46E5', custom: false };
+
+  class FakeOffscreen {
+    constructor(
+      public width: number,
+      public height: number,
+    ) {}
+    getContext() {
+      return fakeCtx(this.width, this.height);
+    }
+  }
+  vi.stubGlobal('OffscreenCanvas', FakeOffscreen);
+  vi.stubGlobal(
+    'createImageBitmap',
+    vi.fn(async () => ({ width: 1280, height: 720, close: () => undefined })),
+  );
+});
+
+describe('gifDelayMs', () => {
+  it('rounds a frame duration to GIF centisecond granularity', () => {
+    expect(gifDelayMs(1 / 30)).toBe(30);
+    expect(gifDelayMs(3)).toBe(3000);
+  });
+
+  it('never emits a delay browsers would clamp away', () => {
+    expect(gifDelayMs(0)).toBe(20);
+    expect(gifDelayMs(0.001)).toBe(20);
+  });
+});
+
+describe('exportGuideAsGif', () => {
+  it('writes the video frame timeline at the GIF frame rate', async () => {
+    const steps = [makeStep(0), makeStep(1)];
+    await exportGuideAsGif(guide, steps, shotsFor(steps), opts());
+
+    expect(rec.written).toHaveLength(totalStepFrames(2, SPEC.fps));
+    expect(rec.written.every((f) => f.width === SPEC.width && f.height === SPEC.height)).toBe(true);
+    expect(rec.finished).toBe(1);
+  });
+
+  it('gives every frame its own palette so a branded cover cannot tint the rest', async () => {
+    const steps = [makeStep(0)];
+    const { quantize } = await import('gifenc');
+    vi.mocked(quantize).mockClear();
+
+    await exportGuideAsGif(guide, steps, shotsFor(steps), opts({ cover: true }));
+
+    expect(quantize).toHaveBeenCalledTimes(totalStepFrames(1, SPEC.fps) + 2);
+    expect(rec.written.every((f) => f.options.palette !== undefined)).toBe(true);
+  });
+
+  it('loops forever', async () => {
+    const steps = [makeStep(0)];
+    await exportGuideAsGif(guide, steps, shotsFor(steps), opts());
+    expect(rec.written[0].options).toMatchObject({ repeat: 0 });
+  });
+
+  it('adds the cover and end cards when asked', async () => {
+    const steps = [makeStep(0)];
+    await exportGuideAsGif(guide, steps, shotsFor(steps), opts({ cover: true }));
+
+    expect(rec.written).toHaveLength(totalStepFrames(1, SPEC.fps) + 2);
+  });
+
+  it('skips a step that has neither a screenshot nor a block', async () => {
+    const steps = [makeStep(0), makeStep(1)];
+    const screenshots = shotsFor(steps);
+    screenshots.delete('s1');
+
+    await exportGuideAsGif(guide, steps, screenshots, opts());
+    expect(rec.written).toHaveLength(totalStepFrames(1, SPEC.fps));
+  });
+
+  it('reports progress up to the frame total', async () => {
+    const steps = [makeStep(0)];
+    const onProgress = vi.fn();
+
+    await exportGuideAsGif(guide, steps, shotsFor(steps), opts(), { onProgress });
+    const total = totalStepFrames(1, SPEC.fps);
+    expect(onProgress).toHaveBeenCalledTimes(total);
+    expect(onProgress).toHaveBeenLastCalledWith(total, total);
+  });
+
+  it('refuses a guide with nothing to draw', async () => {
+    await expect(exportGuideAsGif(guide, [makeStep(0)], new Map(), opts())).rejects.toThrow(/no screenshots/);
+  });
+
+  it('aborts without encoding anything', async () => {
+    const steps = [makeStep(0)];
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      exportGuideAsGif(guide, steps, shotsFor(steps), opts(), { signal: controller.signal }),
+    ).rejects.toThrow(DOMException);
+    expect(rec.written).toHaveLength(0);
+  });
+});

--- a/src/core/export/__tests__/options.test.ts
+++ b/src/core/export/__tests__/options.test.ts
@@ -29,7 +29,12 @@ describe('normaliseExportOptions', () => {
       imageScale: 'small',
       stepDescriptions: DEFAULT_EXPORT_OPTIONS.stepDescriptions,
       resolution: DEFAULT_EXPORT_OPTIONS.resolution,
+      gifQuality: DEFAULT_EXPORT_OPTIONS.gifQuality,
     });
+  });
+
+  it('rejects an unknown gif quality so the encoder never gets bogus dimensions', () => {
+    expect(normaliseExportOptions({ gifQuality: 'huge' }).gifQuality).toBe(DEFAULT_EXPORT_OPTIONS.gifQuality);
   });
 
   it('rejects an unknown resolution so the encoder never gets bogus dimensions', () => {

--- a/src/core/export/gif-export.ts
+++ b/src/core/export/gif-export.ts
@@ -1,0 +1,101 @@
+import { loadBranding } from '@/core/export/branding';
+import { type ExportOptions, GIF_SPECS, type GifSpec, loadExportOptions } from '@/core/export/options';
+import { isBlock } from '@/core/guides/blocks';
+import type { Guide, Screenshot, Step } from '@/core/guides/types';
+import { logger } from '@/lib/logger';
+import { composeGuideFrames, totalStepFrames } from './video-export';
+import { FRAME_HEIGHT, FRAME_WIDTH } from './video-support';
+
+export const GIF_MAX_COLORS = 128;
+export const GIF_MIN_DELAY_MS = 20;
+export const GIF_YIELD_EVERY = 8;
+
+export type GifOptions = Pick<ExportOptions, 'cover' | 'stepDescriptions' | 'gifQuality'>;
+
+export interface GifExportControls {
+  onProgress?: (encoded: number, frames: number) => void;
+  signal?: AbortSignal;
+}
+
+export interface GifExportResult {
+  blob: Blob;
+  extension: 'gif';
+}
+
+export function gifDelayMs(durationSec: number): number {
+  return Math.max(GIF_MIN_DELAY_MS, Math.round(durationSec * 100) * 10);
+}
+
+export function gifFrameCount(
+  steps: Step[],
+  screenshots: Map<string, Screenshot>,
+  cover: boolean,
+  spec: GifSpec,
+): number {
+  const frames = steps.filter((step) => isBlock(step) || screenshots.has(step.id));
+  return frames.length === 0 ? 0 : totalStepFrames(frames.length, spec.fps) + (cover ? 2 : 0);
+}
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+export async function exportGuideAsGif(
+  guide: Guide,
+  steps: Step[],
+  screenshots: Map<string, Screenshot>,
+  exportOptions?: GifOptions,
+  controls: GifExportControls = {},
+): Promise<GifExportResult> {
+  const frames = steps.filter((step) => isBlock(step) || screenshots.has(step.id));
+  if (frames.length === 0) throw new Error('This guide has no screenshots to turn into a GIF');
+
+  const { GIFEncoder, applyPalette, quantize } = await import('gifenc');
+
+  const [brand, options] = await Promise.all([
+    loadBranding(),
+    exportOptions ? Promise.resolve(exportOptions) : loadExportOptions(),
+  ]);
+
+  const spec = GIF_SPECS[options.gifQuality] ?? GIF_SPECS.medium;
+  const canvas = new OffscreenCanvas(spec.width, spec.height);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas 2D context unavailable');
+  ctx.scale(spec.width / FRAME_WIDTH, spec.height / FRAME_HEIGHT);
+
+  const total = gifFrameCount(steps, screenshots, Boolean(options.cover), spec);
+  logger.info('[gif] encoding', { steps: frames.length, frames: total, ...spec });
+
+  const gif = GIFEncoder();
+  let written = 0;
+
+  await composeGuideFrames(
+    guide,
+    frames,
+    screenshots,
+    options,
+    brand,
+    ctx,
+    { width: spec.width, height: spec.height },
+    async (_at, duration) => {
+      const { data } = ctx.getImageData(0, 0, spec.width, spec.height);
+      const palette = quantize(data, GIF_MAX_COLORS);
+      gif.writeFrame(applyPalette(data, palette), spec.width, spec.height, {
+        palette,
+        delay: gifDelayMs(duration),
+        ...(written === 0 ? { repeat: 0 } : {}),
+      });
+      written += 1;
+      if (written % GIF_YIELD_EVERY === 0) await yieldToEventLoop();
+    },
+    controls,
+    spec.fps,
+  );
+
+  gif.finish();
+  const blob = new Blob([gif.bytes() as BlobPart], { type: 'image/gif' });
+  logger.info('[gif] encoded', { frames: written, bytes: blob.size });
+  return { blob, extension: 'gif' };
+}

--- a/src/core/export/options.ts
+++ b/src/core/export/options.ts
@@ -12,6 +12,22 @@ export type VideoResolution = '720p' | '1080p';
 
 export const VIDEO_RESOLUTIONS: VideoResolution[] = ['720p', '1080p'];
 
+export type GifQuality = 'low' | 'medium' | 'high';
+
+export interface GifSpec {
+  width: number;
+  height: number;
+  fps: number;
+}
+
+export const GIF_SPECS: Record<GifQuality, GifSpec> = {
+  low: { width: 320, height: 180, fps: 8 },
+  medium: { width: 480, height: 270, fps: 10 },
+  high: { width: 640, height: 360, fps: 15 },
+};
+
+export const GIF_QUALITIES: GifQuality[] = ['low', 'medium', 'high'];
+
 export interface ExportOptions {
   cover: boolean;
   screenshots: boolean;
@@ -19,6 +35,7 @@ export interface ExportOptions {
   imageScale: ImageScale;
   stepDescriptions: boolean;
   resolution: VideoResolution;
+  gifQuality: GifQuality;
 }
 
 export const DEFAULT_EXPORT_OPTIONS: ExportOptions = {
@@ -28,6 +45,7 @@ export const DEFAULT_EXPORT_OPTIONS: ExportOptions = {
   imageScale: 'medium',
   stepDescriptions: true,
   resolution: '720p',
+  gifQuality: 'medium',
 };
 
 const bool = (value: unknown, fallback: boolean) => (typeof value === 'boolean' ? value : fallback);
@@ -45,6 +63,7 @@ export function normaliseExportOptions(value: unknown): ExportOptions {
     resolution: VIDEO_RESOLUTIONS.includes(raw.resolution as VideoResolution)
       ? (raw.resolution as VideoResolution)
       : DEFAULT_EXPORT_OPTIONS.resolution,
+    gifQuality: raw.gifQuality && raw.gifQuality in GIF_SPECS ? raw.gifQuality : DEFAULT_EXPORT_OPTIONS.gifQuality,
   };
 }
 

--- a/src/core/export/video-export.ts
+++ b/src/core/export/video-export.ts
@@ -544,7 +544,7 @@ function drawCursor(ctx: Ctx, x: number, y: number, scale: number) {
   ctx.restore();
 }
 
-function drawStepFrame(ctx: Ctx, layer: StepLayer, frame: number, device: Size) {
+function drawStepFrame(ctx: Ctx, layer: StepLayer, frame: number, device: Size, fps = FPS) {
   if (layer.kind === 'block') {
     drawBlockFrame(ctx, layer);
     return;
@@ -557,7 +557,7 @@ function drawStepFrame(ctx: Ctx, layer: StepLayer, frame: number, device: Size) 
       ? reserveTooltip(layer.target, tooltipBand(box), layer.bitmap, fit.height, device.width, device.height)
       : layer.target;
 
-  const crop = zoomCrop(layer.bitmap, framed, easeInOut(zoomProgress(frame)), device.width, device.height);
+  const crop = zoomCrop(layer.bitmap, framed, easeInOut(zoomProgress(frame, fps)), device.width, device.height);
   ctx.drawImage(layer.bitmap, crop.x, crop.y, crop.width, crop.height, fit.x, fit.y, fit.width, fit.height);
 
   const scale = fit.width / crop.width;
@@ -571,10 +571,10 @@ function drawStepFrame(ctx: Ctx, layer: StepLayer, frame: number, device: Size) 
       }
     : { x: FRAME_WIDTH / 2, y: FRAME_HEIGHT, width: 0, height: 0 };
 
-  const ringIn = ringProgress(frame);
+  const ringIn = ringProgress(frame, fps);
   if (layer.target && layer.ring && ringIn > 0) drawRing(ctx, anchor, layer.ring, ringIn);
 
-  const tipIn = tooltipProgress(frame);
+  const tipIn = tooltipProgress(frame, fps);
   if (box && tipIn > 0) {
     ctx.save();
     ctx.globalAlpha *= tipIn;
@@ -584,7 +584,7 @@ function drawStepFrame(ctx: Ctx, layer: StepLayer, frame: number, device: Size) 
   }
 
   if (layer.target) {
-    const travel = easeInOut(cursorProgress(frame));
+    const travel = easeInOut(cursorProgress(frame, fps));
     const tip = project(
       layer.from.x + (layer.target.x + layer.target.width * 0.42 - layer.from.x) * travel,
       layer.from.y + (layer.target.y + layer.target.height * 0.55 - layer.from.y) * travel,
@@ -657,6 +657,8 @@ async function drawCardFrame(ctx: Ctx, guide: Guide, steps: Step[], brand: Brand
 
 export type VideoOptions = Pick<ExportOptions, 'cover' | 'stepDescriptions' | 'resolution'>;
 
+export type FrameOptions = Pick<ExportOptions, 'cover' | 'stepDescriptions'>;
+
 export interface VideoExportControls {
   onProgress?: (done: number, total: number) => void;
   signal?: AbortSignal;
@@ -702,57 +704,24 @@ export function videoChapters(frames: Step[], cover: boolean, fps = FPS): VideoC
   }));
 }
 
-export async function exportGuideAsVideo(
+export type FrameSink = (timeSec: number, durationSec: number) => Promise<void>;
+
+export async function composeGuideFrames(
   guide: Guide,
-  steps: Step[],
+  frames: Step[],
   screenshots: Map<string, Screenshot>,
-  exportOptions?: VideoOptions,
-  controls: VideoExportControls = {},
-): Promise<VideoExportResult> {
-  const frames = steps.filter((step) => isBlock(step) || screenshots.has(step.id));
-  if (frames.length === 0) throw new Error('This guide has no screenshots to turn into a video');
-
-  const { BufferTarget, CanvasSource, Mp4OutputFormat, Output, QUALITY_HIGH, WebMOutputFormat } = await import(
-    'mediabunny'
-  );
-
-  const [brand, options] = await Promise.all([
-    loadBranding(),
-    exportOptions ? Promise.resolve(exportOptions) : loadExportOptions(),
-  ]);
-
-  const requested = RESOLUTION_SPECS[options.resolution] ? options.resolution : '720p';
-  const preferred = await pickContainer(requested);
-  const resolution = preferred ? requested : '720p';
-  const container = preferred ?? (await pickContainer('720p'));
-  if (!container) throw new Error('This browser cannot encode video');
-  const mp4 = container === 'mp4';
-  const spec = RESOLUTION_SPECS[resolution];
-
-  const canvas = document.createElement('canvas');
-  canvas.width = spec.width;
-  canvas.height = spec.height;
-  const ctx = canvas.getContext('2d');
-  if (!ctx) throw new Error('Canvas 2D context unavailable');
-  ctx.scale(spec.width / FRAME_WIDTH, spec.height / FRAME_HEIGHT);
-  const device = { width: spec.width, height: spec.height };
-
-  const output = new Output({
-    format: mp4 ? new Mp4OutputFormat() : new WebMOutputFormat(),
-    target: new BufferTarget(),
-  });
-  const source = new CanvasSource(canvas, {
-    codec: mp4 ? 'avc' : 'vp9',
-    quality: QUALITY_HIGH,
-    keyFrameInterval: KEY_FRAME_INTERVAL_SEC,
-  });
-  output.addVideoTrack(source);
-  await output.start();
-
-  const span = stepFrames();
-  const overlap = overlapFrames();
+  options: FrameOptions,
+  brand: Branding,
+  ctx: Ctx,
+  device: Size,
+  sink: FrameSink,
+  controls: { onProgress?: (done: number, total: number) => void; signal?: AbortSignal } = {},
+  fps = FPS,
+): Promise<void> {
+  const span = stepFrames(fps);
+  const overlap = overlapFrames(fps);
   const stride = span - overlap;
-  const stepTotal = totalStepFrames(frames.length);
+  const stepTotal = totalStepFrames(frames.length, fps);
   const total = stepTotal + (options.cover ? 2 : 0);
   const loaded = new Map<number, StepLayer>();
   const { onProgress, signal } = controls;
@@ -804,7 +773,7 @@ export async function exportGuideAsVideo(
     if (options.cover) {
       abortIfRequested();
       await drawCardFrame(ctx, guide, cards, brand, i18n.t('export.guideLabel'));
-      await source.add(0, COVER_SECONDS);
+      await sink(0, COVER_SECONDS);
       done += 1;
       onProgress?.(done, total);
     }
@@ -825,15 +794,15 @@ export async function exportGuideAsVideo(
       ctx.fillRect(0, 0, FRAME_WIDTH, FRAME_HEIGHT);
 
       if (previous) {
-        drawStepFrame(ctx, previous, local + stride, device);
+        drawStepFrame(ctx, previous, local + stride, device, fps);
         ctx.globalAlpha = (local + 1) / overlap;
-        drawStepFrame(ctx, current, local, device);
+        drawStepFrame(ctx, current, local, device, fps);
         ctx.globalAlpha = 1;
       } else {
-        drawStepFrame(ctx, current, local, device);
+        drawStepFrame(ctx, current, local, device, fps);
       }
 
-      await source.add(offset + frame / FPS, 1 / FPS);
+      await sink(offset + frame / fps, 1 / fps);
       done += 1;
       onProgress?.(done, total);
     }
@@ -841,18 +810,79 @@ export async function exportGuideAsVideo(
     if (options.cover) {
       abortIfRequested();
       await drawCardFrame(ctx, guide, cards, brand, i18n.t('export.endLabel'));
-      await source.add(offset + stepTotal / FPS, COVER_SECONDS);
+      await sink(offset + stepTotal / fps, COVER_SECONDS);
       done += 1;
       onProgress?.(done, total);
     }
+  } finally {
+    for (const layer of loaded.values()) releaseLayer(layer);
+    loaded.clear();
+  }
+}
 
+export async function exportGuideAsVideo(
+  guide: Guide,
+  steps: Step[],
+  screenshots: Map<string, Screenshot>,
+  exportOptions?: VideoOptions,
+  controls: VideoExportControls = {},
+): Promise<VideoExportResult> {
+  const frames = steps.filter((step) => isBlock(step) || screenshots.has(step.id));
+  if (frames.length === 0) throw new Error('This guide has no screenshots to turn into a video');
+
+  const { BufferTarget, CanvasSource, Mp4OutputFormat, Output, QUALITY_HIGH, WebMOutputFormat } = await import(
+    'mediabunny'
+  );
+
+  const [brand, options] = await Promise.all([
+    loadBranding(),
+    exportOptions ? Promise.resolve(exportOptions) : loadExportOptions(),
+  ]);
+
+  const requested = RESOLUTION_SPECS[options.resolution] ? options.resolution : '720p';
+  const preferred = await pickContainer(requested);
+  const resolution = preferred ? requested : '720p';
+  const container = preferred ?? (await pickContainer('720p'));
+  if (!container) throw new Error('This browser cannot encode video');
+  const mp4 = container === 'mp4';
+  const spec = RESOLUTION_SPECS[resolution];
+
+  const canvas = document.createElement('canvas');
+  canvas.width = spec.width;
+  canvas.height = spec.height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas 2D context unavailable');
+  ctx.scale(spec.width / FRAME_WIDTH, spec.height / FRAME_HEIGHT);
+  const device = { width: spec.width, height: spec.height };
+
+  const output = new Output({
+    format: mp4 ? new Mp4OutputFormat() : new WebMOutputFormat(),
+    target: new BufferTarget(),
+  });
+  const source = new CanvasSource(canvas, {
+    codec: mp4 ? 'avc' : 'vp9',
+    quality: QUALITY_HIGH,
+    keyFrameInterval: KEY_FRAME_INTERVAL_SEC,
+  });
+  output.addVideoTrack(source);
+  await output.start();
+
+  try {
+    await composeGuideFrames(
+      guide,
+      frames,
+      screenshots,
+      options,
+      brand,
+      ctx,
+      device,
+      (at, dur) => source.add(at, dur),
+      controls,
+    );
     await output.finalize();
   } catch (error) {
     await output.cancel();
     throw error;
-  } finally {
-    for (const layer of loaded.values()) releaseLayer(layer);
-    loaded.clear();
   }
 
   const buffer = output.target.buffer;

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -294,6 +294,10 @@ exportPreview:
   stepDescriptions: "Schritttexte"
   stepDescriptionsHint: "Den Schritttext in jedes Videobild einzeichnen"
   resolution: "Videoqualität"
+  gifQuality: "GIF-Qualität"
+  gif_low: "Niedrig"
+  gif_medium: "Mittel"
+  gif_high: "Hoch"
   res_720p: "720p"
   res_1080p: "1080p"
   title: "Export-Vorschau"
@@ -327,6 +331,7 @@ exportMenu:
   html: HTML
   markdown: Markdown
   pdf: PDF
+  gif: GIF
   video: Video
   cancelProgress: "Abbrechen · $1 %"
 

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -363,6 +363,10 @@ exportPreview:
   stepDescriptions: "Step captions"
   stepDescriptionsHint: "Draw the step text onto each video frame"
   resolution: "Video quality"
+  gifQuality: "GIF quality"
+  gif_low: "Low"
+  gif_medium: "Medium"
+  gif_high: "High"
   res_720p: "720p"
   res_1080p: "1080p"
   title: "Export preview"
@@ -396,6 +400,7 @@ exportMenu:
   html: HTML
   markdown: Markdown
   pdf: PDF
+  gif: GIF
   video: Video
   cancelProgress: "Cancel · $1%"
 

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -363,6 +363,10 @@ exportPreview:
   stepDescriptions: "Textos de paso"
   stepDescriptionsHint: "Dibujar el texto del paso en cada fotograma"
   resolution: "Calidad de vídeo"
+  gifQuality: "Calidad del GIF"
+  gif_low: "Baja"
+  gif_medium: "Media"
+  gif_high: "Alta"
   res_720p: "720p"
   res_1080p: "1080p"
   title: "Vista previa de exportación"
@@ -396,6 +400,7 @@ exportMenu:
   html: HTML
   markdown: Markdown
   pdf: PDF
+  gif: GIF
   video: Vídeo
   cancelProgress: "Cancelar · $1 %"
 

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -363,6 +363,10 @@ exportPreview:
   stepDescriptions: "Textes d'étape"
   stepDescriptionsHint: "Incruster le texte de l'étape sur chaque image"
   resolution: "Qualité vidéo"
+  gifQuality: "Qualité du GIF"
+  gif_low: "Basse"
+  gif_medium: "Moyenne"
+  gif_high: "Haute"
   res_720p: "720p"
   res_1080p: "1080p"
   title: "Aperçu de l’export"
@@ -396,6 +400,7 @@ exportMenu:
   html: HTML
   markdown: Markdown
   pdf: PDF
+  gif: GIF
   video: Vidéo
   cancelProgress: "Annuler · $1 %"
 

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -363,6 +363,10 @@ exportPreview:
   stepDescriptions: "Textos da etapa"
   stepDescriptionsHint: "Desenhar o texto da etapa em cada quadro"
   resolution: "Qualidade do vídeo"
+  gifQuality: "Qualidade do GIF"
+  gif_low: "Baixa"
+  gif_medium: "Média"
+  gif_high: "Alta"
   res_720p: "720p"
   res_1080p: "1080p"
   title: "Prévia da exportação"
@@ -396,6 +400,7 @@ exportMenu:
   html: HTML
   markdown: Markdown
   pdf: PDF
+  gif: GIF
   video: Vídeo
   cancelProgress: "Cancelar · $1%"
 

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -363,6 +363,10 @@ exportPreview:
   stepDescriptions: "步骤说明"
   stepDescriptionsHint: "将步骤文字绘制到每一帧视频中"
   resolution: "视频质量"
+  gifQuality: "GIF 质量"
+  gif_low: "低"
+  gif_medium: "中"
+  gif_high: "高"
   res_720p: "720p"
   res_1080p: "1080p"
   title: "导出预览"
@@ -396,6 +400,7 @@ exportMenu:
   html: HTML
   markdown: Markdown
   pdf: PDF
+  gif: GIF
   video: 视频
   cancelProgress: "取消 · $1%"
 

--- a/src/types/gifenc.d.ts
+++ b/src/types/gifenc.d.ts
@@ -1,0 +1,32 @@
+declare module 'gifenc' {
+  export type Palette = number[][];
+
+  export interface WriteFrameOptions {
+    palette?: Palette;
+    delay?: number;
+    transparent?: boolean;
+    dispose?: number;
+    first?: boolean;
+    repeat?: number;
+  }
+
+  export interface Encoder {
+    writeFrame(index: Uint8Array, width: number, height: number, options?: WriteFrameOptions): void;
+    finish(): void;
+    bytes(): Uint8Array;
+  }
+
+  export function GIFEncoder(): Encoder;
+
+  export function quantize(
+    rgba: Uint8Array | Uint8ClampedArray,
+    maxColors: number,
+    options?: { format?: 'rgb565' | 'rgb444' | 'rgba4444'; oneBitAlpha?: boolean; clearAlpha?: boolean },
+  ): Palette;
+
+  export function applyPalette(
+    rgba: Uint8Array | Uint8ClampedArray,
+    palette: Palette,
+    format?: 'rgb565' | 'rgb444' | 'rgba4444',
+  ): Uint8Array;
+}

--- a/src/ui/fullview/ExportPreviewModal.tsx
+++ b/src/ui/fullview/ExportPreviewModal.tsx
@@ -1,4 +1,4 @@
-import { FileCode, FileDown, FileText, Loader2, Video } from 'lucide-react';
+import { FileCode, FileDown, FileImage, FileText, Loader2, Video } from 'lucide-react';
 import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import { i18n } from '#imports';
 import { downloadBlob, downloadText, safeFilename } from '@/core/export/download';
@@ -6,6 +6,7 @@ import { exportGuideAsHTML } from '@/core/export/html-export';
 import {
   DEFAULT_EXPORT_OPTIONS,
   type ExportOptions,
+  GIF_QUALITIES,
   type ImageScale,
   loadExportOptions,
   saveExportOptions,
@@ -32,7 +33,7 @@ interface ExportPreviewModalProps {
   screenshots: Map<string, Screenshot>;
 }
 
-type ExportFormat = 'docx' | 'html' | 'markdown' | 'pdf' | 'video';
+type ExportFormat = 'docx' | 'gif' | 'html' | 'markdown' | 'pdf' | 'video';
 type PreviewMode = 'document' | 'video';
 
 export default function ExportPreviewModal({ open, onOpenChange, guide, steps, screenshots }: ExportPreviewModalProps) {
@@ -142,6 +143,16 @@ export default function ExportPreviewModal({ open, onOpenChange, guide, steps, s
       } else if (format === 'docx') {
         const { exportGuideAsDOCX } = await import('@/core/export/docx-export');
         downloadBlob(await exportGuideAsDOCX(guide, steps, screenshots, options), safeFilename(guide.title, 'docx'));
+      } else if (format === 'gif') {
+        const controller = new AbortController();
+        downloadAbort.current = controller;
+        setDownloadProgress(0);
+        const { exportGuideAsGif } = await import('@/core/export/gif-export');
+        const { blob, extension } = await exportGuideAsGif(guide, steps, screenshots, options, {
+          signal: controller.signal,
+          onProgress: (encoded, frames) => setDownloadProgress(frames > 0 ? encoded / frames : 0),
+        });
+        downloadBlob(blob, safeFilename(guide.title, extension));
       } else if (format === 'video') {
         const controller = new AbortController();
         downloadAbort.current = controller;
@@ -186,6 +197,7 @@ export default function ExportPreviewModal({ open, onOpenChange, guide, steps, s
     { key: 'docx', icon: FileText, label: i18n.t('exportMenu.docx') },
     { key: 'html', icon: FileCode, label: i18n.t('exportMenu.html') },
     { key: 'markdown', icon: FileText, label: i18n.t('exportMenu.markdown') },
+    { key: 'gif', icon: FileImage, label: i18n.t('exportMenu.gif') },
     ...(videoSupported ? [{ key: 'video' as const, icon: Video, label: i18n.t('exportMenu.video') }] : []),
   ];
 
@@ -269,9 +281,29 @@ export default function ExportPreviewModal({ open, onOpenChange, guide, steps, s
               </div>
             )}
 
+            <div className="pt-3 border-t border-border">
+              <div className="text-[12px] font-semibold text-foreground mb-2">{i18n.t('exportPreview.gifQuality')}</div>
+              <div className="flex gap-1.5">
+                {GIF_QUALITIES.map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => update({ gifQuality: value })}
+                    className={`flex-1 px-2 py-1.5 rounded-lg border text-[11px] transition-colors ${
+                      options.gifQuality === value
+                        ? 'border-accent text-accent'
+                        : 'border-border text-muted-foreground hover:border-accent hover:text-foreground'
+                    }`}
+                  >
+                    {i18n.t(`exportPreview.gif_${value}`)}
+                  </button>
+                ))}
+              </div>
+            </div>
+
             <div className="pt-3 border-t border-border space-y-1.5">
               {formats.map(({ key, icon: Icon, label }) => {
-                const cancellable = exporting === key && key === 'video';
+                const cancellable = exporting === key && (key === 'video' || key === 'gif');
                 return (
                   <Button
                     key={key}

--- a/src/ui/sidepanel/ExportMenu.tsx
+++ b/src/ui/sidepanel/ExportMenu.tsx
@@ -1,4 +1,4 @@
-import { Download, FileCode, FileDown, FileText, Loader2, Video } from 'lucide-react';
+import { Download, FileCode, FileDown, FileImage, FileText, Loader2, Video } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { i18n } from '#imports';
 import { downloadBlob, downloadText, safeFilename } from '@/core/export/download';
@@ -17,7 +17,7 @@ interface ExportMenuProps {
   screenshots: Map<string, Screenshot>;
 }
 
-type ExportType = 'docx' | 'html' | 'markdown' | 'pdf' | 'video';
+type ExportType = 'docx' | 'gif' | 'html' | 'markdown' | 'pdf' | 'video';
 
 export default function ExportMenu({
   guideId,
@@ -28,9 +28,9 @@ export default function ExportMenu({
   const [open, setOpen] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [videoSupported, setVideoSupported] = useState(false);
-  const [videoProgress, setVideoProgress] = useState<number | null>(null);
+  const [progress, setProgress] = useState<number | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
-  const videoAbort = useRef<AbortController | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     let active = true;
@@ -68,14 +68,24 @@ export default function ExportMenu({
       } else if (type === 'markdown') {
         const md = await exportGuideAsMarkdown(guide, steps, screenshots);
         downloadText(md, safeFilename(guide.title, 'md'), 'text/markdown');
+      } else if (type === 'gif') {
+        const controller = new AbortController();
+        abortRef.current = controller;
+        setProgress(0);
+        const { exportGuideAsGif } = await import('@/core/export/gif-export');
+        const { blob, extension } = await exportGuideAsGif(guide, steps, screenshots, undefined, {
+          signal: controller.signal,
+          onProgress: (encoded, frames) => setProgress(frames > 0 ? encoded / frames : 0),
+        });
+        downloadBlob(blob, safeFilename(guide.title, extension));
       } else if (type === 'video') {
         const controller = new AbortController();
-        videoAbort.current = controller;
-        setVideoProgress(0);
+        abortRef.current = controller;
+        setProgress(0);
         const { exportGuideAsVideo } = await import('@/core/export/video-export');
         const { blob, extension } = await exportGuideAsVideo(guide, steps, screenshots, undefined, {
           signal: controller.signal,
-          onProgress: (encoded, frames) => setVideoProgress(frames > 0 ? encoded / frames : 0),
+          onProgress: (encoded, frames) => setProgress(frames > 0 ? encoded / frames : 0),
         });
         downloadBlob(blob, safeFilename(guide.title, extension));
       } else {
@@ -84,8 +94,8 @@ export default function ExportMenu({
     } catch (error) {
       if (!(error instanceof DOMException && error.name === 'AbortError')) throw error;
     } finally {
-      videoAbort.current = null;
-      setVideoProgress(null);
+      abortRef.current = null;
+      setProgress(null);
       setExporting(false);
     }
   }
@@ -95,6 +105,7 @@ export default function ExportMenu({
     { type: 'html' as const, icon: FileCode, label: i18n.t('exportMenu.html') },
     { type: 'markdown' as const, icon: FileText, label: i18n.t('exportMenu.markdown') },
     { type: 'pdf' as const, icon: FileDown, label: i18n.t('exportMenu.pdf') },
+    { type: 'gif' as const, icon: FileImage, label: i18n.t('exportMenu.gif') },
     ...(videoSupported ? [{ type: 'video' as const, icon: Video, label: i18n.t('exportMenu.video') }] : []),
   ];
 
@@ -102,13 +113,13 @@ export default function ExportMenu({
     <div ref={menuRef} className="relative">
       <Button
         size="sm"
-        onClick={() => (videoProgress === null ? setOpen((prev) => !prev) : videoAbort.current?.abort())}
-        disabled={exporting && videoProgress === null}
+        onClick={() => (progress === null ? setOpen((prev) => !prev) : abortRef.current?.abort())}
+        disabled={exporting && progress === null}
       >
         {exporting ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
-        {videoProgress === null
+        {progress === null
           ? i18n.t('common.export')
-          : i18n.t('exportMenu.cancelProgress', [String(Math.round(videoProgress * 100))])}
+          : i18n.t('exportMenu.cancelProgress', [String(Math.round(progress * 100))])}
       </Button>
 
       {open && !exporting && (


### PR DESCRIPTION
Guides could only leave as a document or an mp4, and neither animates inline where people share them. GIF now sits alongside the other formats in both export surfaces.

It replays the video's own choreography: `composeGuideFrames` was lifted out of the video encoder and now feeds either one, so both draw identical frames. GIF runs it slower and smaller, because the format has no interframe compression and every frame of a zoom is a full frame. A GIF quality control picks between 320x180 at 8fps and 640x360 at 15fps.

Encoding stays on the main thread and yields every few frames. Moving it to a Web Worker killed the renderer with `KILLED_BAD_MESSAGE` on the first `postMessage`, which I could not explain, so it is inline for now.

Even at High a ten-step guide runs to tens of megabytes, which is too large for GitHub to render inline.
