### PR TITLE
feat(ai): add openrouter as a provider

### DIFF
--- a/src/core/capture/ai/__tests__/models.test.ts
+++ b/src/core/capture/ai/__tests__/models.test.ts
@@ -86,7 +86,21 @@ describe('every provider takes a custom server', () => {
   });
 
   it('no longer offers a second OpenAI entry', () => {
-    expect(Object.keys(AI_PROVIDERS)).toEqual(['openai', 'anthropic', 'deepseek']);
+    expect(Object.keys(AI_PROVIDERS)).not.toContain('openaiCompatible');
+  });
+
+  it('offers OpenRouter with its own endpoint and a model id the catalogue carries', () => {
+    const config = AI_PROVIDERS.openrouter;
+    expect(config.defaultBaseUrl).toBe('https://openrouter.ai/api/v1');
+    expect(config.protocol).toBe('openai');
+    expect(config.transport).toBe('chat');
+    expect(config.keyCheckPath).toBe('/key');
+    expect(config.defaultModel).toBe('openai/gpt-4o-mini');
+    expect(config.models.some((m) => m.id.endsWith(':free'))).toBe(true);
+    for (const option of config.models) {
+      if (option.id === CUSTOM_MODEL_VALUE) continue;
+      expect(option.id).toMatch(/^[a-z0-9-]+\/[\w.-]+(:[\w-]+)?$/);
+    }
   });
 
   it('includes a Custom model option', () => {

--- a/src/core/capture/ai/__tests__/validate.test.ts
+++ b/src/core/capture/ai/__tests__/validate.test.ts
@@ -271,4 +271,55 @@ describe('validateApiKey', () => {
       expect(fetchMock).not.toHaveBeenCalled();
     });
   });
+
+  describe('openrouter', () => {
+    it('checks the key against the authenticated endpoint, not the public catalogue', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ data: { label: 'sk-or-...', usage: 0 } }));
+      fetchMock.mockResolvedValueOnce(modelsBody('openai/gpt-4o-mini', 'anthropic/claude-haiku-4.5'));
+      expect(await validateApiKey('openrouter', 'sk-or-good')).toEqual({
+        valid: true,
+        models: ['openai/gpt-4o-mini', 'anthropic/claude-haiku-4.5'],
+      });
+      expect(fetchMock.mock.calls[0][0]).toBe('https://openrouter.ai/api/v1/key');
+      expect(fetchMock.mock.calls[1][0]).toBe('https://openrouter.ai/api/v1/models');
+    });
+
+    it('rejects a bad key even though the catalogue would answer 200 to anyone', async () => {
+      fetchMock.mockResolvedValueOnce(errorResponse(401));
+      expect(await validateApiKey('openrouter', 'sk-or-bad')).toEqual({ valid: false, reason: 'rejected' });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0][0]).toBe('https://openrouter.ai/api/v1/key');
+    });
+
+    it('still reports the key as good when the catalogue request fails', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ data: { label: 'sk-or-...' } }));
+      fetchMock.mockRejectedValueOnce(new TypeError('fetch failed'));
+      expect(await validateApiKey('openrouter', 'sk-or-good')).toEqual({ valid: true });
+    });
+
+    it('sends the key as a bearer token', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ data: {} }));
+      fetchMock.mockResolvedValueOnce(modelsBody('openai/gpt-4o-mini'));
+      await validateApiKey('openrouter', 'sk-or-good');
+      const [, init] = fetchMock.mock.calls[0];
+      expect((init!.headers as Record<string, string>).Authorization).toBe('Bearer sk-or-good');
+    });
+
+    it('goes through the custom server path when pointed elsewhere', async () => {
+      fetchMock.mockResolvedValueOnce(chatOkBody());
+      fetchMock.mockResolvedValueOnce(modelsBody('local-model'));
+      expect(await validateApiKey('openrouter', 'sk-key', 'http://localhost:8787/v1', 'local-model')).toEqual({
+        valid: true,
+        models: ['local-model'],
+      });
+      expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:8787/v1/chat/completions');
+    });
+
+    it('leaves providers without an authenticated path checking their catalogue', async () => {
+      fetchMock.mockResolvedValueOnce(modelsBody('gpt-4o-mini'));
+      await validateApiKey('openai', 'sk-good');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0][0]).toBe('https://api.openai.com/v1/models');
+    });
+  });
 });

--- a/src/core/capture/ai/models.ts
+++ b/src/core/capture/ai/models.ts
@@ -12,6 +12,7 @@ export interface AIProviderConfig {
   protocol: AIProtocol;
   transport?: OpenAITransport;
   defaultBaseUrl: string;
+  keyCheckPath?: string;
   defaultModel: string;
   models: AIModelOption[];
 }
@@ -55,6 +56,23 @@ export const AI_PROVIDERS = {
       { id: 'deepseek-v4-flash', label: 'DeepSeek V4 Flash' },
       { id: 'deepseek-v4-pro', label: 'DeepSeek V4 Pro' },
       { id: 'deepseek-v4-flash-vision-exp', label: 'DeepSeek V4 Flash Vision Exp' },
+      { id: CUSTOM_MODEL_VALUE, label: 'Custom' },
+    ],
+  },
+  openrouter: {
+    label: 'OpenRouter',
+    protocol: 'openai',
+    transport: 'chat',
+    defaultBaseUrl: 'https://openrouter.ai/api/v1',
+    keyCheckPath: '/key',
+    defaultModel: 'openai/gpt-4o-mini',
+    models: [
+      { id: 'google/gemma-4-26b-a4b-it:free', label: 'Gemma 4 26B (free)' },
+      { id: 'openai/gpt-4o-mini', label: 'GPT-4o Mini' },
+      { id: 'openai/gpt-4.1-mini', label: 'GPT-4.1 Mini' },
+      { id: 'anthropic/claude-haiku-4.5', label: 'Claude Haiku 4.5' },
+      { id: 'google/gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+      { id: 'google/gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash Lite' },
       { id: CUSTOM_MODEL_VALUE, label: 'Custom' },
     ],
   },

--- a/src/core/capture/ai/validate.ts
+++ b/src/core/capture/ai/validate.ts
@@ -142,5 +142,13 @@ export async function validateApiKey(
 
   if (isCustomBaseUrl(config, baseUrl)) return validateCustomServer(config, apiKey, baseUrl as string, model);
 
-  return checkCatalog(`${resolveBaseUrl(config)}/models`, PROTOCOL_HEADERS[config.protocol](apiKey));
+  const headers = PROTOCOL_HEADERS[config.protocol](apiKey);
+  const base = resolveBaseUrl(config);
+  const catalogUrl = `${base}/models`;
+  if (!config.keyCheckPath) return checkCatalog(catalogUrl, headers);
+
+  const authenticated = await checkCatalog(`${base}${config.keyCheckPath}`, headers);
+  if (!authenticated.valid) return authenticated;
+  const models = await fetchModelsFromUrl(catalogUrl, headers);
+  return models ? { valid: true, models } : { valid: true };
 }


### PR DESCRIPTION
OpenRouter is OpenAI-compatible, so this is an entry in the provider table rather than an integration: its own endpoint, chat completions, and a short list of cheap models spanning vendors, with Custom for any of the other 440.

One part did not fall out of the table. OpenRouter's catalogue is public, so the usual key check against `/models` answers 200 to any string and would have called every bad key valid. Keys are checked against `/key`, which 401s, and the catalogue is fetched only once the key is good. Providers with no authenticated path are unchanged.

Most OpenRouter models are paid, so the list carries one `:free` model to make the provider usable on a zero balance. Free models are rate limited to roughly 20 requests a minute, which a long recording will exceed. The six listed ids were verified against the live catalogue.

Closes #70.
