### PR TITLE
chore: declare the licence as MIT and add a star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Click record, do the thing, get a polished guide with annotated screenshots. Nar
   - [📤 Multi-format export](#-multi-format-export)
 - [🔐 Privacy & storage](#-privacy--storage)
 - [🤝 Contributing](#-contributing)
+- [⭐ Star History](#-star-history)
 - [📜 License](#-license)
 
 <br/>
@@ -191,6 +192,22 @@ Two things do leave the browser, both documented in the [privacy policy](https:/
 Contributions of all kinds are welcome: bug reports, feature requests, PRs, and translations.
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup, project layout, and contributor guidelines.
+
+<div align="right">
+
+[![Back to top][back-to-top]](#readme-top)
+
+</div>
+
+## ⭐ Star History
+
+<a href="https://www.star-history.com/#westpoint-io/mimik&Timeline">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=westpoint-io/mimik&type=Timeline&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=westpoint-io/mimik&type=Timeline" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=westpoint-io/mimik&type=Timeline" width="800" />
+  </picture>
+</a>
 
 <div align="right">
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.64",
     "@ai-sdk/openai": "^3.0.49",


### PR DESCRIPTION
The package manifest declared `ISC` while the LICENSE file, the README badge and the README's own licence section all say MIT, so anyone reading the package metadata or letting GitHub detect the licence got the wrong answer. The manifest now says MIT and nothing else in the repo claims otherwise.

The README also gains a star history chart above the licence section, with a light and a dark variant so it stays readable in either theme, plus a table of contents entry.

Reported as #81.

Verified that package.json still parses and reports MIT, and that both chart URLs return 200 with `image/svg+xml`. An earlier 403 on one of them was rate limiting from repeated requests, not a bad URL.

Closes #81
