### PR TITLE
chore: add an AI contribution policy, PR template and issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: Bug report
+description: Something in Mimik does not work
+title: "[Bug] "
+labels: [bug, needs-triage]
+body:
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you report
+      options:
+        - label: I searched existing issues to avoid a duplicate.
+          required: true
+        - label: I reproduced this myself, rather than having a tool report it.
+          required: true
+        - label: I can reproduce it on the latest version.
+          required: false
+        - label: I can reproduce it in a clean browser profile with Mimik as the only extension.
+          required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        Suggesting something new instead? Use the [feature request form](https://github.com/westpoint-io/mimik/issues/new?template=feature_request.yml).
+
+  - type: textarea
+    id: behaviour
+    attributes:
+      label: Current vs expected behaviour
+      description: >
+        What happened, and what you expected instead. Screenshots help a lot.
+        Incomplete reports may be closed without investigation.
+      placeholder: I exported a guide as PDF and expected A, but got B.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Start a recording on example.com
+        2. Click a couple of things, then stop
+        3. Export as PDF
+        4. Observe ...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: areas
+    attributes:
+      label: Which areas are affected?
+      multiple: true
+      options:
+        - Recording and capture
+        - Guide editor
+        - Screenshot editor, annotation or crop
+        - Smart Blur
+        - Export (PDF, DOCX, HTML, Markdown)
+        - Export (video)
+        - Guide Me replay
+        - Voice narration
+        - AI descriptions
+        - Onboarding or settings
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      render: text
+      placeholder: |
+        - Browser: Chrome 140 / Firefox 145 / Edge 140
+        - Mimik version: 1.1.1
+        - OS: macOS 15, Windows 11, Ubuntu 26.04
+        - Site being recorded, if it matters:
+    validations:
+      required: true
+
+  - type: textarea
+    id: console
+    attributes:
+      label: Console errors
+      description: >
+        Chrome: chrome://extensions, Mimik, "service worker", Console.
+        Firefox: about:debugging, Inspect. Paste anything red.
+      render: text
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Anything else that helps. If you used an AI tool to write this report, say so here and confirm you verified every claim in it.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/westpoint-io/mimik/security/advisories/new
+    about: Report privately. Do not open a public issue.
+  - name: Question or idea to talk through
+    url: https://github.com/westpoint-io/mimik/blob/main/CONTRIBUTING.md
+    about: Read the contributing guide first.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,61 @@
+name: Feature request
+description: Suggest something Mimik should do
+title: "[Feature] "
+labels: [enhancement, needs-triage]
+body:
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you begin
+      options:
+        - label: I searched existing issues to avoid a duplicate.
+          required: true
+        - label: I am willing to open a PR for this.
+          required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        Reporting something broken instead? Use the [bug report form](https://github.com/westpoint-io/mimik/issues/new?template=bug_report.yml).
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What are you trying to do that Mimik makes hard today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: What you would want
+      description: Rough is fine. Say what it should do, not how to build it.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: areas
+    attributes:
+      label: Which areas would this affect?
+      multiple: true
+      options:
+        - Recording and capture
+        - Guide editor
+        - Screenshot editor, annotation or crop
+        - Smart Blur
+        - Export (PDF, DOCX, HTML, Markdown)
+        - Export (video)
+        - Guide Me replay
+        - Voice narration
+        - AI descriptions
+        - Onboarding or settings
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, mockups, or how other tools solve it. If you used an AI tool to write this, say so here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+> **AI model(s) used (required):** <!-- Name every model you used, or write "None". You are responsible for every line either way. -->
+
+## Type of change
+
+<!-- Tick one. -->
+
+- [ ] ✨ New feature (feat)
+- [ ] 🐛 Bug fix (fix)
+- [ ] ♻️ Refactor (refactor)
+- [ ] ⚡ Performance (perf)
+- [ ] 🌐 Translation or locale (i18n)
+- [ ] 📝 Documentation (docs)
+- [ ] ✅ Tests only (test)
+- [ ] 🔧 Tooling or dependencies (chore)
+
+## Description
+
+<!-- Two sentences: what changed and why. Write it yourself. Don't paste a
+     generated summary of the diff, we can read the diff. -->
+
+## Related issue
+
+Closes #
+
+## How this was tested
+
+- [ ] `pnpm lint && pnpm test && pnpm build && pnpm build:firefox` passes locally <!-- CI does not run on fork PRs until a maintainer approves it. -->
+- [ ] Tested by hand in the browser
+- [ ] Tests added or updated
+
+## Screenshots
+
+<!-- Required for any UI change. Mimik is a visual tool and a green test run
+     does not show whether a guide still looks right. -->
+
+## Checklist
+
+- [ ] I can explain and debug every line, without going back to an AI tool
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
+- [ ] Existing behaviour still works

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,12 @@ pnpm lint:fix              # auto-fix
 pnpm format                # format only
 ```
 
+### Code style
+
+Biome handles formatting and linting. Run `pnpm lint:fix` and it sorts out indentation, quotes, semicolons and import order for you.
+
+One rule Biome cannot check: do not write comments. Name things so the code explains itself. The exceptions are pragmas and directives the toolchain reads, such as `@ts-expect-error` or `biome-ignore`. When a piece of logic looks like it needs a comment to be understood, it usually wants a clearer name or a smaller function instead.
+
 ## Project Layout
 
 ```
@@ -115,6 +121,24 @@ src/
 5. Open a PR with a clear description of what and why
 
 CI (`pr-test.yml`) will run lint, tests, and both browser builds on every PR.
+
+## Using AI Tools
+
+AI-assisted contributions are welcome here.
+
+Tick the disclosure box in the pull request template and name the tools you used. Saying so costs you nothing. Passing off output you have not read is what gets a PR closed.
+
+You are responsible for every line you submit. If a reviewer asks why something is there, "the model wrote it" is not an answer. Be ready to debug it without going back to the tool.
+
+Write the pull request description yourself. Generated summaries run long and restate the diff, which reviewers can already read. Two sentences on what changed and why beats ten paragraphs. Same for issue reports and review comments.
+
+Reproduce a bug before you file it. Issues written by pointing a tool at the codebase, with no real reproduction, get closed unread.
+
+Leave `good first issue` alone. Those exist for people learning the codebase by hand.
+
+Do not run automated AI reviews on pull requests in this repo. Your own fork is fine.
+
+Repeat submissions of unread AI output will get you blocked.
 
 ## Adding a Translation
 


### PR DESCRIPTION
Issues and pull requests currently arrive in whatever shape the contributor chose, and lately that has meant long blocks of model output that restate the diff instead of saying what changed. Nothing in the repo asks whether AI was used, bug reports turn up without a browser or a version, and a security report has nowhere to go except a public issue.

`CONTRIBUTING.md` gains an AI policy: name the tools, be able to explain and debug every line without them, write the pull request description yourself, reproduce a bug before filing it, and leave `good first issue` for people learning the codebase by hand. It also documents the no-comment rule, which is the one code-style convention Biome cannot enforce and which no contributor could previously have known about.

The pull request template asks for the AI models used as its first line, before the type of change or the description, so it is the first thing a reviewer sees. The issue chooser now offers a bug form and a feature form with no blank option, neither of which submits without a reproduction, browser, version and affected area, and routes security reports to a private advisory. The bug form requires the reporter to confirm they reproduced the problem themselves rather than having a tool report it.

Shape borrowed from Read Frog for the disclosure-first template and the area dropdowns, Dark Reader for the required preflight checks, and Django for the AI disclosure being mandatory rather than optional.

Verified by parsing all three issue forms with a YAML loader. The templates only take effect once merged to the default branch, so the chooser and the pre-filled pull request body still need a look after that.
