### PR TITLE
fix(ai): keep keys per provider and say why a description failed

### DIFF
--- a/src/core/blur/__tests__/scanner.test.ts
+++ b/src/core/blur/__tests__/scanner.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { BlurScanner } from '../scanner';
+
+const BLURRED = '.mimik-blur';
+
+function scanWith(html: string): Document {
+  document.body.innerHTML = html;
+  const scanner = new BlurScanner();
+  scanner.start(['email']);
+  scanner.detach();
+  return document;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('text node filtering', () => {
+  it('blurs a match in real text', () => {
+    scanWith('<p>Write to ada@example.com today</p>');
+    expect(document.querySelectorAll(BLURRED)).toHaveLength(1);
+    expect(document.querySelector(BLURRED)?.textContent).toBe('ada@example.com');
+  });
+
+  it('leaves text with no match alone', () => {
+    scanWith('<p>Nothing sensitive here</p>');
+    expect(document.querySelectorAll(BLURRED)).toHaveLength(0);
+  });
+
+  it('skips empty and whitespace-only nodes without throwing', () => {
+    expect(() => scanWith('<p></p><p>   </p><p>\n\t </p><span></span>')).not.toThrow();
+    expect(document.querySelectorAll(BLURRED)).toHaveLength(0);
+  });
+
+  it('still finds a match among empty and blank siblings', () => {
+    scanWith('<p></p><p>   </p><p>ada@example.com</p><p> </p>');
+    expect(document.querySelectorAll(BLURRED)).toHaveLength(1);
+  });
+
+  it('never walks into an excluded tag', () => {
+    scanWith('<script>ada@example.com</script><style>bob@example.com</style><p>carol@example.com</p>');
+    expect(document.querySelectorAll(BLURRED)).toHaveLength(1);
+    expect(document.querySelector(BLURRED)?.textContent).toBe('carol@example.com');
+  });
+
+  it('does not blur inside something already blurred', () => {
+    scanWith('<p>ada@example.com and bob@example.com</p>');
+    const first = document.querySelectorAll(BLURRED).length;
+    const scanner = new BlurScanner();
+    scanner.start(['email']);
+    scanner.detach();
+    expect(document.querySelectorAll(BLURRED)).toHaveLength(first);
+  });
+});

--- a/src/core/blur/scanner.ts
+++ b/src/core/blur/scanner.ts
@@ -61,7 +61,7 @@ export class BlurScanner {
         if (!node.parentElement) return NodeFilter.FILTER_REJECT;
         if (EXCLUDED_TAGS.has(node.parentElement.tagName)) return NodeFilter.FILTER_REJECT;
         if (node.parentElement.closest(`[${BLUR_ATTR}]`)) return NodeFilter.FILTER_REJECT;
-        if (!node.textContent || !node.textContent.trim()) return NodeFilter.FILTER_REJECT;
+        if (!node.textContent?.trim()) return NodeFilter.FILTER_REJECT;
         return NodeFilter.FILTER_ACCEPT;
       },
     });

--- a/src/core/capture/ai/__tests__/errors.test.ts
+++ b/src/core/capture/ai/__tests__/errors.test.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { APICallError, RetryError } from 'ai';
+import { describe, expect, it } from 'vitest';
+import { aiActionKey, aiFailureKey } from '@/ui/sidepanel/ai-status';
+import { type AiFailureReason, describeAiFailure } from '../errors';
+
+const LOCALES = ['en', 'de', 'es', 'fr', 'pt-BR', 'zh-CN'];
+const REASONS: AiFailureReason[] = [
+  'rejected',
+  'no-credits',
+  'rate-limited',
+  'model-invalid',
+  'quota',
+  'network',
+  'unknown',
+];
+
+function apiError(statusCode: number) {
+  return new APICallError({
+    message: 'Provider returned error',
+    url: 'https://openrouter.ai/api/v1/chat/completions',
+    requestBodyValues: {},
+    statusCode,
+  });
+}
+
+describe('describeAiFailure', () => {
+  it.each([
+    [401, 'rejected'],
+    [403, 'rejected'],
+    [402, 'no-credits'],
+    [429, 'rate-limited'],
+    [404, 'model-invalid'],
+    [413, 'quota'],
+    [500, 'network'],
+  ])('reads %i as %s', (status, reason) => {
+    expect(describeAiFailure(apiError(status))).toMatchObject({ reason, status });
+  });
+
+  it('finds the status inside a retry error, so a rate limit is not read as unknown', () => {
+    const retry = new RetryError({
+      message: 'Failed after 3 attempts. Last error: Provider returned error',
+      reason: 'maxRetriesExceeded',
+      errors: [apiError(429), apiError(429), apiError(429)],
+    });
+    expect(describeAiFailure(retry)).toMatchObject({ reason: 'rate-limited', status: 429 });
+  });
+
+  it('reads a bare failure with no status as unknown rather than guessing', () => {
+    expect(describeAiFailure(new TypeError('fetch failed'))).toEqual({
+      reason: 'unknown',
+      message: 'fetch failed',
+    });
+  });
+
+  it('survives a thrown non-error', () => {
+    expect(describeAiFailure('boom')).toEqual({ reason: 'unknown', message: 'boom' });
+    expect(describeAiFailure(null)).toEqual({ reason: 'unknown', message: 'null' });
+  });
+});
+
+describe('failure copy', () => {
+  it('gives every reason its own message, in every locale', () => {
+    for (const locale of LOCALES) {
+      const text = readFileSync(join(process.cwd(), 'src/locales', `${locale}.yml`), 'utf8');
+      for (const reason of REASONS) {
+        for (const key of [aiFailureKey(reason), aiActionKey(reason)]) {
+          const name = key.replace('aiStatus.', '');
+          expect(text, `${locale} is missing ${name}`).toContain(`  ${name}:`);
+        }
+      }
+    }
+  });
+
+  it('maps an unrecognised reason to the catch-all rather than crashing', () => {
+    expect(aiFailureKey(undefined)).toBe('aiStatus.unknown');
+    expect(aiActionKey(undefined)).toBe('aiStatus.actionCheckKey');
+  });
+
+  it('names the provider in every headline that can', () => {
+    const en = readFileSync(join(process.cwd(), 'src/locales/en.yml'), 'utf8');
+    for (const reason of ['rejected', 'no-credits', 'rate-limited', 'model-invalid', 'network', 'unknown'] as const) {
+      const name = aiFailureKey(reason).replace('aiStatus.', '');
+      const line = en.split('\n').find((l) => l.startsWith(`  ${name}:`));
+      expect(line, `${name} should interpolate the provider`).toContain('$1');
+    }
+  });
+
+  it('gives every reason an action to take', () => {
+    for (const reason of REASONS) expect(aiActionKey(reason)).toMatch(/^aiStatus\.action/);
+  });
+});

--- a/src/core/capture/ai/__tests__/keys.test.ts
+++ b/src/core/capture/ai/__tests__/keys.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { keyFor, migrateApiKeys, parseApiKeys, resolveAiKey, withKeyFor } from '../keys';
+
+describe('parseApiKeys', () => {
+  it('keeps only keys for providers that exist', () => {
+    expect(parseApiKeys({ openai: 'sk-a', openaiCompatible: 'sk-gone', anthropic: 'ak-b' })).toEqual({
+      openai: 'sk-a',
+      anthropic: 'ak-b',
+    });
+  });
+
+  it('drops blank keys and non-strings', () => {
+    expect(parseApiKeys({ openai: '   ', anthropic: 42, deepseek: 'sk-c' })).toEqual({ deepseek: 'sk-c' });
+  });
+
+  it('reads anything that is not an object as no keys', () => {
+    expect(parseApiKeys(null)).toEqual({});
+    expect(parseApiKeys('sk-loose')).toEqual({});
+    expect(parseApiKeys(undefined)).toEqual({});
+  });
+});
+
+describe('migrateApiKeys', () => {
+  it('attaches a pre-existing single key to the provider that was selected', () => {
+    expect(migrateApiKeys({ aiApiKey: 'sk-legacy', aiProvider: 'anthropic' })).toEqual({ anthropic: 'sk-legacy' });
+  });
+
+  it('attaches a legacy key to openai when the stored provider is gone', () => {
+    expect(migrateApiKeys({ aiApiKey: 'sk-legacy', aiProvider: 'openaiCompatible' })).toEqual({ openai: 'sk-legacy' });
+  });
+
+  it('prefers the per-provider map once it exists', () => {
+    expect(migrateApiKeys({ aiApiKeys: { openai: 'sk-new' }, aiApiKey: 'sk-legacy', aiProvider: 'anthropic' })).toEqual(
+      { openai: 'sk-new' },
+    );
+  });
+
+  it('returns nothing when no key was ever saved', () => {
+    expect(migrateApiKeys({})).toEqual({});
+    expect(migrateApiKeys({ aiApiKey: '  ' })).toEqual({});
+  });
+});
+
+describe('keyFor and withKeyFor', () => {
+  it('reads a provider with no key as empty rather than undefined', () => {
+    expect(keyFor({ openai: 'sk-a' }, 'anthropic')).toBe('');
+  });
+
+  it('stores a key against one provider without touching the others', () => {
+    const next = withKeyFor({ openai: 'sk-a' }, 'anthropic', 'ak-b');
+    expect(next).toEqual({ openai: 'sk-a', anthropic: 'ak-b' });
+  });
+
+  it('clearing one provider leaves the others intact', () => {
+    expect(withKeyFor({ openai: 'sk-a', anthropic: 'ak-b' }, 'anthropic', '')).toEqual({ openai: 'sk-a' });
+    expect(withKeyFor({ openai: 'sk-a', anthropic: 'ak-b' }, 'anthropic', '   ')).toEqual({ openai: 'sk-a' });
+  });
+});
+
+describe('resolveAiKey', () => {
+  it('hands back the key belonging to the selected provider, never another', () => {
+    const stored = { aiApiKeys: { openai: 'sk-openai', anthropic: 'ak-anthropic' }, aiProvider: 'anthropic' };
+    expect(resolveAiKey(stored)).toEqual({ provider: 'anthropic', apiKey: 'ak-anthropic' });
+  });
+
+  it('reports no key rather than a neighbour key when the selected provider has none', () => {
+    const stored = { aiApiKeys: { openai: 'sk-openai' }, aiProvider: 'openrouter' };
+    expect(resolveAiKey(stored)).toEqual({ provider: 'openrouter', apiKey: '' });
+  });
+
+  it('falls back to openai for an unknown stored provider', () => {
+    expect(resolveAiKey({ aiApiKeys: { openai: 'sk-a' }, aiProvider: 'nope' })).toEqual({
+      provider: 'openai',
+      apiKey: 'sk-a',
+    });
+  });
+});

--- a/src/core/capture/ai/__tests__/validate.test.ts
+++ b/src/core/capture/ai/__tests__/validate.test.ts
@@ -7,7 +7,7 @@ const { fetchMock } = vi.hoisted(() => {
 
 vi.stubGlobal('fetch', fetchMock);
 
-import { validateApiKey } from '../validate';
+import { spendWarning, validateApiKey } from '../validate';
 
 function jsonResponse(body: unknown, init?: ResponseInit) {
   return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' }, ...init });
@@ -320,6 +320,52 @@ describe('validateApiKey', () => {
       await validateApiKey('openai', 'sk-good');
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock.mock.calls[0][0]).toBe('https://api.openai.com/v1/models');
+    });
+  });
+
+  describe('whether a key can spend', () => {
+    const freeTierKeyBody = {
+      data: {
+        is_free_tier: true,
+        limit: null,
+        limit_remaining: null,
+        usage: 0,
+        rate_limit: { interval: '10s', requests: -1, note: 'This field is deprecated and safe to ignore.' },
+      },
+    };
+
+    it('warns when the account has never bought credits', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(freeTierKeyBody));
+      fetchMock.mockResolvedValueOnce(modelsBody('openai/gpt-4o-mini'));
+      expect(await validateApiKey('openrouter', 'sk-or-free')).toEqual({
+        valid: true,
+        models: ['openai/gpt-4o-mini'],
+        warning: 'cannot-spend',
+      });
+    });
+
+    it('stays quiet for a funded account', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ data: { is_free_tier: false, limit_remaining: null } }));
+      fetchMock.mockResolvedValueOnce(modelsBody('openai/gpt-4o-mini'));
+      expect(await validateApiKey('openrouter', 'sk-or-paid')).toEqual({
+        valid: true,
+        models: ['openai/gpt-4o-mini'],
+      });
+    });
+
+    it('warns when the key has spent its own cap', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ data: { is_free_tier: false, limit_remaining: 0 } }));
+      fetchMock.mockResolvedValueOnce(modelsBody('openai/gpt-4o-mini'));
+      expect(await validateApiKey('openrouter', 'sk-or-spent')).toMatchObject({ warning: 'cannot-spend' });
+    });
+
+    it('ignores the deprecated rate limit field rather than reading it as a cap', () => {
+      expect(spendWarning({ data: { rate_limit: { requests: -1 } } })).toBeUndefined();
+    });
+
+    it('says nothing about providers that expose no spend information', async () => {
+      fetchMock.mockResolvedValueOnce(modelsBody('gpt-4o-mini'));
+      expect(await validateApiKey('openai', 'sk-good')).toEqual({ valid: true, models: ['gpt-4o-mini'] });
     });
   });
 });

--- a/src/core/capture/ai/description.ts
+++ b/src/core/capture/ai/description.ts
@@ -1,6 +1,5 @@
 import { generateText } from 'ai';
 import { localStorage } from '@/lib/browser-api';
-import { logger } from '@/lib/logger';
 import type { DOMContext } from '../dom/context';
 import { serializeDOMContext } from '../dom/context';
 import { getLanguageSuffix, STEP_DESCRIPTION_PROMPT } from './prompts';
@@ -13,18 +12,12 @@ export async function getAIDescription(
   apiKey: string,
   baseUrl?: string,
 ): Promise<string | null> {
-  try {
-    const settings = await localStorage.get(['aiLanguage']);
-    const locale = (settings.aiLanguage as string) || 'en';
-    const { text } = await generateText({
-      model: createModel(provider, model, apiKey, baseUrl),
-      prompt:
-        STEP_DESCRIPTION_PROMPT.replace('{{context}}', serializeDOMContext(domContext)) + getLanguageSuffix(locale),
-      maxOutputTokens: 50,
-    });
-    return text.trim().replace(/^"|"$/g, '') || null;
-  } catch (err) {
-    logger.error('AI description failed, using fallback', err);
-    return null;
-  }
+  const settings = await localStorage.get(['aiLanguage']);
+  const locale = (settings.aiLanguage as string) || 'en';
+  const { text } = await generateText({
+    model: createModel(provider, model, apiKey, baseUrl),
+    prompt: STEP_DESCRIPTION_PROMPT.replace('{{context}}', serializeDOMContext(domContext)) + getLanguageSuffix(locale),
+    maxOutputTokens: 50,
+  });
+  return text.trim().replace(/^"|"$/g, '') || null;
 }

--- a/src/core/capture/ai/errors.ts
+++ b/src/core/capture/ai/errors.ts
@@ -1,0 +1,45 @@
+export type AiFailureReason =
+  | 'rejected'
+  | 'no-credits'
+  | 'rate-limited'
+  | 'model-invalid'
+  | 'quota'
+  | 'network'
+  | 'unknown';
+
+export interface AiFailure {
+  reason: AiFailureReason;
+  status?: number;
+  message: string;
+}
+
+function statusOf(err: unknown): number | undefined {
+  let current = err;
+  for (let depth = 0; depth < 5 && typeof current === 'object' && current !== null; depth += 1) {
+    const status = (current as { statusCode?: unknown }).statusCode;
+    if (typeof status === 'number') return status;
+    current = (current as { lastError?: unknown; cause?: unknown }).lastError ?? (current as { cause?: unknown }).cause;
+  }
+  return undefined;
+}
+
+function messageOf(err: unknown): string {
+  if (typeof err === 'object' && err !== null) {
+    const message = (err as { message?: unknown }).message;
+    if (typeof message === 'string' && message) return message;
+  }
+  return String(err);
+}
+
+export function describeAiFailure(err: unknown): AiFailure {
+  const status = statusOf(err);
+  const message = messageOf(err);
+
+  if (status === 401 || status === 403) return { reason: 'rejected', status, message };
+  if (status === 402) return { reason: 'no-credits', status, message };
+  if (status === 429) return { reason: 'rate-limited', status, message };
+  if (status === 404) return { reason: 'model-invalid', status, message };
+  if (status === 413) return { reason: 'quota', status, message };
+  if (status !== undefined) return { reason: 'network', status, message };
+  return { reason: 'unknown', message };
+}

--- a/src/core/capture/ai/keys.ts
+++ b/src/core/capture/ai/keys.ts
@@ -1,0 +1,44 @@
+import { type AIProviderKey, isProviderKey, providerOrDefault } from './models';
+
+export type AIApiKeys = Partial<Record<AIProviderKey, string>>;
+
+export function parseApiKeys(value: unknown): AIApiKeys {
+  if (typeof value !== 'object' || value === null) return {};
+  const keys: AIApiKeys = {};
+  for (const [provider, key] of Object.entries(value as Record<string, unknown>)) {
+    if (!isProviderKey(provider)) continue;
+    const trimmed = typeof key === 'string' ? key.trim() : '';
+    if (trimmed) keys[provider] = trimmed;
+  }
+  return keys;
+}
+
+export function migrateApiKeys(stored: { aiApiKeys?: unknown; aiApiKey?: unknown; aiProvider?: unknown }): AIApiKeys {
+  const keys = parseApiKeys(stored.aiApiKeys);
+  if (Object.keys(keys).length > 0) return keys;
+
+  const legacy = typeof stored.aiApiKey === 'string' ? stored.aiApiKey.trim() : '';
+  return legacy ? { [providerOrDefault(stored.aiProvider)]: legacy } : {};
+}
+
+export function keyFor(keys: AIApiKeys, provider: AIProviderKey): string {
+  return keys[provider] ?? '';
+}
+
+export function withKeyFor(keys: AIApiKeys, provider: AIProviderKey, apiKey: string): AIApiKeys {
+  const next = { ...keys };
+  const trimmed = apiKey.trim();
+  if (trimmed) next[provider] = apiKey;
+  else delete next[provider];
+  return next;
+}
+
+export const AI_KEY_SETTINGS = ['aiApiKeys', 'aiApiKey', 'aiProvider'] as const;
+
+export function resolveAiKey(stored: { aiApiKeys?: unknown; aiApiKey?: unknown; aiProvider?: unknown }): {
+  provider: AIProviderKey;
+  apiKey: string;
+} {
+  const provider = providerOrDefault(stored.aiProvider);
+  return { provider, apiKey: keyFor(migrateApiKeys(stored), provider) };
+}

--- a/src/core/capture/ai/rewrite.ts
+++ b/src/core/capture/ai/rewrite.ts
@@ -2,7 +2,8 @@ import { generateText } from 'ai';
 import { localStorage } from '@/lib/browser-api';
 import { logger } from '@/lib/logger';
 import type { RewriteSelectionResponse } from '@/lib/messaging';
-import { AI_PROVIDERS, providerOrDefault } from './models';
+import { resolveAiKey } from './keys';
+import { AI_PROVIDERS } from './models';
 import { getLanguageSuffix, REWRITE_PROMPT } from './prompts';
 import { createModel } from './provider';
 
@@ -22,17 +23,23 @@ export function buildRewritePrompt(text: string, instruction: string, locale: st
 }
 
 export async function rewriteSelection(text: string, instruction: string): Promise<RewriteSelectionResponse> {
-  const settings = await localStorage.get(['aiApiKey', 'aiProvider', 'aiModel', 'aiBaseUrl', 'aiLanguage']);
-  if (!settings.aiApiKey) return { error: 'no-api-key' };
-
-  const provider = providerOrDefault(settings.aiProvider);
+  const settings = await localStorage.get([
+    'aiApiKeys',
+    'aiApiKey',
+    'aiProvider',
+    'aiModel',
+    'aiBaseUrl',
+    'aiLanguage',
+  ]);
+  const { provider, apiKey } = resolveAiKey(settings);
+  if (!apiKey) return { error: 'no-api-key' };
 
   try {
     const { text: raw } = await generateText({
       model: createModel(
         provider,
         (settings.aiModel as string) || AI_PROVIDERS[provider].defaultModel,
-        settings.aiApiKey as string,
+        apiKey,
         settings.aiBaseUrl as string | undefined,
       ),
       prompt: buildRewritePrompt(text, instruction, (settings.aiLanguage as string) || 'en'),

--- a/src/core/capture/ai/validate.ts
+++ b/src/core/capture/ai/validate.ts
@@ -8,8 +8,10 @@ import {
   resolveBaseUrl,
 } from './models';
 
+export type KeyWarning = 'cannot-spend';
+
 export type KeyValidation =
-  | { valid: true; models?: string[] }
+  | { valid: true; models?: string[]; warning?: KeyWarning }
   | { valid: false; reason: 'rejected' | 'network' | 'model-required' | 'model-invalid'; models?: string[] };
 
 const REQUEST_TIMEOUT_MS = 10_000;
@@ -54,22 +56,38 @@ async function fetchModelsFromUrl(url: string, headers: Record<string, string>):
   }
 }
 
-async function checkCatalog(url: string, headers: Record<string, string>): Promise<KeyValidation> {
+type AuthProbe = { valid: true; body: unknown } | { valid: false; reason: 'rejected' | 'network' };
+
+async function probeAuth(url: string, headers: Record<string, string>): Promise<AuthProbe> {
   try {
     const res = await fetch(url, {
       headers,
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
-    if (res.ok) {
-      const models = parseModelIds(await res.json().catch(() => null));
-      return models ? { valid: true, models } : { valid: true };
-    }
+    if (res.ok) return { valid: true, body: await res.json().catch(() => null) };
     if (res.status === 401 || res.status === 403) return { valid: false, reason: 'rejected' };
     return { valid: false, reason: 'network' };
   } catch (err) {
     logger.error('API key validation request failed', err);
     return { valid: false, reason: 'network' };
   }
+}
+
+async function checkCatalog(url: string, headers: Record<string, string>): Promise<KeyValidation> {
+  const probe = await probeAuth(url, headers);
+  if (!probe.valid) return probe;
+  const models = parseModelIds(probe.body);
+  return models ? { valid: true, models } : { valid: true };
+}
+
+export function spendWarning(body: unknown): KeyWarning | undefined {
+  if (typeof body !== 'object' || body === null) return undefined;
+  const data = (body as { data?: unknown }).data;
+  if (typeof data !== 'object' || data === null) return undefined;
+  const key = data as { is_free_tier?: unknown; limit_remaining?: unknown };
+  if (key.is_free_tier === true) return 'cannot-spend';
+  if (typeof key.limit_remaining === 'number' && key.limit_remaining <= 0) return 'cannot-spend';
+  return undefined;
 }
 
 async function probeWithInference(
@@ -147,8 +165,10 @@ export async function validateApiKey(
   const catalogUrl = `${base}/models`;
   if (!config.keyCheckPath) return checkCatalog(catalogUrl, headers);
 
-  const authenticated = await checkCatalog(`${base}${config.keyCheckPath}`, headers);
+  const authenticated = await probeAuth(`${base}${config.keyCheckPath}`, headers);
   if (!authenticated.valid) return authenticated;
+
+  const warning = spendWarning(authenticated.body);
   const models = await fetchModelsFromUrl(catalogUrl, headers);
-  return models ? { valid: true, models } : { valid: true };
+  return { valid: true, ...(models ? { models } : {}), ...(warning ? { warning } : {}) };
 }

--- a/src/core/capture/voice/__tests__/api-key.test.ts
+++ b/src/core/capture/voice/__tests__/api-key.test.ts
@@ -122,6 +122,6 @@ describe('normalizeVoiceProvider', () => {
 
 describe('VOICE_KEY_SETTINGS', () => {
   it('names every storage key the resolution reads', () => {
-    expect([...VOICE_KEY_SETTINGS]).toEqual(['voiceProvider', 'voiceApiKey', 'aiProvider', 'aiApiKey']);
+    expect([...VOICE_KEY_SETTINGS]).toEqual(['voiceProvider', 'voiceApiKey', 'aiProvider', 'aiApiKey', 'aiApiKeys']);
   });
 });

--- a/src/core/capture/voice/api-key.ts
+++ b/src/core/capture/voice/api-key.ts
@@ -1,12 +1,14 @@
+import { resolveAiKey } from '@/core/capture/ai/keys';
 import type { VoiceProvider } from './transcribe';
 
-export const VOICE_KEY_SETTINGS = ['voiceProvider', 'voiceApiKey', 'aiProvider', 'aiApiKey'] as const;
+export const VOICE_KEY_SETTINGS = ['voiceProvider', 'voiceApiKey', 'aiProvider', 'aiApiKey', 'aiApiKeys'] as const;
 
 export interface VoiceKeySettings {
   voiceProvider?: unknown;
   voiceApiKey?: unknown;
   aiProvider?: unknown;
   aiApiKey?: unknown;
+  aiApiKeys?: unknown;
 }
 
 export type VoiceApiKeySource = 'voice' | 'ai' | 'none';
@@ -30,8 +32,9 @@ export function resolveVoiceApiKey(settings: VoiceKeySettings): ResolvedVoiceApi
   const own = trimmed(settings.voiceApiKey);
   if (own) return { provider, apiKey: own, source: 'voice' };
 
-  const shared = trimmed(settings.aiApiKey);
-  const aiProvider = trimmed(settings.aiProvider) || 'openai';
+  const resolved = resolveAiKey(settings);
+  const shared = resolved.apiKey;
+  const aiProvider = resolved.provider;
   if (provider !== 'openai' || aiProvider !== 'openai' || !shared) {
     return { provider, apiKey: '', source: 'none' };
   }

--- a/src/core/guides/service.ts
+++ b/src/core/guides/service.ts
@@ -3,7 +3,7 @@ import type { NarrationUpdate } from '@/core/capture/voice/narration-updates';
 import type { ScreenshotEdits } from '@/core/screenshot/types';
 import { db } from './db';
 import { hashPayload } from './snapshot-hash';
-import type { BlockType, CalloutVariant, Guide, Screenshot, Snapshot, Step } from './types';
+import type { BlockType, CalloutVariant, DescriptionSource, Guide, Screenshot, Snapshot, Step } from './types';
 
 export type GuideChangeEvent = { type: 'starred'; id: string; starred: boolean } | { type: 'mutated' };
 
@@ -195,8 +195,12 @@ export async function updateCallout(stepId: string, variant: CalloutVariant, col
   await db.steps.update(stepId, { calloutVariant: variant, calloutColor: color });
 }
 
-export async function updateStepDescription(stepId: string, description: string): Promise<void> {
-  await db.steps.update(stepId, { description });
+export async function updateStepDescription(
+  stepId: string,
+  description: string,
+  source?: DescriptionSource,
+): Promise<void> {
+  await db.steps.update(stepId, source ? { description, descriptionSource: source } : { description });
 }
 
 export async function applyNarrationToSteps(updates: readonly NarrationUpdate[]): Promise<void> {

--- a/src/core/guides/types.ts
+++ b/src/core/guides/types.ts
@@ -1,6 +1,9 @@
 import type { AIApiKeys } from '@/core/capture/ai/keys';
 import type { AIProviderKey } from '@/core/capture/ai/models';
 import type { VoiceProvider } from '@/core/capture/voice/transcribe';
+import type { BrandLogo } from '@/core/export/branding';
+import type { ExportOptions } from '@/core/export/options';
+import type { GuideMeSession } from '@/core/guideme/session';
 import type { ScreenshotEdits } from '@/core/screenshot/types';
 
 export interface Guide {
@@ -61,15 +64,31 @@ export interface Screenshot {
 
 export interface Settings {
   aiApiKey: string;
-  aiApiKeys?: AIApiKeys;
+  aiApiKeys: AIApiKeys;
   aiProvider: AIProviderKey;
   aiModel: string;
-  aiBaseUrl?: string;
+  aiBaseUrl: string;
+  aiLanguage: string;
   voiceEnabled: boolean;
   voiceProvider: VoiceProvider;
   voiceApiKey: string;
   voiceMicrophoneId: string;
+  voiceLanguage: string;
+  blurPresets: Record<string, boolean>;
+  targetColor: string;
+  brandLogo: BrandLogo | null;
+  brandFooter: string;
+  brandAttribution: boolean;
+  exportOptions: ExportOptions;
+  guideMeSession: GuideMeSession | null;
+  guideMeStep: Step | null;
+  guideMeBlocked: number | null;
+  guideMeManual: boolean;
+  mimikBlurMode: boolean;
+  onboardingCompleted: boolean;
 }
+
+export type SettingsKey = keyof Settings;
 
 export interface ElementMeta {
   tag: string;

--- a/src/core/guides/types.ts
+++ b/src/core/guides/types.ts
@@ -1,3 +1,4 @@
+import type { AIApiKeys } from '@/core/capture/ai/keys';
 import type { AIProviderKey } from '@/core/capture/ai/models';
 import type { VoiceProvider } from '@/core/capture/voice/transcribe';
 import type { ScreenshotEdits } from '@/core/screenshot/types';
@@ -14,7 +15,7 @@ export interface Guide {
   staging?: boolean;
 }
 
-export type DescriptionSource = 'narration' | 'ai' | 'heuristic';
+export type DescriptionSource = 'narration' | 'ai' | 'heuristic' | 'manual';
 
 export type BlockType = 'heading' | 'callout';
 
@@ -60,6 +61,7 @@ export interface Screenshot {
 
 export interface Settings {
   aiApiKey: string;
+  aiApiKeys?: AIApiKeys;
   aiProvider: AIProviderKey;
   aiModel: string;
   aiBaseUrl?: string;

--- a/src/entrypoints/background/ai-description.ts
+++ b/src/entrypoints/background/ai-description.ts
@@ -1,19 +1,31 @@
 import { getAIDescription } from '@/core/capture/ai/description';
+import { describeAiFailure } from '@/core/capture/ai/errors';
+import { resolveAiKey } from '@/core/capture/ai/keys';
+import { AI_PROVIDERS } from '@/core/capture/ai/models';
 import type { DOMContext } from '@/core/capture/dom/context';
 import { localStorage } from '@/lib/browser-api';
+import { logger } from '@/lib/logger';
+import { broadcastAiToPanel } from '@/lib/port';
 
 export async function generateAiDescription(domContext: DOMContext): Promise<string | undefined> {
-  const settings = await localStorage.get(['aiApiKey', 'aiProvider', 'aiModel', 'aiBaseUrl']);
-  if (!settings.aiApiKey) return undefined;
+  const settings = await localStorage.get(['aiApiKeys', 'aiApiKey', 'aiProvider', 'aiModel', 'aiBaseUrl']);
+  const { provider, apiKey } = resolveAiKey(settings);
+  if (!apiKey) return undefined;
 
-  const provider = (settings.aiProvider as string) || 'openai';
-  const model = (settings.aiModel as string) || 'gpt-4o-mini';
-  const description = await getAIDescription(
-    domContext,
-    provider,
-    model,
-    settings.aiApiKey as string,
-    settings.aiBaseUrl as string | undefined,
-  );
-  return description || undefined;
+  const model = (settings.aiModel as string) || AI_PROVIDERS[provider].defaultModel;
+  try {
+    const description = await getAIDescription(
+      domContext,
+      provider,
+      model,
+      apiKey,
+      settings.aiBaseUrl as string | undefined,
+    );
+    return description || undefined;
+  } catch (err) {
+    const failure = describeAiFailure(err);
+    logger.error(`AI description failed (${failure.reason}${failure.status ? ` ${failure.status}` : ''})`, err);
+    broadcastAiToPanel({ type: 'AI_UPDATE', reason: failure.reason, status: failure.status, provider });
+    return undefined;
+  }
 }

--- a/src/entrypoints/background/guide-meta.ts
+++ b/src/entrypoints/background/guide-meta.ts
@@ -1,6 +1,7 @@
 import { i18n } from '#imports';
+import { resolveAiKey } from '@/core/capture/ai/keys';
 import { generateGuideMeta } from '@/core/capture/ai/meta';
-import { AI_PROVIDERS, providerOrDefault } from '@/core/capture/ai/models';
+import { AI_PROVIDERS } from '@/core/capture/ai/models';
 import { actionSteps } from '@/core/guides/blocks';
 import {
   clearStepAiPending,
@@ -29,20 +30,20 @@ type GuideMetaInputs =
   | { ok: false; reason: ResolveFailure };
 
 async function resolveGuideMetaInputs(guideId: string): Promise<GuideMetaInputs> {
-  const settings = await localStorage.get(['aiApiKey', 'aiProvider', 'aiModel', 'aiBaseUrl']);
-  if (!settings.aiApiKey) return { ok: false, reason: 'no-api-key' };
+  const settings = await localStorage.get(['aiApiKeys', 'aiApiKey', 'aiProvider', 'aiModel', 'aiBaseUrl']);
+  const { provider, apiKey } = resolveAiKey(settings);
+  if (!apiKey) return { ok: false, reason: 'no-api-key' };
 
   const steps = actionSteps(await getStepsForGuide(guideId));
   const described = steps.filter((s) => s.description).map((s) => ({ description: s.description, url: s.url }));
   if (described.length === 0) return { ok: false, reason: 'no-steps' };
 
-  const provider = providerOrDefault(settings.aiProvider);
   return {
     ok: true,
     steps: described.length > 15 ? [...described.slice(0, 10), ...described.slice(-5)] : described,
     provider,
     model: (settings.aiModel as string) || AI_PROVIDERS[provider].defaultModel,
-    apiKey: settings.aiApiKey as string,
+    apiKey,
     baseUrl: settings.aiBaseUrl as string | undefined,
   };
 }

--- a/src/entrypoints/background/step-pipeline.ts
+++ b/src/entrypoints/background/step-pipeline.ts
@@ -1,3 +1,4 @@
+import { AI_KEY_SETTINGS, resolveAiKey } from '@/core/capture/ai/keys';
 import type { DOMContext } from '@/core/capture/dom/context';
 import { CaptureState } from '@/core/capture/machine';
 import { buildFallbackDescription } from '@/core/capture/step-description';
@@ -57,7 +58,7 @@ async function takeScreenshot(stepId: string, meta: ElementMeta): Promise<string
 }
 
 async function tryAIDescription(stepId: string, domContext: DOMContext) {
-  if (!(await localStorage.get(['aiApiKey'])).aiApiKey) return;
+  if (!resolveAiKey(await localStorage.get([...AI_KEY_SETTINGS])).apiKey) return;
   try {
     await clearStepAiPending(stepId, await generateAiDescription(domContext));
   } catch (err) {
@@ -79,7 +80,7 @@ export async function handleCaptureStep(data: CaptureStepData): Promise<CaptureS
   const screenshotId = await takeScreenshot(stepId, data.elementMeta);
 
   const narrationCapturing = getVoiceUpdate().phase === 'recording';
-  const hasAiKey = !!(await localStorage.get(['aiApiKey'])).aiApiKey;
+  const hasAiKey = !!resolveAiKey(await localStorage.get([...AI_KEY_SETTINGS])).apiKey;
   const willUseAI = shouldQueueAiDescription({
     action: data.action,
     hasDomContext: !!data.domContext,
@@ -98,6 +99,7 @@ export async function handleCaptureStep(data: CaptureStepData): Promise<CaptureS
     timestamp,
     screenshotId,
     elementMeta: data.elementMeta,
+    descriptionSource: 'heuristic',
     aiPending: willUseAI || narrationCapturing,
   });
   await addStepToGuide(guideId, stepId);

--- a/src/lib/__tests__/storage-typing.test.ts
+++ b/src/lib/__tests__/storage-typing.test.ts
@@ -1,0 +1,25 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { Settings } from '@/core/guides/types';
+import { localStorage } from '@/lib/browser-api';
+
+describe('storage access is checked against the declared settings', () => {
+  it('returns the declared type for a key, not unknown', async () => {
+    const stored = await localStorage.get(['aiProvider', 'aiApiKeys']);
+    expectTypeOf(stored.aiProvider).toEqualTypeOf<Settings['aiProvider'] | undefined>();
+    expectTypeOf(stored.aiApiKeys).toEqualTypeOf<Settings['aiApiKeys'] | undefined>();
+  });
+
+  it('rejects a key that is not declared', () => {
+    // @ts-expect-error an undeclared storage key must not compile
+    void localStorage.get(['aiApiKeyTypo']);
+    // @ts-expect-error an undeclared storage key must not compile
+    void localStorage.set({ aiApiKeyTypo: 'x' });
+  });
+
+  it('rejects the wrong type for a declared key', () => {
+    // @ts-expect-error aiProvider is a provider key, not an arbitrary string
+    void localStorage.set({ aiProvider: 'not-a-provider' });
+    // @ts-expect-error voiceEnabled is a boolean
+    void localStorage.set({ voiceEnabled: 'yes' });
+  });
+});

--- a/src/lib/browser-api.ts
+++ b/src/lib/browser-api.ts
@@ -1,5 +1,6 @@
 import type { PublicPath } from 'wxt/browser';
 import { type Browser, browser } from '#imports';
+import type { Settings, SettingsKey } from '@/core/guides/types';
 
 type HtmlPublicPath = Extract<PublicPath, `${string}.html`>;
 type ScriptPath = Extract<PublicPath, `${string}.js`>;
@@ -104,8 +105,9 @@ export const sessionStorage = {
 };
 
 export const localStorage = {
-  get: (keys: string[]) => browser.storage.local.get(keys),
-  set: (items: Record<string, unknown>) => browser.storage.local.set(items),
+  get: <K extends SettingsKey>(keys: readonly K[]) =>
+    browser.storage.local.get(keys as unknown as K) as Promise<Partial<Pick<Settings, K>>>,
+  set: (items: Partial<Settings>) => browser.storage.local.set(items),
 };
 
 export function setSidePanelBehavior(openOnActionClick: boolean): void {

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -118,6 +118,7 @@ export interface ValidateApiKeyResponse {
   valid: boolean;
   reason?: 'rejected' | 'network' | 'model-required' | 'model-invalid';
   models?: string[];
+  warning?: 'cannot-spend';
 }
 
 export interface EnterBlurModeResponse {

--- a/src/lib/port.ts
+++ b/src/lib/port.ts
@@ -1,4 +1,5 @@
 import { browser } from '#imports';
+import type { AiFailureReason } from '@/core/capture/ai/errors';
 import type { CaptureStateValue } from '@/core/capture/machine';
 import { logger } from '@/lib/logger';
 import type { VoiceErrorReason } from '@/lib/voice-messages';
@@ -23,7 +24,14 @@ export interface PanelVoiceUpdate {
   narrated?: number;
 }
 
-type PortMessage = PanelStateUpdate | PanelVoiceUpdate;
+export interface PanelAiUpdate {
+  type: 'AI_UPDATE';
+  reason: AiFailureReason;
+  status?: number;
+  provider: string;
+}
+
+type PortMessage = PanelStateUpdate | PanelVoiceUpdate | PanelAiUpdate;
 type Port = ReturnType<typeof browser.runtime.connect>;
 
 function openPort(
@@ -75,6 +83,7 @@ export function connectToBackground(callbacks: {
   onConnect: () => void;
   onDisconnect: () => void;
   onVoiceUpdate?: (update: PanelVoiceUpdate) => void;
+  onAiUpdate?: (update: PanelAiUpdate) => void;
 }): () => void {
   return openPort(
     PORT_NAME,
@@ -83,6 +92,8 @@ export function connectToBackground(callbacks: {
         callbacks.onStateUpdate(msg);
       } else if (msg.type === 'VOICE_UPDATE') {
         callbacks.onVoiceUpdate?.(msg);
+      } else if (msg.type === 'AI_UPDATE') {
+        callbacks.onAiUpdate?.(msg);
       }
     },
     callbacks.onConnect,
@@ -145,6 +156,10 @@ function broadcastTo(ports: Set<Port>, message: PortMessage): void {
 }
 
 export function broadcastStateToPanel(update: PanelStateUpdate): void {
+  broadcastTo(panelPorts, update);
+}
+
+export function broadcastAiToPanel(update: PanelAiUpdate): void {
   broadcastTo(panelPorts, update);
 }
 

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -140,6 +140,7 @@ settings:
   keyModelRequired: Wähle ein Modell, bevor du diesen Schlüssel prüfst.
   keyModelInvalid: Das ausgewählte Modell ist bei diesem Anbieter nicht verfügbar.
   checkKey: Schlüssel prüfen
+  keyCannotSpend: "Dieser Schlüssel hat kein Guthaben, es funktionieren nur kostenlose Modelle."
   keyUnreachable: Der Anbieter war nicht erreichbar. Prüfe deine Verbindung und versuche es erneut.
   modelsFound: "$1 Modelle verfügbar"
 
@@ -534,3 +535,24 @@ micPermission:
   deniedMessage: Dein Browser blockiert das Mikrofon für Mimik, daher kann der Sprachkommentar nicht aufnehmen. Öffne die Website-Einstellungen über das Symbol links in der Adressleiste, setze Mikrofon auf Zulassen und versuche es dann erneut. Anleitungen aufzeichnen funktioniert auch ohne.
   retry: Erneut versuchen
   privacy: Audio bleibt nur während der Aufnahme im Speicher und wird an den von dir konfigurierten Transkriptionsanbieter gesendet. Mimik speichert es nie.
+
+aiStatus:
+  rejected: "$1 hat deinen API-Schlüssel abgelehnt."
+  noCredits: "Dein $1-Konto hat kein Guthaben."
+  rateLimited: "$1 begrenzt, wie oft Mimik anfragen darf."
+  modelInvalid: "$1 bietet dieses Modell für dein Konto nicht an."
+  quota: "Diese Anfrage war zu groß für dieses Modell."
+  network: "Mimik konnte $1 nicht erreichen."
+  unknown: "$1 hat die Anfrage abgelehnt."
+  actionCheckKey: "Prüfe deinen Schlüssel in den Einstellungen."
+  actionAddCredits: "Guthaben aufladen, dann den Schlüssel erneut prüfen."
+  actionWait: "Warte einen Moment, bevor du weiter aufnimmst."
+  actionPickModel: "Wähle in den Einstellungen ein anderes Modell."
+  actionConnection: "Prüfe deine Verbindung."
+
+stepSource:
+  ai: "KI"
+  voice: "Stimme"
+  basic: "Einfach"
+  edited: "Bearbeitet"
+  hint: "Woher diese Beschreibung kommt"

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -134,6 +134,7 @@ settings:
   keyModelRequired: Choose a model before checking this key.
   keyModelInvalid: The selected model is not available from this provider.
   checkKey: Check key
+  keyCannotSpend: "This key has no credits, so only free models will work."
   keyUnreachable: Could not reach the provider. Check your connection and try again.
   modelsFound: "$1 models available"
   smartBlur: Smart Blur
@@ -533,3 +534,24 @@ micPermission:
   deniedMessage: Your browser is blocking the microphone for Mimik, so voice narration cannot record. Open the site settings from the icon at the left of the address bar, set Microphone to Allow, then try again. Capturing guides keeps working without it.
   retry: Try again
   privacy: Audio is held in memory only while you record and is sent to the transcription provider you configured. Mimik never stores it.
+
+aiStatus:
+  rejected: "$1 rejected your API key."
+  noCredits: "Your $1 account has no credits."
+  rateLimited: "$1 is limiting how often Mimik can ask."
+  modelInvalid: "$1 does not offer that model to your account."
+  quota: "That request was too large for this model."
+  network: "Mimik could not reach $1."
+  unknown: "$1 refused the request."
+  actionCheckKey: "Check your key in Settings."
+  actionAddCredits: "Add credits, then check the key again."
+  actionWait: "Wait a moment before recording more."
+  actionPickModel: "Pick another model in Settings."
+  actionConnection: "Check your connection."
+
+stepSource:
+  ai: "AI"
+  voice: "Voice"
+  basic: "Basic"
+  edited: "Edited"
+  hint: "Where this description came from"

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -134,6 +134,7 @@ settings:
   keyModelRequired: Elige un modelo antes de comprobar esta clave.
   keyModelInvalid: El modelo seleccionado no está disponible en este proveedor.
   checkKey: Comprobar clave
+  keyCannotSpend: "Esta clave no tiene créditos, solo funcionarán los modelos gratuitos."
   keyUnreachable: No se pudo conectar con el proveedor. Revisa tu conexión e inténtalo de nuevo.
   modelsFound: "$1 modelos disponibles"
   smartBlur: Desenfoque inteligente
@@ -533,3 +534,24 @@ micPermission:
   deniedMessage: Tu navegador está bloqueando el micrófono para Mimik, así que la narración por voz no puede grabar. Abre la configuración del sitio desde el icono a la izquierda de la barra de direcciones, pon Micrófono en Permitir y vuelve a intentarlo. Capturar guías sigue funcionando sin esto.
   retry: Intentar de nuevo
   privacy: El audio solo se guarda en memoria mientras grabas y se envía al proveedor de transcripción que hayas configurado. Mimik nunca lo almacena.
+
+aiStatus:
+  rejected: "$1 rechazó tu clave de API."
+  noCredits: "Tu cuenta de $1 no tiene créditos."
+  rateLimited: "$1 está limitando la frecuencia de las peticiones de Mimik."
+  modelInvalid: "$1 no ofrece ese modelo a tu cuenta."
+  quota: "Esa petición fue demasiado grande para este modelo."
+  network: "Mimik no pudo contactar con $1."
+  unknown: "$1 rechazó la petición."
+  actionCheckKey: "Revisa tu clave en Ajustes."
+  actionAddCredits: "Añade créditos y vuelve a comprobar la clave."
+  actionWait: "Espera un momento antes de seguir grabando."
+  actionPickModel: "Elige otro modelo en Ajustes."
+  actionConnection: "Revisa tu conexión."
+
+stepSource:
+  ai: "IA"
+  voice: "Voz"
+  basic: "Básica"
+  edited: "Editada"
+  hint: "De dónde viene esta descripción"

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -134,6 +134,7 @@ settings:
   keyModelRequired: Choisissez un modèle avant de vérifier cette clé.
   keyModelInvalid: "Le modèle sélectionné n'est pas disponible chez ce fournisseur."
   checkKey: Vérifier la clé
+  keyCannotSpend: "Cette clé n’a pas de crédits, seuls les modèles gratuits fonctionneront."
   keyUnreachable: Le fournisseur est injoignable. Vérifiez votre connexion et réessayez.
   modelsFound: "$1 modèles disponibles"
   smartBlur: Flou intelligent
@@ -533,3 +534,24 @@ micPermission:
   deniedMessage: Votre navigateur bloque le microphone pour Mimik, la narration vocale ne peut donc pas enregistrer. Ouvrez les paramètres du site depuis l'icône à gauche de la barre d'adresse, réglez Microphone sur Autoriser, puis réessayez. La capture de guides continue de fonctionner sans cela.
   retry: Réessayer
   privacy: L'audio reste en mémoire pendant l'enregistrement et n'est envoyé qu'au service de transcription que vous avez configuré. Mimik ne le conserve jamais.
+
+aiStatus:
+  rejected: "$1 a refusé votre clé API."
+  noCredits: "Votre compte $1 n’a pas de crédits."
+  rateLimited: "$1 limite la fréquence des requêtes de Mimik."
+  modelInvalid: "$1 ne propose pas ce modèle à votre compte."
+  quota: "Cette requête était trop volumineuse pour ce modèle."
+  network: "Mimik n’a pas pu joindre $1."
+  unknown: "$1 a refusé la requête."
+  actionCheckKey: "Vérifiez votre clé dans les réglages."
+  actionAddCredits: "Ajoutez des crédits, puis revérifiez la clé."
+  actionWait: "Attendez un instant avant de continuer."
+  actionPickModel: "Choisissez un autre modèle dans les réglages."
+  actionConnection: "Vérifiez votre connexion."
+
+stepSource:
+  ai: "IA"
+  voice: "Voix"
+  basic: "Simple"
+  edited: "Modifiée"
+  hint: "D’où vient cette description"

--- a/src/locales/pt-BR.yml
+++ b/src/locales/pt-BR.yml
@@ -134,6 +134,7 @@ settings:
   keyModelRequired: Escolha um modelo antes de verificar esta chave.
   keyModelInvalid: O modelo selecionado não está disponível neste provedor.
   checkKey: Verificar chave
+  keyCannotSpend: "Esta chave não tem créditos, então só modelos gratuitos vão funcionar."
   keyUnreachable: Não deu pra falar com o provedor. Confere sua conexão e tenta de novo.
   modelsFound: "$1 modelos disponíveis"
   smartBlur: Desfoque inteligente
@@ -533,3 +534,24 @@ micPermission:
   deniedMessage: Seu navegador está bloqueando o microfone para o Mimik, então a narração por voz não pode gravar. Abra as configurações do site pelo ícone à esquerda da barra de endereços, defina Microfone como Permitir e tente de novo. Capturar guias continua funcionando sem isso.
   retry: Tentar de novo
   privacy: O áudio fica apenas na memória enquanto você grava e é enviado ao provedor de transcrição que você configurou. O Mimik nunca o armazena.
+
+aiStatus:
+  rejected: "$1 rejeitou sua chave de API."
+  noCredits: "Sua conta $1 não tem créditos."
+  rateLimited: "$1 está limitando a frequência das requisições do Mimik."
+  modelInvalid: "$1 não oferece esse modelo para sua conta."
+  quota: "Essa requisição foi grande demais para este modelo."
+  network: "O Mimik não conseguiu contatar $1."
+  unknown: "$1 recusou a requisição."
+  actionCheckKey: "Confira sua chave em Configurações."
+  actionAddCredits: "Adicione créditos e verifique a chave de novo."
+  actionWait: "Espere um momento antes de continuar gravando."
+  actionPickModel: "Escolha outro modelo em Configurações."
+  actionConnection: "Verifique sua conexão."
+
+stepSource:
+  ai: "IA"
+  voice: "Voz"
+  basic: "Básica"
+  edited: "Editada"
+  hint: "De onde veio esta descrição"

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -134,6 +134,7 @@ settings:
   keyModelInvalid: 所选模型在此提供商上不可用。请选择其他模型或输入自定义模型 ID。
   keyModelRequired: 需要选择模型。请从列表中选择或输入自定义模型 ID。
   checkKey: 检查密钥
+  keyCannotSpend: "该密钥没有额度，只能使用免费模型。"
   keyUnreachable: 无法连接到提供商。请检查网络后重试。
   modelsFound: "找到 $1 个模型"
   smartBlur: 智能模糊
@@ -533,3 +534,24 @@ micPermission:
   deniedMessage: 浏览器正在阻止 Mimik 使用麦克风，因此无法录制语音讲解。请从地址栏左侧图标打开网站设置，将麦克风设为允许，然后重试。即使没有麦克风，捕获指南仍可继续使用。
   retry: 重试
   privacy: 音频只会在录制期间保存在内存中，并会发送到你配置的转写提供商。Mimik 永远不会存储它。
+
+aiStatus:
+  rejected: "$1 拒绘了你的 API 密钥。"
+  noCredits: "你的 $1 账户没有额度。"
+  rateLimited: "$1 正在限制 Mimik 的请求频率。"
+  modelInvalid: "$1 未向你的账户提供该模型。"
+  quota: "该请求内容超出了模型上限。"
+  network: "Mimik 无法连接到 $1。"
+  unknown: "$1 拒绘了该请求。"
+  actionCheckKey: "请在设置中检查密钥。"
+  actionAddCredits: "充值后再次检查密钥。"
+  actionWait: "稍等一下再继续录制。"
+  actionPickModel: "请在设置中选择其他模型。"
+  actionConnection: "请检查网络连接。"
+
+stepSource:
+  ai: "AI"
+  voice: "语音"
+  basic: "基础"
+  edited: "已编辑"
+  hint: "这条描述的来源"

--- a/src/ui/fullview/GuideContent.tsx
+++ b/src/ui/fullview/GuideContent.tsx
@@ -186,7 +186,7 @@ export default function GuideContent({ guideId, initialStepId, initialTool }: Gu
   }, [guideId]);
 
   const handleDescriptionChange = useCallback(async (stepId: string, description: string) => {
-    await updateStepDescription(stepId, description);
+    await updateStepDescription(stepId, description, 'manual');
     setData((prev) => {
       if (!prev) return prev;
       return { ...prev, steps: prev.steps.map((s) => (s.id === stepId ? { ...s, description } : s)) };

--- a/src/ui/onboarding/App.tsx
+++ b/src/ui/onboarding/App.tsx
@@ -2,6 +2,7 @@ import { Globe, Mic, MousePointerClick, Shield } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { browser, i18n } from '#imports';
 import { PRESET_LABELS, type PresetKey } from '@/core/blur/regexes';
+import { type AIApiKeys, keyFor, migrateApiKeys, withKeyFor } from '@/core/capture/ai/keys';
 import {
   AI_PROVIDERS,
   type AIProviderKey,
@@ -16,7 +17,7 @@ import type { VoiceProvider } from '@/core/capture/voice/transcribe';
 import { localStorage, openSidebar, requestHostPermissions } from '@/lib/browser-api';
 import { Input } from '@/ui/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/ui/components/ui/select';
-import { KeyStatusNote, ModelList, SecretInput, useKeyCheck } from '@/ui/shared/key-check';
+import { KeyStatusNote, KeyWarningNote, ModelList, SecretInput, useKeyCheck } from '@/ui/shared/key-check';
 import MicrophonePicker from '@/ui/shared/MicrophonePicker';
 
 interface StepProps {
@@ -127,6 +128,7 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
   const [provider, setProvider] = useState<AIProviderKey>('openai');
   const [model, setModel] = useState(AI_PROVIDERS.openai.defaultModel);
   const [apiKey, setApiKey] = useState('');
+  const [apiKeys, setApiKeys] = useState<AIApiKeys>({});
   const [baseUrl, setBaseUrl] = useState('');
   const [aiLanguage, setAiLanguage] = useState<AILanguageCode>('en');
   const [ownServer, setOwnServer] = useState(false);
@@ -135,11 +137,13 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
 
   useEffect(() => {
     const load = () =>
-      localStorage.get(['aiProvider', 'aiModel', 'aiApiKey', 'aiBaseUrl', 'aiLanguage']).then((stored) => {
+      localStorage.get(['aiProvider', 'aiModel', 'aiApiKey', 'aiApiKeys', 'aiBaseUrl', 'aiLanguage']).then((stored) => {
         const key = providerOrDefault(stored.aiProvider);
         setProvider(key);
         if (typeof stored.aiModel === 'string') setModel(stored.aiModel);
-        if (typeof stored.aiApiKey === 'string') setApiKey(stored.aiApiKey);
+        const keys = migrateApiKeys(stored);
+        setApiKeys(keys);
+        setApiKey(keyFor(keys, key));
         if (isCustomBaseUrl(AI_PROVIDERS[key], stored.aiBaseUrl as string)) {
           setBaseUrl(stored.aiBaseUrl as string);
           setOwnServer(true);
@@ -165,8 +169,10 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
     setCustomModel(false);
     setOwnServer(false);
     setBaseUrl('');
+    const nextKey = keyFor(apiKeys, newProvider);
+    setApiKey(nextKey);
     aiKeyCheck.reset();
-    void localStorage.set({ aiProvider: newProvider, aiModel: nextModel, aiBaseUrl: '' });
+    void localStorage.set({ aiProvider: newProvider, aiModel: nextModel, aiBaseUrl: '', aiApiKey: nextKey });
   };
 
   const handleOwnServerToggle = () => {
@@ -194,8 +200,10 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
 
   const handleApiKeyChange = (nextKey: string) => {
     setApiKey(nextKey);
+    const nextKeys = withKeyFor(apiKeys, provider, nextKey);
+    setApiKeys(nextKeys);
     aiKeyCheck.reset();
-    void localStorage.set({ aiApiKey: nextKey });
+    void localStorage.set({ aiApiKey: nextKey, aiApiKeys: nextKeys });
   };
 
   const handleBaseUrlChange = (nextUrl: string) => {
@@ -289,6 +297,7 @@ function AISetupStep({ onNext, onSkip, onBack, index, total }: StepProps) {
                 </button>
                 <div className="min-w-0">
                   <KeyStatusNote status={aiKeyCheck.status} />
+                  <KeyWarningNote warning={aiKeyCheck.warning} />
                 </div>
               </div>
               {aiKeyCheck.models && <ModelList models={aiKeyCheck.models} />}

--- a/src/ui/shared/SettingsView.tsx
+++ b/src/ui/shared/SettingsView.tsx
@@ -18,6 +18,7 @@ import {
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { i18n } from '#imports';
 import { PRESET_LABELS, type PresetKey } from '@/core/blur/regexes';
+import { type AIApiKeys, keyFor, migrateApiKeys, withKeyFor } from '@/core/capture/ai/keys';
 import {
   AI_PROVIDERS,
   type AIProviderKey,
@@ -39,7 +40,7 @@ import { Input } from '@/ui/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/ui/components/ui/popover';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/ui/components/ui/select';
 import ColorPicker from '@/ui/shared/ColorPicker';
-import { KeyStatusNote, ModelList, SecretInput, useKeyCheck } from '@/ui/shared/key-check';
+import { KeyStatusNote, KeyWarningNote, ModelList, SecretInput, useKeyCheck } from '@/ui/shared/key-check';
 import MicrophonePicker from '@/ui/shared/MicrophonePicker';
 import { changedSettings, type SettingsSnapshot } from '@/ui/shared/settings-autosave';
 
@@ -60,6 +61,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
   const [provider, setProvider] = useState<AIProviderKey>('openai');
   const [model, setModel] = useState(AI_PROVIDERS.openai.defaultModel);
   const [apiKey, setApiKey] = useState('');
+  const [apiKeys, setApiKeys] = useState<AIApiKeys>({});
   const [baseUrl, setBaseUrl] = useState('');
   const [saved, setSaved] = useState(false);
   const aiKeyCheck = useKeyCheck();
@@ -92,6 +94,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
     localStorage
       .get([
         'aiApiKey',
+        'aiApiKeys',
         'aiProvider',
         'aiModel',
         'aiBaseUrl',
@@ -109,7 +112,9 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
         const p = providerOrDefault(result.aiProvider);
         setProvider(p);
         setModel((result.aiModel as string) || AI_PROVIDERS[p].defaultModel);
-        if (result.aiApiKey) setApiKey(result.aiApiKey as string);
+        const keys = migrateApiKeys(result);
+        setApiKeys(keys);
+        setApiKey(keyFor(keys, p));
         if (isCustomBaseUrl(AI_PROVIDERS[p], result.aiBaseUrl as string)) {
           setBaseUrl(result.aiBaseUrl as string);
           setOwnServer(true);
@@ -129,6 +134,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
 
   const stored = {
     aiApiKey: apiKey,
+    aiApiKeys: apiKeys,
     aiProvider: provider,
     aiModel: model,
     aiBaseUrl: baseUrl,
@@ -194,6 +200,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
 
   const handleProviderChange = (newProvider: AIProviderKey) => {
     setProvider(newProvider);
+    setApiKey(keyFor(apiKeys, newProvider));
     aiKeyCheck.reset();
     setCustomModel(false);
     setModel(AI_PROVIDERS[newProvider].defaultModel);
@@ -320,6 +327,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
                 value={apiKey}
                 onChange={(next) => {
                   setApiKey(next);
+                  setApiKeys((prev) => withKeyFor(prev, provider, next));
                   aiKeyCheck.reset();
                 }}
                 placeholder="sk-..."
@@ -338,6 +346,7 @@ export default function SettingsView({ onBack }: SettingsViewProps) {
               </Button>
             </div>
             <KeyStatusNote status={aiKeyCheck.status} />
+            <KeyWarningNote warning={aiKeyCheck.warning} />
             {aiKeyCheck.models && <ModelList models={aiKeyCheck.models} />}
             {!apiKey.trim() && (
               <p className="mt-1.5 flex items-start gap-1.5 text-[10px] text-destructive leading-relaxed" role="alert">

--- a/src/ui/shared/StepSourceBadge.tsx
+++ b/src/ui/shared/StepSourceBadge.tsx
@@ -1,0 +1,29 @@
+import { i18n } from '#imports';
+import type { DescriptionSource } from '@/core/guides/types';
+
+const STYLES: Record<DescriptionSource, string> = {
+  ai: 'bg-secondary text-accent',
+  narration: 'bg-success/10 text-success',
+  heuristic: 'bg-primary text-primary-foreground',
+  manual: 'border border-border text-muted-foreground',
+};
+
+const LABELS: Record<DescriptionSource, string> = {
+  ai: 'stepSource.ai',
+  narration: 'stepSource.voice',
+  heuristic: 'stepSource.basic',
+  manual: 'stepSource.edited',
+};
+
+export default function StepSourceBadge({ source }: { source: DescriptionSource | undefined }) {
+  if (!source) return null;
+
+  return (
+    <span
+      className={`inline-block leading-none text-[9px] font-bold uppercase tracking-wide rounded px-1 py-[2px] shrink-0 ${STYLES[source]}`}
+      title={i18n.t('stepSource.hint')}
+    >
+      {i18n.t(LABELS[source])}
+    </span>
+  );
+}

--- a/src/ui/shared/__tests__/step-source-badge.test.tsx
+++ b/src/ui/shared/__tests__/step-source-badge.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { DescriptionSource } from '@/core/guides/types';
+import StepSourceBadge from '@/ui/shared/StepSourceBadge';
+
+const SOURCES: DescriptionSource[] = ['ai', 'narration', 'heuristic', 'manual'];
+const LOCALES = ['en', 'de', 'es', 'fr', 'pt-BR', 'zh-CN'];
+
+describe('StepSourceBadge', () => {
+  it('says nothing for a step recorded before the field existed', () => {
+    const { container } = render(<StepSourceBadge source={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it.each(SOURCES)('renders a label for %s', (source) => {
+    render(<StepSourceBadge source={source} />);
+    expect(screen.getByText(/.+/)).toBeInTheDocument();
+  });
+
+  it('distinguishes a rule-based description from an AI one', () => {
+    const { container: ai } = render(<StepSourceBadge source="ai" />);
+    const { container: basic } = render(<StepSourceBadge source="heuristic" />);
+    expect(ai.textContent).not.toBe(basic.textContent);
+    expect(ai.firstElementChild?.className).not.toBe(basic.firstElementChild?.className);
+  });
+
+  it('carries a label for every source, in every locale', () => {
+    for (const locale of LOCALES) {
+      const text = readFileSync(join(process.cwd(), 'src/locales', `${locale}.yml`), 'utf8');
+      for (const key of ['ai', 'voice', 'basic', 'edited', 'hint']) {
+        expect(text, `${locale} is missing stepSource.${key}`).toContain(`  ${key}:`);
+      }
+    }
+  });
+});

--- a/src/ui/shared/key-check.tsx
+++ b/src/ui/shared/key-check.tsx
@@ -1,4 +1,4 @@
-import { Check, Eye, EyeOff } from 'lucide-react';
+import { Check, Eye, EyeOff, TriangleAlert } from 'lucide-react';
 import { useCallback, useRef, useState } from 'react';
 import { i18n } from '#imports';
 import { sendMessage } from '@/lib/messaging';
@@ -6,9 +6,12 @@ import { Input } from '@/ui/components/ui/input';
 
 export type KeyStatus = 'checking' | 'valid' | 'rejected' | 'unreachable' | 'model-required' | 'model-invalid' | null;
 
+export type KeyWarning = 'cannot-spend';
+
 export function useKeyCheck() {
   const [status, setStatus] = useState<KeyStatus>(null);
   const [models, setModels] = useState<string[] | null>(null);
+  const [warning, setWarning] = useState<KeyWarning | null>(null);
   const validated = useRef('');
   const requestId = useRef(0);
 
@@ -21,10 +24,12 @@ export function useKeyCheck() {
     const currentRequestId = ++requestId.current;
     setStatus('checking');
     setModels(null);
+    setWarning(null);
     const result = await sendMessage('validateApiKey', { provider, apiKey, baseUrl, model }).catch(() => null);
     if (requestId.current !== currentRequestId) return;
     if (result?.valid) validated.current = fingerprint;
     setModels(result?.models?.length ? result.models : null);
+    setWarning(result?.valid && result.warning ? result.warning : null);
     setStatus(
       result?.valid
         ? 'valid'
@@ -43,9 +48,10 @@ export function useKeyCheck() {
     validated.current = '';
     setStatus(null);
     setModels(null);
+    setWarning(null);
   }, []);
 
-  return { status, models, check, reset };
+  return { status, models, warning, check, reset };
 }
 
 export function KeyStatusNote({ status }: { status: KeyStatus }) {
@@ -85,6 +91,16 @@ export function KeyStatusNote({ status }: { status: KeyStatus }) {
     );
   }
   return null;
+}
+
+export function KeyWarningNote({ warning }: { warning: KeyWarning | null }) {
+  if (!warning) return null;
+  return (
+    <p className="mt-1 flex items-start gap-1.5 text-[10px] text-foreground leading-relaxed" role="status">
+      <TriangleAlert size={11} className="shrink-0 mt-0.5 text-destructive" />
+      <span>{i18n.t('settings.keyCannotSpend')}</span>
+    </p>
+  );
 }
 
 export function ModelList({ models }: { models: string[] }) {

--- a/src/ui/sidepanel/AiStatus.tsx
+++ b/src/ui/sidepanel/AiStatus.tsx
@@ -1,0 +1,25 @@
+import { TriangleAlert } from 'lucide-react';
+import { i18n } from '#imports';
+import { findProvider } from '@/core/capture/ai/models';
+import type { PanelAiUpdate } from '@/lib/port';
+import { aiActionKey, aiFailureKey } from './ai-status';
+
+interface AiStatusProps {
+  update: PanelAiUpdate | null;
+}
+
+export default function AiStatus({ update }: AiStatusProps) {
+  if (!update) return null;
+
+  const label = findProvider(update.provider)?.label ?? update.provider;
+
+  return (
+    <div className="px-4 pt-2.5 flex items-start gap-2" role="status">
+      <TriangleAlert size={13} className="shrink-0 mt-0.5 text-destructive" />
+      <p className="text-[10px] leading-relaxed text-muted-foreground">
+        <span className="font-semibold text-foreground">{i18n.t(aiFailureKey(update.reason), [label])}</span>{' '}
+        {i18n.t(aiActionKey(update.reason))}
+      </p>
+    </div>
+  );
+}

--- a/src/ui/sidepanel/App.tsx
+++ b/src/ui/sidepanel/App.tsx
@@ -17,7 +17,7 @@ import {
 import { logger } from '@/lib/logger';
 import { sendMessage } from '@/lib/messaging';
 import { getVoiceStatus } from '@/lib/offscreen';
-import { connectToBackground, type PanelVoiceUpdate } from '@/lib/port';
+import { connectToBackground, type PanelAiUpdate, type PanelVoiceUpdate } from '@/lib/port';
 import { Button } from '@/ui/components/ui/button';
 import { Input } from '@/ui/components/ui/input';
 import { TooltipProvider } from '@/ui/components/ui/tooltip';
@@ -94,6 +94,7 @@ export default function App() {
   const [search, setSearch] = useState('');
   const [activeUrl, setActiveUrl] = useState<string>();
   const [voice, setVoice] = useState<PanelVoiceUpdate>({ type: 'VOICE_UPDATE', phase: 'idle' });
+  const [aiFailure, setAiFailure] = useState<PanelAiUpdate | null>(null);
   const [voiceStarted, setVoiceStarted] = useState(false);
 
   useEffect(() => {
@@ -113,6 +114,7 @@ export default function App() {
       onStateUpdate: (update) => {
         if (update.state === CaptureState.RECORDING) {
           setIsRecording(true);
+          setAiFailure(null);
           const guideId = update.currentGuideId;
           if (guideId) {
             setView((prev) => (prev.name === 'recording' ? prev : { name: 'recording', guideId }));
@@ -125,6 +127,7 @@ export default function App() {
         if (update.phase !== 'idle') setVoiceStarted(true);
         setVoice(update);
       },
+      onAiUpdate: setAiFailure,
     });
 
     return disconnect;
@@ -210,7 +213,7 @@ export default function App() {
 
   function renderView() {
     if (view.name === 'recording') {
-      return <RecordingView guideId={view.guideId} onStop={handleStopRecording} voice={voice} />;
+      return <RecordingView guideId={view.guideId} onStop={handleStopRecording} voice={voice} aiFailure={aiFailure} />;
     }
 
     if (view.name === 'guideme') {

--- a/src/ui/sidepanel/RecordingView.tsx
+++ b/src/ui/sidepanel/RecordingView.tsx
@@ -5,11 +5,13 @@ import { deleteStep, getScreenshotsForSteps, getStepsForGuide } from '@/core/gui
 import type { Screenshot, Step } from '@/core/guides/types';
 import { getActiveTab, localStorage } from '@/lib/browser-api';
 import { sendMessage } from '@/lib/messaging';
-import type { PanelVoiceUpdate } from '@/lib/port';
+import type { PanelAiUpdate, PanelVoiceUpdate } from '@/lib/port';
 import { extractDomain } from '@/lib/utils';
 import { Button } from '@/ui/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/components/ui/tooltip';
 import ScreenshotView from '@/ui/shared/ScreenshotView';
+import StepSourceBadge from '@/ui/shared/StepSourceBadge';
+import AiStatus from './AiStatus';
 import MicToggle from './MicToggle';
 import VoiceStatus from './VoiceStatus';
 
@@ -17,6 +19,7 @@ interface RecordingViewProps {
   guideId: string;
   onStop: () => void;
   voice: PanelVoiceUpdate;
+  aiFailure: PanelAiUpdate | null;
 }
 
 function timeAgo(createdAt: number): string {
@@ -31,7 +34,7 @@ interface LiveStep {
   screenshot?: Screenshot;
 }
 
-export default function RecordingView({ guideId, onStop, voice }: RecordingViewProps) {
+export default function RecordingView({ guideId, onStop, voice, aiFailure }: RecordingViewProps) {
   const [steps, setSteps] = useState<LiveStep[]>([]);
   const [siteUrl, setSiteUrl] = useState('');
   const [isBlurring, setIsBlurring] = useState(false);
@@ -189,8 +192,11 @@ export default function RecordingView({ guideId, onStop, voice }: RecordingViewP
                           {liveStep.step.description}
                         </p>
                       )}
-                      <span className="text-[10px] text-purple">
-                        {timeAgo(liveStep.step.timestamp)} · {extractDomain(liveStep.step.url || siteUrl)}
+                      <span className="flex items-baseline gap-1.5 text-[10px] text-purple">
+                        {!liveStep.step.aiPending && <StepSourceBadge source={liveStep.step.descriptionSource} />}
+                        <span>
+                          {timeAgo(liveStep.step.timestamp)} · {extractDomain(liveStep.step.url || siteUrl)}
+                        </span>
                       </span>
                     </div>
                     <Tooltip>
@@ -216,6 +222,7 @@ export default function RecordingView({ guideId, onStop, voice }: RecordingViewP
 
       {/* Bottom bar */}
       <div className="shrink-0 border-t border-border">
+        <AiStatus update={aiFailure} />
         {import.meta.env.BROWSER !== 'firefox' && <VoiceStatus update={voice} enabled={voiceEnabled} />}
         <div className="px-4 py-2.5 flex items-center gap-2">
           <Button onClick={onStop} className="flex-1 h-10 rounded-full font-semibold text-[13px]">

--- a/src/ui/sidepanel/StepCard.tsx
+++ b/src/ui/sidepanel/StepCard.tsx
@@ -11,6 +11,7 @@ import ConfirmDialog from '@/ui/shared/ConfirmDialog';
 import { DragGrip, type DragHandleProps, useCardDrag } from '@/ui/shared/card-drag';
 import ImagePlaceholder from '@/ui/shared/ImagePlaceholder';
 import ScreenshotView from '@/ui/shared/ScreenshotView';
+import StepSourceBadge from '@/ui/shared/StepSourceBadge';
 
 interface StepCardProps {
   step: Step;
@@ -150,7 +151,8 @@ export default function StepCard({
             />
           )}
         </div>
-        <div className="flex items-center justify-end mt-1">
+        <div className="flex items-center justify-between gap-2 mt-1">
+          {step.aiPending ? <span /> : <StepSourceBadge source={step.descriptionSource} />}
           <div className="flex items-center gap-0.5">
             {askAi.trigger}
             {screenshot && (

--- a/src/ui/sidepanel/ai-status.ts
+++ b/src/ui/sidepanel/ai-status.ts
@@ -1,0 +1,31 @@
+import type { AiFailureReason } from '@/core/capture/ai/errors';
+
+const AI_FAILURE_KEYS: Record<AiFailureReason, string> = {
+  rejected: 'aiStatus.rejected',
+  'no-credits': 'aiStatus.noCredits',
+  'rate-limited': 'aiStatus.rateLimited',
+  'model-invalid': 'aiStatus.modelInvalid',
+  quota: 'aiStatus.quota',
+  network: 'aiStatus.network',
+  unknown: 'aiStatus.unknown',
+};
+
+const AI_ACTION_KEYS: Record<AiFailureReason, string> = {
+  rejected: 'aiStatus.actionCheckKey',
+  'no-credits': 'aiStatus.actionAddCredits',
+  'rate-limited': 'aiStatus.actionWait',
+  'model-invalid': 'aiStatus.actionPickModel',
+  quota: 'aiStatus.actionPickModel',
+  network: 'aiStatus.actionConnection',
+  unknown: 'aiStatus.actionCheckKey',
+};
+
+export function aiFailureKey(reason: AiFailureReason | undefined): string {
+  const key = reason === undefined ? undefined : AI_FAILURE_KEYS[reason];
+  return key ?? AI_FAILURE_KEYS.unknown;
+}
+
+export function aiActionKey(reason: AiFailureReason | undefined): string {
+  const key = reason === undefined ? undefined : AI_ACTION_KEYS[reason];
+  return key ?? AI_ACTION_KEYS.unknown;
+}


### PR DESCRIPTION
Mimik kept one API key for every AI provider, so switching provider carried the previous key over and sent it to the wrong company. Keys are stored per provider now, and every reader resolves the one for the selected provider, the voice fallback included. A key saved before this attaches to whichever provider was selected at the time.

When a provider refused, every step quietly became rule-based text and the only trace was a retry count in the console. Failures now carry the HTTP status, map to a named reason, and reach the recording panel as a banner that names the provider and what to do about it.

Each step also shows where its description came from, so a provider that fails halfway through a recording no longer leaves a guide you cannot tell apart. A key check against OpenRouter warns when the account cannot spend, since its catalogue answers happily to a key that has no credits.
