### PR TITLE
feat(ai): let every provider point at a custom server

### DIFF
--- a/src/core/capture/ai/__tests__/custom-server.test.ts
+++ b/src/core/capture/ai/__tests__/custom-server.test.ts
@@ -1,0 +1,163 @@
+import { createServer, type Server } from 'node:http';
+import { generateText } from 'ai';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createModel } from '../provider';
+import { validateApiKey } from '../validate';
+
+interface Seen {
+  path: string;
+  key?: string;
+}
+
+const TEXT = 'Clicked the Update profile button';
+
+function startMockServer(models: string[]): Promise<{ server: Server; seen: Seen[]; url: string }> {
+  const seen: Seen[] = [];
+  const server = createServer((req, res) => {
+    const path = new URL(req.url ?? '/', 'http://x').pathname;
+    const auth = req.headers.authorization;
+    const key = auth ? auth.replace('Bearer ', '') : (req.headers['x-api-key'] as string | undefined);
+    seen.push({ path, key });
+    const send = (code: number, body: unknown) => {
+      res.writeHead(code, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(body));
+    };
+    if (key === 'bad') return send(401, { error: { message: 'Invalid API key' } });
+    if (path.endsWith('/models')) return send(200, { object: 'list', data: models.map((id) => ({ id })) });
+    let raw = '';
+    req.on('data', (c) => {
+      raw += c;
+    });
+    req.on('end', () => {
+      const body = JSON.parse(raw || '{}');
+      if (!models.includes(body.model)) return send(404, { error: { message: 'model not found' } });
+      if (path.endsWith('/messages')) {
+        return send(200, {
+          id: 'msg_mock',
+          type: 'message',
+          role: 'assistant',
+          model: body.model,
+          content: [{ type: 'text', text: TEXT }],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        });
+      }
+      if (path.endsWith('/responses')) {
+        return send(200, {
+          id: 'resp_mock',
+          object: 'response',
+          status: 'completed',
+          model: body.model,
+          output: [
+            { type: 'message', role: 'assistant', status: 'completed', content: [{ type: 'output_text', text: TEXT }] },
+          ],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        });
+      }
+      if (path.endsWith('/chat/completions')) {
+        return send(200, {
+          id: 'chatcmpl-mock',
+          object: 'chat.completion',
+          created: 1,
+          model: body.model,
+          choices: [{ index: 0, message: { role: 'assistant', content: TEXT }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        });
+      }
+      send(404, { error: { message: 'not found' } });
+    });
+  });
+  return new Promise((resolve) =>
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      resolve({ server, seen, url: `http://127.0.0.1:${port}/v1` });
+    }),
+  );
+}
+
+let openai: { server: Server; seen: Seen[]; url: string };
+let anthropic: { server: Server; seen: Seen[]; url: string };
+let OPENAI_URL: string;
+let ANTHROPIC_URL: string;
+
+beforeAll(async () => {
+  openai = await startMockServer(['mock-tiny', 'mock-large']);
+  anthropic = await startMockServer(['claude-local']);
+  OPENAI_URL = openai.url;
+  ANTHROPIC_URL = anthropic.url;
+});
+
+afterAll(() => {
+  openai?.server.close();
+  anthropic?.server.close();
+});
+
+describe('a real custom server, real fetch, real SDK', () => {
+  it('validates an openai-protocol server', async () => {
+    expect(await validateApiKey('openai', 'sk-test', OPENAI_URL, 'mock-tiny')).toEqual({
+      valid: true,
+      models: ['mock-tiny', 'mock-large'],
+    });
+  });
+
+  it('validates an anthropic-protocol server, using x-api-key against /messages', async () => {
+    expect(await validateApiKey('anthropic', 'ak-test', ANTHROPIC_URL, 'claude-local')).toEqual({
+      valid: true,
+      models: ['claude-local'],
+    });
+    expect(anthropic.seen.some((r) => r.path === '/v1/messages' && r.key === 'ak-test')).toBe(true);
+  });
+
+  it('validates deepseek pointed at the same server', async () => {
+    expect(await validateApiKey('deepseek', 'sk-test', OPENAI_URL, 'mock-tiny')).toMatchObject({ valid: true });
+  });
+
+  it('reports a bad key as rejected, not as a network error', async () => {
+    expect(await validateApiKey('openai', 'bad', OPENAI_URL, 'mock-tiny')).toEqual({
+      valid: false,
+      reason: 'rejected',
+    });
+  });
+
+  it('reports an unknown model as model-invalid', async () => {
+    expect(await validateApiKey('openai', 'sk-test', OPENAI_URL, 'nope')).toMatchObject({
+      valid: false,
+      reason: 'model-invalid',
+    });
+  });
+
+  it('generates against a custom server over chat completions, the endpoint the key check probed', async () => {
+    const before = openai.seen.length;
+    const { text } = await generateText({
+      model: createModel('openai', 'mock-tiny', 'sk-test', OPENAI_URL),
+      prompt: 'Describe this step.',
+    });
+    expect(text).toBe(TEXT);
+    expect(openai.seen.slice(before).map((r) => r.path)).toContain('/v1/chat/completions');
+  });
+
+  it('generates through the anthropic protocol against a custom server', async () => {
+    const { text } = await generateText({
+      model: createModel('anthropic', 'claude-local', 'ak-test', ANTHROPIC_URL),
+      prompt: 'Describe this step.',
+    });
+    expect(text).toBe(TEXT);
+  });
+
+  it('keeps deepseek on chat completions at its own default endpoint', async () => {
+    const before = openai.seen.length;
+    await generateText({
+      model: createModel('deepseek', 'mock-tiny', 'sk-test', OPENAI_URL),
+      prompt: 'Describe this step.',
+    });
+    expect(openai.seen.slice(before).map((r) => r.path)).toContain('/v1/chat/completions');
+  });
+
+  it('leaves the OpenAI default endpoint on the responses API', async () => {
+    const before = openai.seen.length;
+    const model = createModel('openai', 'mock-tiny', 'sk-test', '');
+    expect(model.modelId).toBe('mock-tiny');
+    expect(openai.seen.length).toBe(before);
+  });
+});

--- a/src/core/capture/ai/__tests__/models.test.ts
+++ b/src/core/capture/ai/__tests__/models.test.ts
@@ -1,7 +1,15 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { AI_PROVIDERS, CUSTOM_MODEL_VALUE, isCustomModel } from '../models';
+import {
+  AI_PROVIDERS,
+  CUSTOM_MODEL_VALUE,
+  findProvider,
+  isCustomBaseUrl,
+  isCustomModel,
+  isProviderKey,
+  resolveBaseUrl,
+} from '../models';
 
 const LOCALES = ['en', 'de', 'es', 'fr', 'pt-BR', 'zh-CN'];
 
@@ -61,21 +69,62 @@ describe('every provider default is selectable', () => {
   });
 });
 
-describe('OpenAI provider has base URL support', () => {
-  it('opts into a base URL', () => {
-    const config = AI_PROVIDERS.openai;
-    expect(config.baseUrl).toBe(true);
+describe('every provider takes a custom server', () => {
+  it.each(Object.entries(AI_PROVIDERS))('%s carries a default base URL and a protocol', (_key, config) => {
+    expect(config.defaultBaseUrl).toMatch(/^https:\/\//);
+    expect(['openai', 'anthropic']).toContain(config.protocol);
   });
 
-  it('carries the base URL label in every locale', () => {
+  it('carries the custom server copy in every locale', () => {
     for (const locale of LOCALES) {
-      expect(localeKeys(locale).has('settings.baseUrl')).toBe(true);
+      const keys = localeKeys(locale);
+      expect(keys.has('settings.baseUrl')).toBe(true);
+      expect(keys.has('settings.useOwnServer')).toBe(true);
+      expect(keys.has('settings.ownServerHintOpenai')).toBe(true);
+      expect(keys.has('settings.ownServerHintAnthropic')).toBe(true);
     }
+  });
+
+  it('no longer offers a second OpenAI entry', () => {
+    expect(Object.keys(AI_PROVIDERS)).toEqual(['openai', 'anthropic', 'deepseek']);
   });
 
   it('includes a Custom model option', () => {
     const config = AI_PROVIDERS.openai;
     expect(config.models.some((m) => m.id === CUSTOM_MODEL_VALUE)).toBe(true);
+  });
+});
+
+describe('custom base URL detection', () => {
+  it('reads a blank or default URL as not custom', () => {
+    expect(isCustomBaseUrl(AI_PROVIDERS.openai, '')).toBe(false);
+    expect(isCustomBaseUrl(AI_PROVIDERS.openai, undefined)).toBe(false);
+    expect(isCustomBaseUrl(AI_PROVIDERS.openai, 'https://api.openai.com/v1')).toBe(false);
+    expect(isCustomBaseUrl(AI_PROVIDERS.openai, 'https://api.openai.com/v1/')).toBe(false);
+  });
+
+  it('reads another host as custom, per provider', () => {
+    expect(isCustomBaseUrl(AI_PROVIDERS.openai, 'http://localhost:11434/v1')).toBe(true);
+    expect(isCustomBaseUrl(AI_PROVIDERS.anthropic, 'http://localhost:4000')).toBe(true);
+    expect(isCustomBaseUrl(AI_PROVIDERS.deepseek, 'https://api.deepseek.com')).toBe(false);
+  });
+
+  it('resolves to the provider default when nothing is set', () => {
+    expect(resolveBaseUrl(AI_PROVIDERS.deepseek)).toBe('https://api.deepseek.com');
+    expect(resolveBaseUrl(AI_PROVIDERS.anthropic, '  ')).toBe('https://api.anthropic.com/v1');
+    expect(resolveBaseUrl(AI_PROVIDERS.openai, 'http://localhost:8787/v1/')).toBe('http://localhost:8787/v1');
+  });
+});
+
+describe('stored provider keys', () => {
+  it('rejects a provider that no longer exists', () => {
+    expect(isProviderKey('openaiCompatible')).toBe(false);
+    expect(findProvider('openaiCompatible')).toBeUndefined();
+  });
+
+  it('accepts the ones that do', () => {
+    expect(isProviderKey('openai')).toBe(true);
+    expect(findProvider('deepseek')).toBe(AI_PROVIDERS.deepseek);
   });
 });
 

--- a/src/core/capture/ai/__tests__/validate.test.ts
+++ b/src/core/capture/ai/__tests__/validate.test.ts
@@ -209,4 +209,66 @@ describe('validateApiKey', () => {
       });
     });
   });
+
+  describe('a custom server on any provider', () => {
+    it('probes an openai-protocol server at chat/completions with a bearer token', async () => {
+      fetchMock.mockResolvedValueOnce(chatOkBody());
+      fetchMock.mockResolvedValueOnce(modelsBody('mock-tiny'));
+      await validateApiKey('openai', 'sk-key', 'http://localhost:8787/v1', 'mock-tiny');
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('http://localhost:8787/v1/chat/completions');
+      expect((init!.headers as Record<string, string>).Authorization).toBe('Bearer sk-key');
+    });
+
+    it('probes an anthropic-protocol server at messages with an x-api-key', async () => {
+      fetchMock.mockResolvedValueOnce(chatOkBody());
+      fetchMock.mockResolvedValueOnce(modelsBody('claude-local'));
+      expect(await validateApiKey('anthropic', 'ak-key', 'http://localhost:4000', 'claude-local')).toEqual({
+        valid: true,
+        models: ['claude-local'],
+      });
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('http://localhost:4000/messages');
+      const headers = init!.headers as Record<string, string>;
+      expect(headers['x-api-key']).toBe('ak-key');
+      expect(headers.Authorization).toBeUndefined();
+      expect(JSON.parse(init!.body as string).max_tokens).toBe(8);
+    });
+
+    it('lets deepseek point somewhere else', async () => {
+      fetchMock.mockResolvedValueOnce(chatOkBody());
+      fetchMock.mockResolvedValueOnce(modelsBody('local-r1'));
+      expect(await validateApiKey('deepseek', 'sk-key', 'http://localhost:1234/v1', 'local-r1')).toEqual({
+        valid: true,
+        models: ['local-r1'],
+      });
+      expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:1234/v1/chat/completions');
+    });
+
+    it('treats a provider default typed in by hand as the default, not a custom server', async () => {
+      fetchMock.mockResolvedValueOnce(modelsBody('deepseek-v4-flash'));
+      expect(await validateApiKey('deepseek', 'sk-key', 'https://api.deepseek.com/', 'deepseek-v4-flash')).toEqual({
+        valid: true,
+        models: ['deepseek-v4-flash'],
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0][0]).toBe('https://api.deepseek.com/models');
+    });
+
+    it('checks an anthropic key against anthropic by default', async () => {
+      fetchMock.mockResolvedValueOnce(modelsBody('claude-3-5-haiku-20241022'));
+      await validateApiKey('anthropic', 'ak-key');
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://api.anthropic.com/v1/models');
+      expect((init!.headers as Record<string, string>)['anthropic-version']).toBe('2023-06-01');
+    });
+
+    it('no longer knows the removed compatible provider, and sends it no key', async () => {
+      expect(await validateApiKey('openaiCompatible', 'sk-key', 'http://localhost:8787/v1', 'mock-tiny')).toEqual({
+        valid: false,
+        reason: 'network',
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/core/capture/ai/models.ts
+++ b/src/core/capture/ai/models.ts
@@ -3,22 +3,28 @@ export interface AIModelOption {
   label: string;
 }
 
-export const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
+export type AIProtocol = 'openai' | 'anthropic';
+
+export type OpenAITransport = 'responses' | 'chat';
 
 export interface AIProviderConfig {
   label: string;
+  protocol: AIProtocol;
+  transport?: OpenAITransport;
+  defaultBaseUrl: string;
   defaultModel: string;
   models: AIModelOption[];
-  baseUrl?: boolean;
 }
 
 export const CUSTOM_MODEL_VALUE = 'mimik-custom-model';
 
-export const AI_PROVIDERS: Record<string, AIProviderConfig> = {
+export const AI_PROVIDERS = {
   openai: {
     label: 'OpenAI',
+    protocol: 'openai',
+    transport: 'responses',
+    defaultBaseUrl: 'https://api.openai.com/v1',
     defaultModel: 'gpt-4o-mini',
-    baseUrl: true,
     models: [
       { id: 'gpt-4o-mini', label: 'GPT-4o Mini' },
       { id: 'gpt-4.1-nano', label: 'GPT-4.1 Nano' },
@@ -30,6 +36,8 @@ export const AI_PROVIDERS: Record<string, AIProviderConfig> = {
   },
   anthropic: {
     label: 'Anthropic',
+    protocol: 'anthropic',
+    defaultBaseUrl: 'https://api.anthropic.com/v1',
     defaultModel: 'claude-3-5-haiku-20241022',
     models: [
       { id: 'claude-3-5-haiku-20241022', label: 'Claude 3.5 Haiku' },
@@ -37,14 +45,11 @@ export const AI_PROVIDERS: Record<string, AIProviderConfig> = {
       { id: CUSTOM_MODEL_VALUE, label: 'Custom' },
     ],
   },
-  openaiCompatible: {
-    label: 'OpenAI Compatible',
-    defaultModel: 'gpt-4o-mini',
-    models: [],
-    baseUrl: true,
-  },
   deepseek: {
     label: 'DeepSeek',
+    protocol: 'openai',
+    transport: 'chat',
+    defaultBaseUrl: 'https://api.deepseek.com',
     defaultModel: 'deepseek-v4-flash',
     models: [
       { id: 'deepseek-v4-flash', label: 'DeepSeek V4 Flash' },
@@ -53,9 +58,41 @@ export const AI_PROVIDERS: Record<string, AIProviderConfig> = {
       { id: CUSTOM_MODEL_VALUE, label: 'Custom' },
     ],
   },
-};
+} satisfies Record<string, AIProviderConfig>;
 
 export type AIProviderKey = keyof typeof AI_PROVIDERS;
+
+export const DEFAULT_AI_PROVIDER: AIProviderKey = 'openai';
+
+export function isProviderKey(value: unknown): value is AIProviderKey {
+  return typeof value === 'string' && value in AI_PROVIDERS;
+}
+
+export function findProvider(provider: string): AIProviderConfig | undefined {
+  return isProviderKey(provider) ? AI_PROVIDERS[provider] : undefined;
+}
+
+export function providerOrDefault(value: unknown): AIProviderKey {
+  return isProviderKey(value) ? value : DEFAULT_AI_PROVIDER;
+}
+
+export function normalizeBaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, '');
+}
+
+export function resolveBaseUrl(config: AIProviderConfig, baseUrl?: string): string {
+  return normalizeBaseUrl(baseUrl?.trim() || config.defaultBaseUrl);
+}
+
+export function isCustomBaseUrl(config: AIProviderConfig, baseUrl?: string): boolean {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) return false;
+  return normalizeBaseUrl(trimmed) !== normalizeBaseUrl(config.defaultBaseUrl);
+}
+
+export function openAITransport(config: AIProviderConfig, baseUrl?: string): OpenAITransport {
+  return isCustomBaseUrl(config, baseUrl) ? 'chat' : (config.transport ?? 'chat');
+}
 
 export function isCustomModel(model: string, provider: AIProviderConfig): boolean {
   const id = model.trim();

--- a/src/core/capture/ai/provider.ts
+++ b/src/core/capture/ai/provider.ts
@@ -1,14 +1,11 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
-
-const DEEPSEEK_BASE_URL = 'https://api.deepseek.com';
+import { AI_PROVIDERS, DEFAULT_AI_PROVIDER, findProvider, openAITransport, resolveBaseUrl } from './models';
 
 export function createModel(provider: string, model: string, apiKey: string, baseUrl?: string) {
-  if (provider === 'anthropic') return createAnthropic({ apiKey })(model);
-  if (provider === 'openaiCompatible') {
-    const baseURL = baseUrl?.trim();
-    return createOpenAI(baseURL ? { apiKey, baseURL } : { apiKey })(model);
-  }
-  if (provider === 'deepseek') return createOpenAI({ apiKey, baseURL: DEEPSEEK_BASE_URL, name: 'deepseek' })(model);
-  return createOpenAI({ apiKey })(model);
+  const config = findProvider(provider) ?? AI_PROVIDERS[DEFAULT_AI_PROVIDER];
+  const baseURL = resolveBaseUrl(config, baseUrl);
+  if (config.protocol === 'anthropic') return createAnthropic({ apiKey, baseURL })(model);
+  const openai = createOpenAI({ apiKey, baseURL, name: provider });
+  return openAITransport(config, baseUrl) === 'responses' ? openai(model) : openai.chat(model);
 }

--- a/src/core/capture/ai/rewrite.ts
+++ b/src/core/capture/ai/rewrite.ts
@@ -2,7 +2,7 @@ import { generateText } from 'ai';
 import { localStorage } from '@/lib/browser-api';
 import { logger } from '@/lib/logger';
 import type { RewriteSelectionResponse } from '@/lib/messaging';
-import { AI_PROVIDERS } from './models';
+import { AI_PROVIDERS, providerOrDefault } from './models';
 import { getLanguageSuffix, REWRITE_PROMPT } from './prompts';
 import { createModel } from './provider';
 
@@ -25,7 +25,7 @@ export async function rewriteSelection(text: string, instruction: string): Promi
   const settings = await localStorage.get(['aiApiKey', 'aiProvider', 'aiModel', 'aiBaseUrl', 'aiLanguage']);
   if (!settings.aiApiKey) return { error: 'no-api-key' };
 
-  const provider = (settings.aiProvider as string) || 'openai';
+  const provider = providerOrDefault(settings.aiProvider);
 
   try {
     const { text: raw } = await generateText({

--- a/src/core/capture/ai/validate.ts
+++ b/src/core/capture/ai/validate.ts
@@ -1,5 +1,12 @@
 import { logger } from '@/lib/logger';
-import { DEFAULT_OPENAI_BASE_URL } from './models';
+import {
+  type AIProtocol,
+  type AIProviderConfig,
+  findProvider,
+  isCustomBaseUrl,
+  normalizeBaseUrl,
+  resolveBaseUrl,
+} from './models';
 
 export type KeyValidation =
   | { valid: true; models?: string[] }
@@ -7,34 +14,18 @@ export type KeyValidation =
 
 const REQUEST_TIMEOUT_MS = 10_000;
 
-function normalizeUrl(url: string): string {
-  return url.trim().replace(/\/+$/, '');
-}
+const PROTOCOL_HEADERS: Record<AIProtocol, (key: string) => Record<string, string>> = {
+  openai: (key) => ({ Authorization: `Bearer ${key}` }),
+  anthropic: (key) => ({
+    'x-api-key': key,
+    'anthropic-version': '2023-06-01',
+    'anthropic-dangerous-direct-browser-access': 'true',
+  }),
+};
 
-function isOpenAIEndpoint(baseUrl?: string): boolean {
-  if (!baseUrl?.trim()) return true;
-  return normalizeUrl(baseUrl) === normalizeUrl(DEFAULT_OPENAI_BASE_URL);
-}
-
-const ENDPOINTS: Record<string, { url?: string; headers: (key: string) => Record<string, string> }> = {
-  openai: {
-    url: 'https://api.openai.com/v1/models',
-    headers: (key) => ({ Authorization: `Bearer ${key}` }),
-  },
-  anthropic: {
-    url: 'https://api.anthropic.com/v1/models',
-    headers: (key) => ({
-      'x-api-key': key,
-      'anthropic-version': '2023-06-01',
-      'anthropic-dangerous-direct-browser-access': 'true',
-    }),
-  },
+const VOICE_ENDPOINTS: Record<string, { url: string; headers: (key: string) => Record<string, string> }> = {
   groq: {
     url: 'https://api.groq.com/openai/v1/models',
-    headers: (key) => ({ Authorization: `Bearer ${key}` }),
-  },
-  deepseek: {
-    url: 'https://api.deepseek.com/models',
     headers: (key) => ({ Authorization: `Bearer ${key}` }),
   },
 };
@@ -63,78 +54,14 @@ async function fetchModelsFromUrl(url: string, headers: Record<string, string>):
   }
 }
 
-async function probeWithChatCompletion(
-  baseUrl: string,
-  model: string,
-  headers: Record<string, string>,
-): Promise<boolean> {
-  try {
-    const chatUrl = `${normalizeUrl(baseUrl)}/chat/completions`;
-    const res = await fetch(chatUrl, {
-      method: 'POST',
-      headers: { ...headers, 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        model,
-        messages: [{ role: 'user', content: 'Reply with OK.' }],
-        max_tokens: 8,
-        stream: false,
-      }),
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    });
-    return res.ok;
-  } catch {
-    return false;
-  }
-}
-
-export async function validateApiKey(
-  provider: string,
-  apiKey: string,
-  baseUrl?: string,
-  model?: string,
-): Promise<KeyValidation> {
-  if (provider === 'openai' && !isOpenAIEndpoint(baseUrl)) {
-    const trimmedBase = baseUrl?.trim();
-    if (!trimmedBase) {
-      logger.error('OpenAI provider with no base URL');
-      return { valid: false, reason: 'network' };
-    }
-
-    const headers = { Authorization: `Bearer ${apiKey}` };
-
-    const selectedModel = model?.trim();
-    if (!selectedModel) {
-      const models = await fetchModelsFromUrl(`${normalizeUrl(trimmedBase)}/models`, headers);
-      return models ? { valid: false, reason: 'model-required', models } : { valid: false, reason: 'model-required' };
-    }
-
-    const probeOk = await probeWithChatCompletion(trimmedBase, selectedModel, headers);
-    if (!probeOk) {
-      const models = await fetchModelsFromUrl(`${normalizeUrl(trimmedBase)}/models`, headers);
-      if (models && !models.includes(selectedModel)) {
-        return { valid: false, reason: 'model-invalid', models };
-      }
-      return { valid: false, reason: 'rejected' };
-    }
-
-    const models = await fetchModelsFromUrl(`${normalizeUrl(trimmedBase)}/models`, headers);
-    return models ? { valid: true, models } : { valid: true };
-  }
-
-  const endpoint = ENDPOINTS[provider];
-  const url = endpoint?.url ?? null;
-  if (!url) {
-    logger.error('No API key validation endpoint for provider', provider);
-    return { valid: false, reason: 'network' };
-  }
+async function checkCatalog(url: string, headers: Record<string, string>): Promise<KeyValidation> {
   try {
     const res = await fetch(url, {
-      headers: endpoint.headers(apiKey),
+      headers,
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
     if (res.ok) {
-      const body = await res.json().catch(() => null);
-      const models = parseModelIds(body);
+      const models = parseModelIds(await res.json().catch(() => null));
       return models ? { valid: true, models } : { valid: true };
     }
     if (res.status === 401 || res.status === 403) return { valid: false, reason: 'rejected' };
@@ -143,4 +70,77 @@ export async function validateApiKey(
     logger.error('API key validation request failed', err);
     return { valid: false, reason: 'network' };
   }
+}
+
+async function probeWithInference(
+  protocol: AIProtocol,
+  baseUrl: string,
+  model: string,
+  headers: Record<string, string>,
+): Promise<boolean> {
+  const base = normalizeBaseUrl(baseUrl);
+  const url = protocol === 'anthropic' ? `${base}/messages` : `${base}/chat/completions`;
+  const body =
+    protocol === 'anthropic'
+      ? { model, max_tokens: 8, messages: [{ role: 'user', content: 'Reply with OK.' }] }
+      : { model, messages: [{ role: 'user', content: 'Reply with OK.' }], max_tokens: 8, stream: false };
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function validateCustomServer(
+  config: AIProviderConfig,
+  apiKey: string,
+  baseUrl: string,
+  model?: string,
+): Promise<KeyValidation> {
+  const headers = PROTOCOL_HEADERS[config.protocol](apiKey);
+  const base = normalizeBaseUrl(baseUrl);
+  const catalogUrl = `${base}/models`;
+
+  const selectedModel = model?.trim();
+  if (!selectedModel) {
+    const models = await fetchModelsFromUrl(catalogUrl, headers);
+    return models ? { valid: false, reason: 'model-required', models } : { valid: false, reason: 'model-required' };
+  }
+
+  if (await probeWithInference(config.protocol, base, selectedModel, headers)) {
+    const models = await fetchModelsFromUrl(catalogUrl, headers);
+    return models ? { valid: true, models } : { valid: true };
+  }
+
+  const models = await fetchModelsFromUrl(catalogUrl, headers);
+  if (models && !models.includes(selectedModel)) return { valid: false, reason: 'model-invalid', models };
+  return { valid: false, reason: 'rejected' };
+}
+
+export async function validateApiKey(
+  provider: string,
+  apiKey: string,
+  baseUrl?: string,
+  model?: string,
+): Promise<KeyValidation> {
+  const config = findProvider(provider);
+
+  if (!config) {
+    const endpoint = VOICE_ENDPOINTS[provider];
+    if (!endpoint) {
+      logger.error('No API key validation endpoint for provider', provider);
+      return { valid: false, reason: 'network' };
+    }
+    return checkCatalog(endpoint.url, endpoint.headers(apiKey));
+  }
+
+  if (isCustomBaseUrl(config, baseUrl)) return validateCustomServer(config, apiKey, baseUrl as string, model);
+
+  return checkCatalog(`${resolveBaseUrl(config)}/models`, PROTOCOL_HEADERS[config.protocol](apiKey));
 }

--- a/src/core/guides/types.ts
+++ b/src/core/guides/types.ts
@@ -1,3 +1,4 @@
+import type { AIProviderKey } from '@/core/capture/ai/models';
 import type { VoiceProvider } from '@/core/capture/voice/transcribe';
 import type { ScreenshotEdits } from '@/core/screenshot/types';
 
@@ -59,7 +60,7 @@ export interface Screenshot {
 
 export interface Settings {
   aiApiKey: string;
-  aiProvider: 'openai' | 'anthropic' | 'openaiCompatible' | 'deepseek';
+  aiProvider: AIProviderKey;
   aiModel: string;
   aiBaseUrl?: string;
   voiceEnabled: boolean;

--- a/src/entrypoints/background/guide-meta.ts
+++ b/src/entrypoints/background/guide-meta.ts
@@ -1,6 +1,6 @@
 import { i18n } from '#imports';
 import { generateGuideMeta } from '@/core/capture/ai/meta';
-import { AI_PROVIDERS } from '@/core/capture/ai/models';
+import { AI_PROVIDERS, providerOrDefault } from '@/core/capture/ai/models';
 import { actionSteps } from '@/core/guides/blocks';
 import {
   clearStepAiPending,
@@ -36,7 +36,7 @@ async function resolveGuideMetaInputs(guideId: string): Promise<GuideMetaInputs>
   const described = steps.filter((s) => s.description).map((s) => ({ description: s.description, url: s.url }));
   if (described.length === 0) return { ok: false, reason: 'no-steps' };
 
-  const provider = (settings.aiProvider as string) || 'openai';
+  const provider = providerOrDefault(settings.aiProvider);
   return {
     ok: true,
     steps: described.length > 15 ? [...described.slice(0, 10), ...described.slice(-5)] : described,

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -98,9 +98,14 @@ settings:
   aiDescriptions: KI-Beschreibungen
   modelCustom: Eigenes Modell
   baseUrl: Basis-URL
+  useOwnServer: Eigenen Server verwenden
+  ownServerHintOpenai: "Funktioniert mit Ollama, LM Studio, vLLM oder jedem OpenAI-kompatiblen Server."
+  ownServerHintAnthropic: "Funktioniert mit einem LiteLLM-Proxy oder jedem Anthropic-kompatiblen Server."
   provider: Anbieter
   model: Modell
   apiKey: API-Schlüssel
+  showKey: Schlüssel anzeigen
+  hideKey: Schlüssel verbergen
   aiLanguage: Sprache der Beschreibungen
   voiceNarration: Sprachkommentar
   voiceUsingAiKey: "Es ist kein Sprach-Schlüssel gesetzt, daher nutzt Mimik den OpenAI-Schlüssel aus den KI-Beschreibungen oben."

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -88,7 +88,12 @@ settings:
   model: Model
   modelCustom: Custom model
   baseUrl: Base URL
+  useOwnServer: Use my own server
+  ownServerHintOpenai: "Works with Ollama, LM Studio, vLLM, or any OpenAI-compatible server."
+  ownServerHintAnthropic: "Works with a LiteLLM proxy or any Anthropic-compatible server."
   apiKey: API Key
+  showKey: Show key
+  hideKey: Hide key
   aiLanguage: Description Language
   voiceNarration: Voice Narration
   voiceUsingAiKey: "No voice key is set, so Mimik uses the OpenAI key from AI Descriptions above."

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -88,7 +88,12 @@ settings:
   model: Modelo
   modelCustom: Modelo personalizado
   baseUrl: URL base
+  useOwnServer: Usar mi propio servidor
+  ownServerHintOpenai: "Funciona con Ollama, LM Studio, vLLM o cualquier servidor compatible con OpenAI."
+  ownServerHintAnthropic: "Funciona con un proxy LiteLLM o cualquier servidor compatible con Anthropic."
   apiKey: Clave API
+  showKey: Mostrar clave
+  hideKey: Ocultar clave
   aiLanguage: Idioma de descripciones
   voiceNarration: "Narración por voz"
   voiceUsingAiKey: "No hay clave de voz, así que Mimik usa la clave de OpenAI de Descripciones con IA de arriba."

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -88,7 +88,12 @@ settings:
   model: "Modèle"
   modelCustom: Modèle personnalisé
   baseUrl: URL de base
+  useOwnServer: Utiliser mon propre serveur
+  ownServerHintOpenai: "Fonctionne avec Ollama, LM Studio, vLLM ou tout serveur compatible OpenAI."
+  ownServerHintAnthropic: "Fonctionne avec un proxy LiteLLM ou tout serveur compatible Anthropic."
   apiKey: "Clé API"
+  showKey: Afficher la clé
+  hideKey: Masquer la clé
   aiLanguage: Langue des descriptions
   voiceNarration: "Narration vocale"
   voiceUsingAiKey: "Aucune clé vocale n'est définie : Mimik utilise la clé OpenAI des descriptions IA ci-dessus."

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -88,7 +88,12 @@ settings:
   model: Modelo
   modelCustom: Modelo personalizado
   baseUrl: URL base
+  useOwnServer: Usar meu próprio servidor
+  ownServerHintOpenai: "Funciona com Ollama, LM Studio, vLLM ou qualquer servidor compatível com OpenAI."
+  ownServerHintAnthropic: "Funciona com um proxy LiteLLM ou qualquer servidor compatível com Anthropic."
   apiKey: Chave da API
+  showKey: Mostrar chave
+  hideKey: Ocultar chave
   aiLanguage: "Idioma das descrições"
   voiceNarration: "Narração por voz"
   voiceUsingAiKey: "Não tem chave de voz, então o Mimik usa a chave da OpenAI das Descrições com IA lá de cima."

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -88,7 +88,12 @@ settings:
   model: 模型
   modelCustom: 自定义模型
   baseUrl: 基础 URL
+  useOwnServer: 使用自己的服务器
+  ownServerHintOpenai: "支持 Ollama、LM Studio、vLLM 或任何兼容 OpenAI 的服务器。"
+  ownServerHintAnthropic: "支持 LiteLLM 代理或任何兼容 Anthropic 的服务器。"
   apiKey: API 密钥
+  showKey: 显示密钥
+  hideKey: 隐藏密钥
   aiLanguage: 描述语言
   voiceNarration: 语音讲解
   voiceUsingAiKey: "未设置语音密钥，因此 Mimik 会使用上方 AI 描述中的 OpenAI 密钥。"

--- a/src/ui/onboarding/App.tsx
+++ b/src/ui/onboarding/App.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, Globe, Mic, MousePointerClick, Shield } from 'lucide-react';
+import { Globe, Mic, MousePointerClick, Shield } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { browser, i18n } from '#imports';
 import { PRESET_LABELS, type PresetKey } from '@/core/blur/regexes';
@@ -6,15 +6,17 @@ import {
   AI_PROVIDERS,
   type AIProviderKey,
   CUSTOM_MODEL_VALUE,
-  DEFAULT_OPENAI_BASE_URL,
+  DEFAULT_AI_PROVIDER,
+  isCustomBaseUrl,
   isCustomModel,
+  providerOrDefault,
 } from '@/core/capture/ai/models';
 import { AI_LANGUAGES, type AILanguageCode } from '@/core/capture/ai/prompts';
 import type { VoiceProvider } from '@/core/capture/voice/transcribe';
 import { localStorage, openSidebar, requestHostPermissions } from '@/lib/browser-api';
 import { Input } from '@/ui/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/ui/components/ui/select';
-import { KeyStatusNote, ModelList, useKeyCheck } from '@/ui/shared/key-check';
+import { KeyStatusNote, ModelList, SecretInput, useKeyCheck } from '@/ui/shared/key-check';
 import MicrophonePicker from '@/ui/shared/MicrophonePicker';
 
 interface StepProps {
@@ -127,19 +129,21 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
   const [apiKey, setApiKey] = useState('');
   const [baseUrl, setBaseUrl] = useState('');
   const [aiLanguage, setAiLanguage] = useState<AILanguageCode>('en');
-  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [ownServer, setOwnServer] = useState(false);
   const [customModel, setCustomModel] = useState(false);
   const aiKeyCheck = useKeyCheck();
 
   useEffect(() => {
     const load = () =>
       localStorage.get(['aiProvider', 'aiModel', 'aiApiKey', 'aiBaseUrl', 'aiLanguage']).then((stored) => {
-        if (typeof stored.aiProvider === 'string' && stored.aiProvider in AI_PROVIDERS) {
-          setProvider(stored.aiProvider as AIProviderKey);
-        }
+        const key = providerOrDefault(stored.aiProvider);
+        setProvider(key);
         if (typeof stored.aiModel === 'string') setModel(stored.aiModel);
         if (typeof stored.aiApiKey === 'string') setApiKey(stored.aiApiKey);
-        if (typeof stored.aiBaseUrl === 'string') setBaseUrl(stored.aiBaseUrl);
+        if (isCustomBaseUrl(AI_PROVIDERS[key], stored.aiBaseUrl as string)) {
+          setBaseUrl(stored.aiBaseUrl as string);
+          setOwnServer(true);
+        }
         if (typeof stored.aiLanguage === 'string') setAiLanguage(stored.aiLanguage as AILanguageCode);
       });
 
@@ -151,7 +155,7 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
     return () => document.removeEventListener('visibilitychange', onVisible);
   }, []);
 
-  const providerConfig = AI_PROVIDERS[provider];
+  const providerConfig = AI_PROVIDERS[provider] ?? AI_PROVIDERS[DEFAULT_AI_PROVIDER];
   const usingCustomModel = customModel || isCustomModel(model, providerConfig);
 
   const handleProviderChange = (newProvider: AIProviderKey) => {
@@ -159,8 +163,20 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
     setProvider(newProvider);
     setModel(nextModel);
     setCustomModel(false);
+    setOwnServer(false);
+    setBaseUrl('');
     aiKeyCheck.reset();
-    void localStorage.set({ aiProvider: newProvider, aiModel: nextModel });
+    void localStorage.set({ aiProvider: newProvider, aiModel: nextModel, aiBaseUrl: '' });
+  };
+
+  const handleOwnServerToggle = () => {
+    const next = !ownServer;
+    setOwnServer(next);
+    if (!next) {
+      setBaseUrl('');
+      void localStorage.set({ aiBaseUrl: '' });
+    }
+    aiKeyCheck.reset();
   };
 
   const handleModelChange = (nextModel: string) => {
@@ -209,7 +225,7 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
                 {i18n.t('settings.provider')}
               </label>
               <Select value={provider} onValueChange={(v) => handleProviderChange(v as AIProviderKey)}>
-                <SelectTrigger className="w-full rounded-xl px-4 py-2.5 text-sm focus:border-accent focus:ring-accent/10">
+                <SelectTrigger className="w-full h-11 rounded-xl px-4 text-sm focus:border-accent focus:ring-accent/10">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -225,7 +241,7 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
             <div>
               <label className="block text-xs font-semibold text-foreground mb-1.5">{i18n.t('settings.model')}</label>
               <Select value={usingCustomModel ? CUSTOM_MODEL_VALUE : model} onValueChange={handleModelChange}>
-                <SelectTrigger className="w-full rounded-xl px-4 py-2.5 text-sm focus:border-accent focus:ring-accent/10">
+                <SelectTrigger className="w-full h-11 rounded-xl px-4 text-sm focus:border-accent focus:ring-accent/10">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -246,19 +262,19 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
                     void localStorage.set({ aiModel: e.target.value });
                   }}
                   placeholder={providerConfig.defaultModel}
-                  className="w-full mt-1.5 rounded-xl px-4 py-2.5 text-sm focus:border-accent focus:ring-accent/10"
+                  className="w-full mt-1.5 h-11 rounded-xl px-4 text-sm focus:border-accent focus:ring-accent/10"
                 />
               )}
             </div>
 
             <div>
               <label className="block text-xs font-semibold text-foreground mb-1.5">{i18n.t('settings.apiKey')}</label>
-              <Input
-                type="password"
+              <SecretInput
                 value={apiKey}
-                onChange={(e) => handleApiKeyChange(e.target.value)}
+                onChange={handleApiKeyChange}
                 placeholder="sk-..."
-                className="w-full rounded-xl px-4 py-2.5 text-sm focus:border-accent focus:ring-accent/10"
+                className="w-full h-11 rounded-xl px-4 text-sm focus:border-accent focus:ring-accent/10"
+                buttonClassName="right-3"
               />
               <div className="flex items-center gap-3 mt-2">
                 <button
@@ -278,46 +294,56 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
               {aiKeyCheck.models && <ModelList models={aiKeyCheck.models} />}
             </div>
 
-            {providerConfig.baseUrl && (
-              <div>
+            <div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-xs font-semibold text-foreground flex items-center gap-1">
+                  <Globe size={12} className="-mt-px" />
+                  {i18n.t('settings.useOwnServer')}
+                </span>
                 <button
                   type="button"
-                  onClick={() => setAdvancedOpen((v) => !v)}
-                  className="flex items-center gap-1 text-xs font-semibold text-accent hover:text-foreground transition-colors py-0.5"
+                  role="switch"
+                  aria-checked={ownServer}
+                  aria-label={i18n.t('settings.useOwnServer')}
+                  onClick={handleOwnServerToggle}
+                  className={`w-10 h-6 rounded-full transition-colors relative shrink-0 ${
+                    ownServer ? 'bg-accent' : 'bg-border'
+                  }`}
                 >
-                  <ChevronDown
-                    size={14}
-                    className={`transition-transform duration-200 ${advancedOpen ? 'rotate-180' : ''}`}
+                  <span
+                    className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow-sm transition-transform ${
+                      ownServer ? 'translate-x-4' : 'translate-x-0'
+                    }`}
                   />
-                  Advanced
                 </button>
-                {advancedOpen && (
-                  <div className="mt-2 space-y-2">
-                    <label className="block text-xs font-semibold text-foreground mb-1.5">
-                      <Globe size={11} className="inline mr-1 -mt-px" />
-                      {i18n.t('settings.baseUrl')}
-                    </label>
-                    <Input
-                      type="text"
-                      value={baseUrl}
-                      onChange={(e) => handleBaseUrlChange(e.target.value)}
-                      placeholder={DEFAULT_OPENAI_BASE_URL}
-                      className="w-full rounded-xl px-4 py-2.5 text-sm focus:border-accent focus:ring-accent/10"
-                    />
-                    <p className="text-[10px] text-muted-foreground leading-relaxed">
-                      Custom endpoint for OpenAI-compatible APIs. Leave empty for the default.
-                    </p>
-                  </div>
-                )}
               </div>
-            )}
+              {ownServer && (
+                <div className="mt-2 space-y-2">
+                  <Input
+                    type="text"
+                    value={baseUrl}
+                    onChange={(e) => handleBaseUrlChange(e.target.value)}
+                    placeholder={providerConfig.defaultBaseUrl}
+                    aria-label={i18n.t('settings.baseUrl')}
+                    className="w-full h-11 rounded-xl px-4 text-sm focus:border-accent focus:ring-accent/10"
+                  />
+                  <p className="text-[11px] text-muted-foreground leading-relaxed">
+                    {i18n.t(
+                      providerConfig.protocol === 'anthropic'
+                        ? 'settings.ownServerHintAnthropic'
+                        : 'settings.ownServerHintOpenai',
+                    )}
+                  </p>
+                </div>
+              )}
+            </div>
 
             <div>
               <label className="block text-xs font-semibold text-foreground mb-1.5">
                 {i18n.t('settings.aiLanguage')}
               </label>
               <Select value={aiLanguage} onValueChange={(v) => handleLanguageChange(v as AILanguageCode)}>
-                <SelectTrigger className="w-full rounded-xl px-4 py-2.5 text-sm focus:border-accent focus:ring-accent/10">
+                <SelectTrigger className="w-full h-11 rounded-xl px-4 text-sm focus:border-accent focus:ring-accent/10">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -474,33 +500,37 @@ function VoiceStep({ onNext, onSkip, onBack, index, total }: StepProps) {
           <div className="border border-border rounded-2xl p-4 space-y-3 mb-6">
             <div className="flex gap-3">
               <div className="flex-1">
-                <label className="block text-[11px] font-semibold text-foreground mb-1">
+                <label className="block text-xs font-semibold text-foreground mb-1.5">
                   {i18n.t('settings.provider')}
                 </label>
-                <select
-                  value={provider}
-                  onChange={(e) => handleProviderChange(e.target.value as VoiceProvider)}
-                  className="w-full border border-border rounded-xl px-3 py-2 text-[13px] text-foreground bg-card font-medium outline-none focus:border-accent focus:ring-2 focus:ring-accent/10"
-                >
-                  <option value="openai">OpenAI</option>
-                  <option value="groq">Groq</option>
-                </select>
+                <Select value={provider} onValueChange={(v) => handleProviderChange(v as VoiceProvider)}>
+                  <SelectTrigger className="h-11 rounded-xl px-4 text-sm focus:border-accent focus:ring-accent/10">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="openai">OpenAI</SelectItem>
+                    <SelectItem value="groq">Groq</SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
               <div className="flex-1">
-                <label className="block text-[11px] font-semibold text-foreground mb-1">
+                <label className="block text-xs font-semibold text-foreground mb-1.5">
                   {i18n.t('settings.apiKey')}
                 </label>
-                <input
-                  type="password"
+                <SecretInput
                   value={apiKey}
-                  onChange={(e) => handleApiKeyChange(e.target.value)}
+                  onChange={handleApiKeyChange}
                   placeholder={provider === 'groq' ? 'gsk_...' : 'sk-...'}
-                  className="w-full border border-border rounded-xl px-3 py-2 text-[13px] text-foreground bg-card font-medium outline-none focus:border-accent focus:ring-2 focus:ring-accent/10 placeholder:text-muted-foreground/50"
+                  className="w-full h-11 rounded-xl px-4 text-sm focus:border-accent focus:ring-accent/10"
                 />
               </div>
             </div>
 
-            <MicrophonePicker value={microphoneId} onChange={handleMicrophoneChange} />
+            <MicrophonePicker
+              value={microphoneId}
+              onChange={handleMicrophoneChange}
+              triggerClassName="h-11 px-4 text-sm"
+            />
 
             <div className="flex items-start gap-2 px-3 py-2.5 rounded-xl bg-secondary text-[11px] text-muted-foreground leading-relaxed">
               <Mic size={12} className="shrink-0 mt-0.5 text-accent" />

--- a/src/ui/shared/MicrophonePicker.tsx
+++ b/src/ui/shared/MicrophonePicker.tsx
@@ -21,6 +21,7 @@ import {
 } from './microphones';
 
 interface MicrophonePickerProps {
+  triggerClassName?: string;
   value: string;
   onChange: (deviceId: string) => void;
 }
@@ -59,7 +60,7 @@ function StatusBadge({ status }: { status: MicrophoneStatus }) {
   );
 }
 
-export default function MicrophonePicker({ value, onChange }: MicrophonePickerProps) {
+export default function MicrophonePicker({ value, onChange, triggerClassName }: MicrophonePickerProps) {
   const [devices, setDevices] = useState<MicrophoneDevice[]>([]);
   const [testing, setTesting] = useState(false);
   const [level, setLevel] = useState(0);
@@ -219,11 +220,7 @@ export default function MicrophonePicker({ value, onChange }: MicrophonePickerPr
               onChange(toStoredMicrophoneId(next));
             }}
           >
-            <SelectTrigger
-              id={triggerId}
-              aria-label={i18n.t('settings.microphone')}
-              className="rounded-lg border-border bg-card text-[13px] font-medium text-foreground"
-            >
+            <SelectTrigger id={triggerId} aria-label={i18n.t('settings.microphone')} className={triggerClassName}>
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/src/ui/shared/SettingsView.tsx
+++ b/src/ui/shared/SettingsView.tsx
@@ -22,8 +22,10 @@ import {
   AI_PROVIDERS,
   type AIProviderKey,
   CUSTOM_MODEL_VALUE,
-  DEFAULT_OPENAI_BASE_URL,
+  DEFAULT_AI_PROVIDER,
+  isCustomBaseUrl,
   isCustomModel,
+  providerOrDefault,
 } from '@/core/capture/ai/models';
 import { AI_LANGUAGES, type AILanguageCode } from '@/core/capture/ai/prompts';
 import { resolveVoiceApiKey } from '@/core/capture/voice/api-key';
@@ -37,7 +39,7 @@ import { Input } from '@/ui/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/ui/components/ui/popover';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/ui/components/ui/select';
 import ColorPicker from '@/ui/shared/ColorPicker';
-import { KeyStatusNote, ModelList, useKeyCheck } from '@/ui/shared/key-check';
+import { KeyStatusNote, ModelList, SecretInput, useKeyCheck } from '@/ui/shared/key-check';
 import MicrophonePicker from '@/ui/shared/MicrophonePicker';
 import { changedSettings, type SettingsSnapshot } from '@/ui/shared/settings-autosave';
 
@@ -63,7 +65,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
   const aiKeyCheck = useKeyCheck();
   const voiceKeyCheck = useKeyCheck();
   const [customModel, setCustomModel] = useState(false);
-  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [ownServer, setOwnServer] = useState(false);
   const [loaded, setLoaded] = useState(false);
   const savedSnapshot = useRef<SettingsSnapshot | null>(null);
   const pending = useRef<SettingsSnapshot>({});
@@ -104,11 +106,14 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
         'brandAttribution',
       ])
       .then((result) => {
-        const p = (result.aiProvider as AIProviderKey) || 'openai';
+        const p = providerOrDefault(result.aiProvider);
         setProvider(p);
         setModel((result.aiModel as string) || AI_PROVIDERS[p].defaultModel);
         if (result.aiApiKey) setApiKey(result.aiApiKey as string);
-        if (result.aiBaseUrl) setBaseUrl(result.aiBaseUrl as string);
+        if (isCustomBaseUrl(AI_PROVIDERS[p], result.aiBaseUrl as string)) {
+          setBaseUrl(result.aiBaseUrl as string);
+          setOwnServer(true);
+        }
         if (result.aiLanguage) setAiLanguage(result.aiLanguage as AILanguageCode);
         if (result.blurPresets) setBlurPresets(result.blurPresets as Record<PresetKey, boolean>);
         setVoiceProvider((result.voiceProvider as VoiceProvider) || 'openai');
@@ -192,6 +197,16 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
     aiKeyCheck.reset();
     setCustomModel(false);
     setModel(AI_PROVIDERS[newProvider].defaultModel);
+    setOwnServer(false);
+    setBaseUrl('');
+  };
+
+  const handleOwnServerToggle = () => {
+    setOwnServer((on) => {
+      if (on) setBaseUrl('');
+      return !on;
+    });
+    aiKeyCheck.reset();
   };
 
   const handleModelChange = (value: string) => {
@@ -206,7 +221,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
     aiKeyCheck.reset();
   };
 
-  const providerConfig = AI_PROVIDERS[provider];
+  const providerConfig = AI_PROVIDERS[provider] ?? AI_PROVIDERS[DEFAULT_AI_PROVIDER];
   const usingCustomModel = customModel || isCustomModel(model, providerConfig);
   const voiceKey = resolveVoiceApiKey({ voiceProvider, voiceApiKey, aiProvider: provider, aiApiKey: apiKey });
 
@@ -257,7 +272,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
               {i18n.t('settings.provider')}
             </label>
             <Select value={provider} onValueChange={(v) => handleProviderChange(v as AIProviderKey)}>
-              <SelectTrigger className="w-full rounded-lg px-3 py-2 text-[13px]">
+              <SelectTrigger className="h-8">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -273,7 +288,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
           <div>
             <label className="block text-[11px] font-semibold text-foreground mb-1">{i18n.t('settings.model')}</label>
             <Select value={usingCustomModel ? CUSTOM_MODEL_VALUE : model} onValueChange={handleModelChange}>
-              <SelectTrigger className="w-full rounded-lg px-3 py-2 text-[13px]">
+              <SelectTrigger className="h-8">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -293,7 +308,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
                 }}
                 placeholder={providerConfig.defaultModel}
                 aria-label={i18n.t('settings.modelCustom')}
-                className="mt-1.5 h-8 text-[12px] rounded-lg border-border"
+                className="mt-1.5 h-8 text-[13px] rounded-lg border-border"
               />
             )}
           </div>
@@ -301,15 +316,14 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
           <div>
             <label className="block text-[11px] font-semibold text-foreground mb-1">{i18n.t('settings.apiKey')}</label>
             <div className="flex items-center gap-1.5">
-              <Input
-                type="password"
+              <SecretInput
                 value={apiKey}
-                onChange={(e) => {
-                  setApiKey(e.target.value);
+                onChange={(next) => {
+                  setApiKey(next);
                   aiKeyCheck.reset();
                 }}
                 placeholder="sk-..."
-                className="h-8 text-[12px] rounded-lg border-border"
+                className="h-8 text-[13px] rounded-lg border-border"
               />
               <Button
                 variant="outline"
@@ -333,43 +347,52 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
             )}
           </div>
 
-          {providerConfig.baseUrl && (
-            <div>
+          <div>
+            <div className="flex items-center justify-between gap-3 py-0.5">
+              <span className="text-[11px] font-semibold text-foreground flex items-center gap-1">
+                <Globe size={11} className="-mt-px" />
+                {i18n.t('settings.useOwnServer')}
+              </span>
               <button
                 type="button"
-                onClick={() => setAdvancedOpen((v) => !v)}
-                className="flex items-center gap-1 text-[11px] font-semibold text-accent hover:text-foreground transition-colors py-0.5"
+                role="switch"
+                aria-checked={ownServer}
+                aria-label={i18n.t('settings.useOwnServer')}
+                onClick={handleOwnServerToggle}
+                className={`w-9 h-5 rounded-full transition-colors relative shrink-0 ${
+                  ownServer ? 'bg-accent' : 'bg-border'
+                }`}
               >
-                <ChevronDown
-                  size={12}
-                  className={`transition-transform duration-200 ${advancedOpen ? 'rotate-180' : ''}`}
+                <span
+                  className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow-sm transition-transform ${
+                    ownServer ? 'translate-x-4' : 'translate-x-0'
+                  }`}
                 />
-                Advanced
               </button>
-              {advancedOpen && (
-                <div className="mt-2 space-y-2">
-                  <label className="block text-[11px] font-semibold text-foreground mb-1">
-                    <Globe size={11} className="inline mr-1 -mt-px" />
-                    {i18n.t('settings.baseUrl')}
-                  </label>
-                  <Input
-                    type="text"
-                    value={baseUrl}
-                    onChange={(e) => {
-                      setBaseUrl(e.target.value);
-                      aiKeyCheck.reset();
-                    }}
-                    placeholder={DEFAULT_OPENAI_BASE_URL}
-                    aria-label={i18n.t('settings.baseUrl')}
-                    className="h-8 text-[12px] rounded-lg border-border"
-                  />
-                  <p className="text-[10px] text-muted-foreground leading-relaxed">
-                    Custom endpoint for OpenAI-compatible APIs. Leave empty for the default.
-                  </p>
-                </div>
-              )}
             </div>
-          )}
+            {ownServer && (
+              <div className="mt-2 space-y-1.5">
+                <Input
+                  type="text"
+                  value={baseUrl}
+                  onChange={(e) => {
+                    setBaseUrl(e.target.value);
+                    aiKeyCheck.reset();
+                  }}
+                  placeholder={providerConfig.defaultBaseUrl}
+                  aria-label={i18n.t('settings.baseUrl')}
+                  className="h-8 text-[13px] rounded-lg border-border"
+                />
+                <p className="text-[10px] text-muted-foreground leading-relaxed">
+                  {i18n.t(
+                    providerConfig.protocol === 'anthropic'
+                      ? 'settings.ownServerHintAnthropic'
+                      : 'settings.ownServerHintOpenai',
+                  )}
+                </p>
+              </div>
+            )}
+          </div>
 
           <div>
             <label className="block text-[11px] font-semibold text-foreground mb-1">
@@ -377,7 +400,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
               {i18n.t('settings.aiLanguage')}
             </label>
             <Select value={aiLanguage} onValueChange={(v) => setAiLanguage(v as AILanguageCode)}>
-              <SelectTrigger className="w-full rounded-lg px-3 py-2 text-[13px]">
+              <SelectTrigger className="h-8">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -397,7 +420,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
               <Target size={14} className="text-accent" />
             </div>
             <div>
-              <div className="text-[13px] font-semibold text-foreground">{i18n.t('settings.targetColor')}</div>
+              <div className="text-xs font-bold text-foreground">{i18n.t('settings.targetColor')}</div>
               <div className="text-[11px] text-muted-foreground">{i18n.t('settings.targetColorHint')}</div>
             </div>
           </div>
@@ -475,7 +498,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
               value={brandFooter}
               onChange={(e) => setBrandFooter(e.target.value)}
               placeholder={i18n.t('settings.footerLinePlaceholder')}
-              className="h-8 text-[12px] rounded-lg border-border"
+              className="h-8 text-[13px] rounded-lg border-border"
             />
             <div className="flex flex-wrap gap-1.5 mt-2">
               {FOOTER_PRESETS().map((preset) => (
@@ -524,30 +547,34 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
             <label className="block text-[11px] font-semibold text-foreground mb-1">
               {i18n.t('settings.provider')}
             </label>
-            <select
+            <Select
               value={voiceProvider}
-              onChange={(e) => {
-                setVoiceProvider(e.target.value as VoiceProvider);
+              onValueChange={(v) => {
+                setVoiceProvider(v as VoiceProvider);
                 voiceKeyCheck.reset();
               }}
-              className="w-full border border-border rounded-lg px-3 py-2 text-[13px] text-foreground bg-card font-medium outline-none focus:border-ring focus:ring-2 focus:ring-ring/10"
             >
-              <option value="openai">OpenAI</option>
-              <option value="groq">Groq</option>
-            </select>
+              <SelectTrigger className="h-8">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="openai">OpenAI</SelectItem>
+                <SelectItem value="groq">Groq</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
 
           <div>
             <label className="block text-[11px] font-semibold text-foreground mb-1">{i18n.t('settings.apiKey')}</label>
             <div className="flex items-center gap-1.5">
-              <Input
-                type="password"
+              <SecretInput
                 value={voiceApiKey}
-                onChange={(e) => {
-                  setVoiceApiKey(e.target.value);
+                onChange={(next) => {
+                  setVoiceApiKey(next);
                   voiceKeyCheck.reset();
                 }}
                 placeholder={voiceProvider === 'groq' ? 'gsk_...' : 'sk-...'}
+                className="h-8 text-[13px] rounded-lg border-border"
               />
               <Button
                 variant="outline"
@@ -576,7 +603,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
           </div>
 
           {import.meta.env.BROWSER !== 'firefox' && (
-            <MicrophonePicker value={voiceMicrophoneId} onChange={setVoiceMicrophoneId} />
+            <MicrophonePicker value={voiceMicrophoneId} onChange={setVoiceMicrophoneId} triggerClassName="h-8" />
           )}
         </div>
 
@@ -593,7 +620,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
               key={key}
               className={`flex items-center justify-between py-2 ${i < arr.length - 1 ? 'border-b border-secondary' : ''}`}
             >
-              <span className="text-xs font-medium text-foreground">{i18n.t(BLUR_PRESET_I18N[key])}</span>
+              <span className="text-[11px] font-semibold text-foreground">{i18n.t(BLUR_PRESET_I18N[key])}</span>
               <button
                 onClick={() =>
                   setBlurPresets((prev) => {

--- a/src/ui/shared/__tests__/key-check.test.tsx
+++ b/src/ui/shared/__tests__/key-check.test.tsx
@@ -1,13 +1,13 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { act, render, renderHook, screen } from '@testing-library/react';
+import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { sendMessageMock } = vi.hoisted(() => ({ sendMessageMock: vi.fn() }));
 
 vi.mock('@/lib/messaging', () => ({ sendMessage: sendMessageMock }));
 
-import { KeyStatusNote, useKeyCheck } from '@/ui/shared/key-check';
+import { KeyStatusNote, SecretInput, useKeyCheck } from '@/ui/shared/key-check';
 
 describe('useKeyCheck', () => {
   beforeEach(() => {
@@ -60,4 +60,29 @@ it('shows a distinct model-required note', () => {
 it('shows a distinct model-invalid note', () => {
   render(<KeyStatusNote status="model-invalid" />);
   expect(screen.getByText('settings.keyModelInvalid')).toBeInTheDocument();
+});
+
+describe('SecretInput', () => {
+  it('hides the key until the reveal button is pressed, and hides it again', () => {
+    render(<SecretInput value="sk-secret" onChange={() => {}} placeholder="sk-..." />);
+
+    const field = screen.getByPlaceholderText('sk-...');
+    expect(field).toHaveAttribute('type', 'password');
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(field).toHaveAttribute('type', 'text');
+    expect(field).toHaveValue('sk-secret');
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(field).toHaveAttribute('type', 'password');
+  });
+
+  it('reports edits while revealed', () => {
+    const onChange = vi.fn();
+    render(<SecretInput value="" onChange={onChange} placeholder="sk-..." />);
+
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.change(screen.getByPlaceholderText('sk-...'), { target: { value: 'sk-typed' } });
+    expect(onChange).toHaveBeenCalledWith('sk-typed');
+  });
 });

--- a/src/ui/shared/key-check.tsx
+++ b/src/ui/shared/key-check.tsx
@@ -1,7 +1,8 @@
-import { Check } from 'lucide-react';
+import { Check, Eye, EyeOff } from 'lucide-react';
 import { useCallback, useRef, useState } from 'react';
 import { i18n } from '#imports';
 import { sendMessage } from '@/lib/messaging';
+import { Input } from '@/ui/components/ui/input';
 
 export type KeyStatus = 'checking' | 'valid' | 'rejected' | 'unreachable' | 'model-required' | 'model-invalid' | null;
 
@@ -102,6 +103,44 @@ export function ModelList({ models }: { models: string[] }) {
           </li>
         ))}
       </ul>
+    </div>
+  );
+}
+
+export function SecretInput({
+  value,
+  onChange,
+  placeholder,
+  className,
+  buttonClassName,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  placeholder?: string;
+  className?: string;
+  buttonClassName?: string;
+}) {
+  const [revealed, setRevealed] = useState(false);
+  const Icon = revealed ? EyeOff : Eye;
+  return (
+    <div className="relative flex-1 min-w-0">
+      <Input
+        type={revealed ? 'text' : 'password'}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className={`pr-8 ${className ?? ''}`}
+      />
+      <button
+        type="button"
+        onClick={() => setRevealed((on) => !on)}
+        aria-pressed={revealed}
+        aria-label={i18n.t(revealed ? 'settings.hideKey' : 'settings.showKey')}
+        title={i18n.t(revealed ? 'settings.hideKey' : 'settings.showKey')}
+        className={`absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors ${buttonClassName ?? ''}`}
+      >
+        <Icon size={13} />
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
The "OpenAI Compatible" provider failed every key check without contacting the server, and left the model list empty. The setting that worked was a Base URL box hidden under Advanced on OpenAI, described in the same words as the broken option.

That provider is gone. Every provider now gets a "Use my own server" switch, off by default, styled like the Smart Blur toggles. Endpoint, protocol and transport come from one per-provider table, so Anthropic and DeepSeek take a custom server too and DeepSeek's URL stops being hardcoded.

Custom servers generate over `/chat/completions` rather than the SDK's default Responses API, which is what the key check already probed and what Ollama and LM Studio implement. Anyone with the removed provider stored falls back to OpenAI instead of crashing settings.

Model lists stay per vendor, so a custom server draws models from its own catalogue.

An API key field can now be revealed to fix a typo in place, in settings and onboarding. Every control in those panels was also put on one height and one text size, and the two remaining native selects became the shared component.
